### PR TITLE
add trillium-forwarding for x-forwarded-*/forwarded header support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ trillium-client = { version = "0.3.1", features = ["json"] }
 trillium-compression = "0.1.0"
 trillium-conn-id = "0.2.1"
 trillium-cookies = "0.4.0"
+trillium-forwarding = "0.2.1"
 trillium-http = { version = "0.2.13", features = ["http-compat"] }
 trillium-logger = "0.4.2"
 trillium-macros = "0.0.2"

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -20,6 +20,7 @@ use trillium_caching_headers::{
 use trillium_compression::compression;
 use trillium_conn_id::conn_id;
 use trillium_cookies::cookies;
+use trillium_forwarding::Forwarding;
 use trillium_macros::Handler;
 use trillium_sessions::sessions;
 
@@ -43,6 +44,7 @@ impl DivviupApi {
 
         Self {
             handler: Box::new((
+                Forwarding::trust_always(),
                 db.clone(),
                 compression(),
                 conn_id(),


### PR DESCRIPTION
currently we're permissively trusting all proxies, but we could configure it to only trust a cidr range or some other trust predicate