### PR TITLE
Docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+*/node_modules

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           context: .
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.rust-features }}
+          cache-to: type=gha,scope=${{ github.ref_name }}-${{ matrix.rust-features }},mode=max
           build-args: |
             GIT_REVISION=${{ steps.git.outputs.GIT_REVISION }}
             RUST_FEATURES=${{ matrix.rust-features }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,9 +17,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
-      - run: |-
-          docker build \
-            --build-arg GIT_REVISION=${GIT_REVISION} \
-            --build-arg RUST_FEATURES=${{ matrix.rust-features }} \
-            .
+      - id: git
+        run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker-container
+          use: true
+          buildkitd-flags: --debug
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_REVISION=${{ steps.git.outputs.GIT_REVISION }}
+            RUST_FEATURES=${{ matrix.rust-features }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           driver: docker-container
           use: true
-          buildkitd-flags: --debug
       - name: Build
         uses: docker/build-push-action@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm run build
 
 FROM rust:1.69.0-alpine as chef
 RUN apk add libc-dev
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN cargo install cargo-chef
 WORKDIR /src
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ An example `.envrc` is provided for optional but recommended use with [`direnv`]
 * `OTEL_EXPORTER_PROMETHEUS_HOST` -- default `"localhost"`
 * `OTEL_EXPORTER_PROMETHEUS_PORT` -- default `9464`
 * `SKIP_APP_COMPILATION` -- we currently build the react app in a build script. To avoid this behavior, set this environment variable.
+* `ASSET_DIR` -- set this to skip building the react app and include react app assets from a different directory
 
 ## Initial setup
 

--- a/build.rs
+++ b/build.rs
@@ -3,11 +3,18 @@ use std::process::Command;
 use rustc_version::version;
 
 fn main() {
-    if std::env::var("SKIP_APP_COMPILATION").is_err() {
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    if std::env::var("ASSET_DIR").is_ok() {
+        // Don't run npm, and let the ASSET_DIR value pass through to the static asset handler.
+    } else if std::env::var("SKIP_APP_COMPILATION").is_ok() {
+        // Skip asset compilation, but reuse stale assets in the OUT_DIR directory.
+        println!("cargo:rustc-env=ASSET_DIR={out_dir}");
+    } else {
+        // Build the react app.
         let status = Command::new("npm")
             .current_dir("app")
             .args(["run", "build"])
-            .env("BUILD_PATH", std::env::var("OUT_DIR").unwrap())
+            .env("BUILD_PATH", &out_dir)
             .status()
             .unwrap();
 
@@ -18,8 +25,12 @@ fn main() {
         println!("cargo:rerun-if-changed=app/package-lock.json");
         println!("cargo:rerun-if-changed=app/public");
         println!("cargo:rerun-if-env-changed=API_URL");
+
+        // Point the static asset handler at the build script output directory.
+        println!("cargo:rustc-env=ASSET_DIR={out_dir}");
     }
 
+    println!("cargo:rerun-if-env-changed=ASSET_DIR");
     println!("cargo:rerun-if-env-changed=SKIP_APP_COMPILATION");
 
     let rustc_semver = version().expect("could not parse rustc version");

--- a/src/handler/assets.rs
+++ b/src/handler/assets.rs
@@ -13,7 +13,7 @@ const ONE_YEAR: Duration = Duration::from_secs(60 * 60 * 24 * 365);
 
 pub fn static_assets(config: &ApiConfig) -> impl Handler {
     ReactApp {
-        handler: static_compiled!("$OUT_DIR").with_index_file("index.html"),
+        handler: static_compiled!("$ASSET_DIR").with_index_file("index.html"),
         api_url: config.api_url.clone(),
     }
 }

--- a/src/handler/origin_router.rs
+++ b/src/handler/origin_router.rs
@@ -21,20 +21,20 @@ impl OriginRouter {
             .map(|boxed_handler| &**boxed_handler)
     }
 
-    /// Construct a new OriginRouter
+    /// Construct a new OriginRouter.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// add a handler to this origin router at the specified exact origin, returning self
-    /// see also [`add_handler`]
+    /// Add a handler to this origin router at the specified exact origin, returning self.
+    /// See also [`add_handler`].
     pub fn with_handler(mut self, origin: &str, handler: impl Handler) -> Self {
         self.add_handler(origin, handler);
         self
     }
 
-    /// add a handler to this origin router at the specified exect origin.
-    /// see also [`with_handler`] for chainability
+    /// Add a handler to this origin router at the specified exact origin.
+    /// See also [`with_handler`] for chainability.
     pub fn add_handler(&mut self, origin: &str, handler: impl Handler) {
         self.map.insert(
             origin.to_lowercase().trim_end_matches('/').to_owned(),


### PR DESCRIPTION
This PR attempts to speed up Docker builds by splitting the NPM build step into another stage, removing cache mounts, re-introducing cargo-chef, and connecting Docker buildx's caching to GitHub Actions. (This builds on #32)

I added a new compile-time environment variable, `ASSET_DIR` that both skips React app compilation and substitutes in precompiled assets. This is then used to break the different compilation steps into different stages. With this, we can use a node-specific base image instead of installing npm.

I took out the cache mounts we previously used and re-added `cargo-chef`. Removing the cache mounts is important, because they would otherwise shadow the target directory produced by the prior `cargo chef cook` build layer.

I updated the `docker` GHA workflow to first install and switch to a `docker-container` builder driver. The default `docker` driver does not support exporting cache, so I think the `--cache-to type=gha --cache-from type=gha` flags from our previous go-around were silently ignored.