### PR TITLE
Rename workflow, bump version number

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,4 +1,4 @@
-name: Docker Release
+name: docker-release
 
 on:
   release:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-api"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "async-lock",
  "async-session",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "divviup-api"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 default-run = "divviup_api_bin"


### PR DESCRIPTION
This renames a GitHub Actions workflow, based on the hypothesis that the space in the name was causing an issue with our IAM principalSet:// URI.