### PR TITLE
Add a second --cache-from pointing at main branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           context: .
           push: false
-          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.rust-features }}
+          cache-from: |
+            type=gha,scope=main-${{ matrix.rust-features }}
+            type=gha,scope=${{ github.ref_name }}-${{ matrix.rust-features }}
           cache-to: type=gha,scope=${{ github.ref_name }}-${{ matrix.rust-features }},mode=max
           build-args: |
             GIT_REVISION=${{ steps.git.outputs.GIT_REVISION }}


### PR DESCRIPTION
This adds a second `--cache-from` directive to the Docker CI action, in order to check cache scopes named after the main branch in addition to the current branch. I noticed the first build in #229 missed and is having to rebuild dependencies. If this works, the first build in this PR should have cache hits on every layer. (since nothing ADDs files in the .github folder)