### PR TITLE
base64-decode public key in HpkeConfig conversion

### DIFF
--- a/src/clients/aggregator_client/api_types.rs
+++ b/src/clients/aggregator_client/api_types.rs
@@ -76,7 +76,7 @@ impl TryFrom<HpkeConfig> for JanusHpkeConfig {
             value.kem_id.unwrap().try_into()?,
             value.kdf_id.unwrap().try_into()?,
             value.aead_id.unwrap().try_into()?,
-            value.public_key.unwrap().into_bytes().into(),
+            URL_SAFE_NO_PAD.decode(value.public_key.unwrap())?.into(),
         ))
     }
 }


### PR DESCRIPTION
`janus_messages::HpkePublicKey` represents a public key directly as a byte array, and serializes as a base64-encoded string, so we need to base64-decode inputs when converting an `Option<String>` into it.