### PR TITLE
Move to `sea-orm-migration` 0.11.3 in `migration`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-cli"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ead9f7dac975f10447f17d08edbb2046daa087b5e0b50bbf8211f303459078c"
+checksum = "efbf34a2caf70c2e3be9bb1e674e9540f6dfd7c8f40f6f05daf3b9740e476005"
 dependencies = [
  "chrono",
  "clap",
@@ -2476,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-migration"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7a6123c1035b0530deb713820688f0234431ab6c1893b14dce493ade76af"
+checksum = "278d3adfd0832b6ffc17d3cfbc574d3695a5c1b38814e0bc8ac238d33f3d87cf"
 dependencies = [
  "async-trait",
  "clap",
@@ -3180,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "once_cell",

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -12,5 +12,5 @@ path = "src/lib.rs"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 
 [dependencies.sea-orm-migration]
-version = "0.11.2"
+version = "0.11.3"
 features = ["runtime-tokio-rustls", "sqlx-postgres"]


### PR DESCRIPTION
`sea-orm-migration` 0.11.2 pulls in a version of `tracing-subscriber` with a bug that stops migrations from working. See [1], [2], [3] for context.

[1]: https://github.com/SeaQL/sea-orm/releases/tag/0.11.3
[2]: https://github.com/SeaQL/sea-orm/issues/1608
[3]: https://github.com/tokio-rs/tracing/pull/2566