### PR TITLE
`divviup-api` in Kind

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -9,6 +9,12 @@ env:
 
 jobs:
   build-and-push:
+    strategy:
+      matrix:
+        image: [
+          { name: "divviup_api", rust_features: "default" },
+          { name: "divviup_api_integration_test", rust_features: "integration-testing" },
+        ]
     permissions:
       id-token: write
       contents: read
@@ -32,5 +38,12 @@ jobs:
           password: ${{ steps.gcp-auth.outputs.access_token }}
       - id: get_version
         run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
-      - run: docker build --tag us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api:${{ steps.get_version.outputs.VERSION }} --build-arg GIT_REVISION=${GIT_REVISION} .
-      - run: docker push us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api:${{ steps.get_version.outputs.VERSION }}
+      - run: |-
+          docker build \
+            --tag us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${{ matrix.image.name }}:${{ steps.get_version.outputs.VERSION }} \
+            --build-arg RUST_FEATURES=${{ matrix.image.rust_features }} \
+            --build-arg GIT_REVISION=${GIT_REVISION} \
+            .
+      - run: |-
+          docker push \
+            us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${{ matrix.image.name }}:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,8 +11,15 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        rust-features: ["default", "integration-testing"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
-      - run: docker build --build-arg GIT_REVISION=${GIT_REVISION} .
+      - run: |-
+          docker build \
+            --build-arg GIT_REVISION=${GIT_REVISION} \
+            --build-arg RUST_FEATURES=${{ matrix.rust-features }} \
+            .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,15 @@ COPY build.rs /src/build.rs
 COPY migration /src/migration
 COPY src /src/src
 RUN cd app && npm ci
-RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --profile release -p migration && cp /src/target/release/migration /migration
-RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --profile release && cp /src/target/release/divviup_api_bin /divviup_api_bin
+ARG RUST_FEATURES=default
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/src/target \
+    cargo build --profile release -p migration && \
+    cp /src/target/release/migration /migration
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/src/target \
+    cargo build --profile release --features ${RUST_FEATURES} && \
+    cp /src/target/release/divviup_api_bin /divviup_api_bin
 
 FROM alpine:3.17.3
 ARG GIT_REVISION=unknown

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -52,9 +52,8 @@ impl DivviupApi {
                 caching_headers(),
                 conn_id(),
                 logger(),
-                origin_router()
-                    .with_handler(config.app_url.as_ref(), static_assets(&config))
-                    .with_handler(config.api_url.as_ref(), api(&db, &config)),
+                origin_router().with_handler(config.app_url.as_ref(), static_assets(&config)),
+                api(&db, &config),
                 ErrorHandler,
             )),
             db,


### PR DESCRIPTION
Changes to support running `divviup-api` in Kind Kubernetes clusters, specifically in Divvi Up's integration testing setup. Specifically:

- change `OriginRouter` to account for clients hitting the API over k8s cluster IP
- make test pass when feature `integration-testing` is enabled and test that config in CI
- building and publish containers with the `integration-testing` feature so we can use them downstream