### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --profile release && cp /src/target/release/divviup_api_bin /divviup_api_bin
 
 FROM alpine:3.17.2
+ARG GIT_REVISION=unknown
+LABEL revision ${GIT_REVISION}
 EXPOSE 8080
 ENV HOST=0.0.0.0
 COPY --from=builder /migration /migration


### PR DESCRIPTION
This adds a Dockerfile, closing #2.

I've been experiencing some very strange problems while testing this. I did the following:

```bash
DOCKER_BUILDKIT=1 docker build -t divviup_api:latest
docker run --rm -e DATABASE_URL=postgres://postgres@<HOST IP>:5432 -e SESSION_SECRET=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA -e API_URL=https://api.example.com/ -e AUTH_CLIENT_ID=BBBBBBBBBBBBB -e AUTH_CLIENT_SECRET=CCCCCCCCCCC -e AUTH_AUDIENCE=DDDDDDDDDDDDDDD -e APP_URL=https://app.example.com/ -e AUTH_URL=https://auth.example.com/ -e RUST_LOG=debug -p 8080:8080 divviup_api:latest
```

TCP connections to Docker's exposed port get closed, i.e. `curl: (52) Empty reply from server`. If I `nsenter` the container and run curl from there, I get an `ok` response. (just like if I ran the binary on the host with `cargo run`) If I strace all the process's threads while doing so, epoll doesn't even return when I make a request passing through docker, but it works normally if the request comes from inside the same container. I wonder if the socket flags set as affordances for live reloading could be interacting poorly with the Docker runtime?

```bash
# Other commands
pidof /divviup_api_bin
sudo strace -f -p <PID>
curl http://127.0.0.1:8080/
sudo nsenter -n -t <PID> curl http://127.0.0.1:8080/
```