### PR TITLE
Add Prometheus and build info gauge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ base64 = "0.21.0"
 env_logger = "0.10.0"
 fastrand = "1.9.0"
 log = "0.4.17"
+opentelemetry = { version = "0.19.0", features = ["metrics"] }
+opentelemetry-prometheus = { version = "0.12.0", features = ["prometheus-encoding"] }
 querystrong = "0.3.0"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ async-session = "3.0.0"
 base64 = "0.21.0"
 env_logger = "0.10.0"
 fastrand = "1.9.0"
+git-version = "0.3.5"
 log = "0.4.17"
 opentelemetry = { version = "0.19.0", features = ["metrics"] }
 opentelemetry-prometheus = { version = "0.12.0", features = ["prometheus-encoding"] }
@@ -67,6 +68,9 @@ features = [
 [dev-dependencies]
 trillium-testing = { version = "0.4.2", features = ["tokio"] }
 sea-orm = { version = "0.11.2", features = ["sqlx-sqlite"] }
+
+[build-dependencies]
+rustc_version = "0.4.0"
 
 [lib]
 name = "divviup_api"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN apk add libc-dev
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock
+COPY build.rs /src/build.rs
 COPY migration /src/migration
 COPY src /src/src
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --profile release -p migration && cp /src/target/release/migration /migration

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ An example `.envrc` is provided for optional but recommended use with [`direnv`]
 * `HOST` -- default `"localhost"`, on unix-like systems, the server can also be configured to bind to bsd/berkeley sockets by setting `HOST` to a filesystem path, in which case `PORT` is ignored
 * `PORT` -- default `8080`
 * `LISTEN_FD` -- if supplied on unix-like systems, if this is set to an open file descriptor number, the server will listen to that fd
-* `OTEL_EXPORTER_PROMETHEUS_HOST` -- default `"0.0.0.0"`
+* `OTEL_EXPORTER_PROMETHEUS_HOST` -- default `"localhost"`
 * `OTEL_EXPORTER_PROMETHEUS_PORT` -- default `9464`
 
 ## Migrating the database

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ An example `.envrc` is provided for optional but recommended use with [`direnv`]
 * `HOST` -- default `"localhost"`, on unix-like systems, the server can also be configured to bind to bsd/berkeley sockets by setting `HOST` to a filesystem path, in which case `PORT` is ignored
 * `PORT` -- default `8080`
 * `LISTEN_FD` -- if supplied on unix-like systems, if this is set to an open file descriptor number, the server will listen to that fd
+* `OTEL_EXPORTER_PROMETHEUS_HOST` -- default `"0.0.0.0"`
+* `OTEL_EXPORTER_PROMETHEUS_PORT` -- default `9464`
 
 ## Migrating the database
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+use rustc_version::version;
+
+fn main() {
+    let rustc_semver = version().expect("could not parse rustc version");
+    println!("cargo:rustc-env=RUSTC_SEMVER={rustc_semver}");
+    println!("cargo:rerun-if-env-changed=RUSTC");
+}

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,4 +1,4 @@
-use divviup_api::{ApiConfig, DivviupApi};
+use divviup_api::{telemetry::install_metrics_exporter, ApiConfig, DivviupApi};
 use trillium_http::Stopper;
 
 #[tokio::main]
@@ -7,6 +7,9 @@ async fn main() {
 
     let config = ApiConfig::from_env().expect("Missing config");
     let stopper = Stopper::new();
+
+    install_metrics_exporter(&config.prometheus_host, config.prometheus_port)
+        .expect("Error setting up metrics");
 
     #[cfg(all(debug_assertions, feature = "aggregator-api-mock"))]
     if let Some(port) = config.aggregator_url.port() {

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,3 +1,5 @@
+use std::panic;
+
 use divviup_api::{telemetry::install_metrics_exporter, ApiConfig, DivviupApi};
 use trillium_http::Stopper;
 
@@ -8,8 +10,12 @@ async fn main() {
     let config = ApiConfig::from_env().expect("Missing config");
     let stopper = Stopper::new();
 
-    install_metrics_exporter(&config.prometheus_host, config.prometheus_port)
-        .expect("Error setting up metrics");
+    let metrics_task_handle = install_metrics_exporter(
+        &config.prometheus_host,
+        config.prometheus_port,
+        stopper.clone(),
+    )
+    .expect("Error setting up metrics");
 
     #[cfg(all(debug_assertions, feature = "aggregator-api-mock"))]
     if let Some(port) = config.aggregator_url.port() {
@@ -26,4 +32,10 @@ async fn main() {
         .with_stopper(stopper)
         .run_async(DivviupApi::new(config).await)
         .await;
+
+    if let Err(e) = metrics_task_handle.await {
+        if let Ok(reason) = e.try_into_panic() {
+            panic::resume_unwind(reason);
+        }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,7 +75,7 @@ impl ApiConfig {
             auth_url: var("AUTH_URL", "url")?,
             aggregator_url: var("AGGREGATOR_URL", "url")?,
             aggregator_secret: var("AGGREGATOR_SECRET", "string")?,
-            prometheus_host: var_optional("OTEL_EXPORTER_PROMETHEUS_HOST", "0.0.0.0", "string")?,
+            prometheus_host: var_optional("OTEL_EXPORTER_PROMETHEUS_HOST", "localhost", "string")?,
             prometheus_port: var_optional(
                 "OTEL_EXPORTER_PROMETHEUS_PORT",
                 "9464",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::handler::oauth2::Oauth2Config;
-use std::str::FromStr;
+use std::{env::VarError, str::FromStr};
 use thiserror::Error;
 use url::Url;
 
@@ -15,6 +15,8 @@ pub struct ApiConfig {
     pub auth_audience: String,
     pub aggregator_url: Url,
     pub aggregator_secret: String,
+    pub prometheus_host: String,
+    pub prometheus_port: u16,
 }
 
 #[derive(Debug, Error, Clone, Copy)]
@@ -31,12 +33,33 @@ pub enum ApiConfigError {
 
 fn var<T: FromStr>(name: &'static str, format: &'static str) -> Result<T, ApiConfigError> {
     std::env::var(name)
-        .map_err(|_| ApiConfigError::MissingEnvVar(name))
-        .and_then(|domain| {
-            domain
+        .map_err(|error| match error {
+            VarError::NotPresent => ApiConfigError::MissingEnvVar(name),
+            VarError::NotUnicode(_) => ApiConfigError::InvalidEnvVarFormat(name, format),
+        })
+        .and_then(|input| {
+            input
                 .parse()
                 .map_err(|_| ApiConfigError::InvalidEnvVarFormat(name, format))
         })
+}
+
+fn var_optional<T: FromStr + 'static>(
+    name: &'static str,
+    default: &'static str,
+    format: &'static str,
+) -> Result<T, ApiConfigError> {
+    let input_res = std::env::var(name);
+    let input = match &input_res {
+        Ok(value) => value,
+        Err(VarError::NotPresent) => default,
+        Err(VarError::NotUnicode(_)) => {
+            return Err(ApiConfigError::InvalidEnvVarFormat(name, format))
+        }
+    };
+    input
+        .parse()
+        .map_err(|_| ApiConfigError::InvalidEnvVarFormat(name, format))
 }
 
 impl ApiConfig {
@@ -52,6 +75,12 @@ impl ApiConfig {
             auth_url: var("AUTH_URL", "url")?,
             aggregator_url: var("AGGREGATOR_URL", "url")?,
             aggregator_secret: var("AGGREGATOR_SECRET", "string")?,
+            prometheus_host: var_optional("OTEL_EXPORTER_PROMETHEUS_HOST", "0.0.0.0", "string")?,
+            prometheus_port: var_optional(
+                "OTEL_EXPORTER_PROMETHEUS_PORT",
+                "9464",
+                "16-bit number",
+            )?,
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod db;
 pub mod entity;
 pub(crate) mod handler;
 mod routes;
+pub mod telemetry;
 mod user;
 
 pub use client::AggregatorClient;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,11 +1,14 @@
 use std::sync::Arc;
 
+use git_version::git_version;
 use opentelemetry::{
+    global,
     metrics::MetricsError,
     sdk::{
         export::metrics::aggregation::stateless_temporality_selector,
         metrics::{controllers, processors, selectors::simple::histogram},
     },
+    Context, KeyValue,
 };
 use opentelemetry_prometheus::{Encoder, TextEncoder};
 use tokio::spawn;
@@ -26,6 +29,28 @@ pub fn install_metrics_exporter(host: &str, port: u16) -> Result<(), MetricsErro
             .build(),
         )
         .try_init()?,
+    );
+
+    // Record the binary's version information in a build info metric.
+    let meter = global::meter("divviup-api");
+    let gauge = meter
+        .u64_observable_gauge("divviup_api_build_info")
+        .with_description("Build-time version information")
+        .init();
+    let mut git_revision: &str = git_version!(fallback = "unknwon");
+    if git_revision == "unknown" {
+        if let Some(value) = option_env!("GIT_REVISION") {
+            git_revision = value;
+        }
+    }
+    gauge.observe(
+        &Context::current(),
+        1,
+        &[
+            KeyValue::new("version", env!("CARGO_PKG_VERSION")),
+            KeyValue::new("revision", git_revision),
+            KeyValue::new("rust_version", env!("RUSTC_SEMVER")),
+        ],
     );
 
     let router = Router::new().get("metrics", move |conn: trillium::Conn| {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use opentelemetry::{
+    metrics::MetricsError,
+    sdk::{
+        export::metrics::aggregation::stateless_temporality_selector,
+        metrics::{controllers, processors, selectors::simple::histogram},
+    },
+};
+use opentelemetry_prometheus::{Encoder, TextEncoder};
+use tokio::spawn;
+use trillium::{KnownHeaderName, Status};
+use trillium_router::Router;
+
+/// Install a Prometheus metrics provider and exporter. The OpenTelemetry global API can be used to
+/// create and update instruments, and they will be sent through this exporter.
+pub fn install_metrics_exporter(host: &str, port: u16) -> Result<(), MetricsError> {
+    let exporter = Arc::new(
+        opentelemetry_prometheus::exporter(
+            controllers::basic(processors::factory(
+                histogram([
+                    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+                ]),
+                stateless_temporality_selector(),
+            ))
+            .build(),
+        )
+        .try_init()?,
+    );
+
+    let router = Router::new().get("metrics", move |conn: trillium::Conn| {
+        let exporter = Arc::clone(&exporter);
+        async move {
+            let mut buffer = Vec::new();
+            let encoder = TextEncoder::new();
+            match encoder.encode(&exporter.registry().gather(), &mut buffer) {
+                Ok(()) => conn
+                    .with_header(
+                        KnownHeaderName::ContentType,
+                        encoder.format_type().to_owned(),
+                    )
+                    .ok(buffer),
+                Err(_) => conn.with_status(Status::InternalServerError),
+            }
+        }
+    });
+
+    spawn(
+        trillium_tokio::config()
+            .with_host(host)
+            .with_port(port)
+            .without_signals()
+            .run_async(router),
+    );
+
+    Ok(())
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -37,7 +37,7 @@ pub fn install_metrics_exporter(host: &str, port: u16) -> Result<(), MetricsErro
         .u64_observable_gauge("divviup_api_build_info")
         .with_description("Build-time version information")
         .init();
-    let mut git_revision: &str = git_version!(fallback = "unknwon");
+    let mut git_revision: &str = git_version!(fallback = "unknown");
     if git_revision == "unknown" {
         if let Some(value) = option_env!("GIT_REVISION") {
             git_revision = value;

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -42,7 +42,7 @@ pub fn config(aggregator_url: Url) -> ApiConfig {
         auth_audience: "aud".into(),
         aggregator_url,
         aggregator_secret: "unused".into(),
-        prometheus_host: "0.0.0.0".to_string(),
+        prometheus_host: "localhost".to_string(),
         prometheus_port: 9464,
     }
 }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -42,6 +42,8 @@ pub fn config(aggregator_url: Url) -> ApiConfig {
         auth_audience: "aud".into(),
         aggregator_url,
         aggregator_secret: "unused".into(),
+        prometheus_host: "0.0.0.0".to_string(),
+        prometheus_port: 9464,
     }
 }
 


### PR DESCRIPTION
This sets up OpenTelemetry SDK configuration with a Prometheus exporter, and adds a build info gauge metric. Sample output:

```
# HELP divviup_api_build_info Build-time version information
# TYPE divviup_api_build_info gauge
divviup_api_build_info{revision="296de78",rust_version="1.68.2",service_name="foobar",version="0.0.1",otel_scope_name="divviup-api",otel_scope_version=""} 1
# HELP otel_scope_info Instrumentation Scope metadata
# TYPE otel_scope_info gauge
otel_scope_info{otel_scope_name="divviup-api",otel_scope_version=""} 1
```