### PR TITLE
test hpke config conversions and minimally validate them

### DIFF
--- a/src/aggregator_api_mock.rs
+++ b/src/aggregator_api_mock.rs
@@ -55,7 +55,7 @@ pub fn task_response(task_create: TaskCreate) -> TaskResponse {
         collector_hpke_config: random_hpke_config(),
         aggregator_auth_tokens: vec![],
         collector_auth_tokens: vec![],
-        aggregator_hpke_configs: std::iter::repeat_with(random_hpke_config).take(5).collect(),
+        aggregator_hpke_configs: repeat_with(random_hpke_config).take(5).collect(),
     }
 }
 
@@ -65,7 +65,7 @@ pub fn random_hpke_config() -> JanusHpkeConfig {
         HpkeKemId::P256HkdfSha256,
         HpkeKdfId::HkdfSha512,
         HpkeAeadId::Aes256Gcm,
-        HpkePublicKey::from(Vec::new()),
+        HpkePublicKey::from(repeat_with(random::<u8>).take(32).collect::<Vec<_>>()),
     )
 }
 
@@ -73,23 +73,21 @@ async fn task_ids(conn: &mut Conn, (): ()) -> Result<Json<TaskIds>, Status> {
     let query = QueryStrong::parse(conn.querystring()).map_err(|_| Status::InternalServerError)?;
     match query.get_str("pagination_token") {
         None => Ok(Json(TaskIds {
-            task_ids: std::iter::repeat_with(|| Uuid::new_v4().to_string())
+            task_ids: repeat_with(|| Uuid::new_v4().to_string())
                 .take(10)
                 .collect(),
             pagination_token: Some("second".into()),
         })),
 
         Some("second") => Ok(Json(TaskIds {
-            task_ids: std::iter::repeat_with(|| Uuid::new_v4().to_string())
+            task_ids: repeat_with(|| Uuid::new_v4().to_string())
                 .take(10)
                 .collect(),
             pagination_token: Some("last".into()),
         })),
 
         _ => Ok(Json(TaskIds {
-            task_ids: std::iter::repeat_with(|| Uuid::new_v4().to_string())
-                .take(5)
-                .collect(),
+            task_ids: repeat_with(|| Uuid::new_v4().to_string()).take(5).collect(),
             pagination_token: None,
         })),
     }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -16,3 +16,17 @@ pub use membership::{
 pub use task::{Column as TaskColumn, Entity as Tasks, Model as Task, NewTask, UpdateTask};
 
 pub use session::{Entity as Sessions, Model as Session};
+
+const URL_SAFE_BASE64_CHARS: &[u8] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+fn url_safe_base64(data: &str) -> Result<(), validator::ValidationError> {
+    if data
+        .chars()
+        .all(|c| u8::try_from(c).map_or(false, |c| URL_SAFE_BASE64_CHARS.contains(&c)))
+    {
+        Ok(())
+    } else {
+        Err(validator::ValidationError::new("base64"))
+    }
+}

--- a/src/entity/task.rs
+++ b/src/entity/task.rs
@@ -1,6 +1,6 @@
 use crate::{
     clients::aggregator_client::api_types::{Role, TaskResponse},
-    entity::{account, membership, Account},
+    entity::{account, membership, url_safe_base64, Account},
     handler::Error,
 };
 use sea_orm::{entity::prelude::*, ActiveValue::Set, IntoActiveModel};
@@ -83,7 +83,7 @@ pub struct HpkeConfig {
     #[validate(required)]
     pub aead_id: Option<u16>,
 
-    #[validate(required)]
+    #[validate(required, custom = "url_safe_base64", length(min = 1))]
     pub public_key: Option<String>,
 }
 

--- a/src/entity/task/new_task.rs
+++ b/src/entity/task/new_task.rs
@@ -1,19 +1,5 @@
 use super::*;
 
-const URL_SAFE_BASE64_CHARS: &[u8] =
-    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-
-fn url_safe_base64(data: &str) -> Result<(), ValidationError> {
-    if data
-        .chars()
-        .all(|c| u8::try_from(c).map_or(false, |c| URL_SAFE_BASE64_CHARS.contains(&c)))
-    {
-        Ok(())
-    } else {
-        Err(ValidationError::new("base64"))
-    }
-}
-
 fn in_the_future(time: &TimeDateTimeWithTimeZone) -> Result<(), ValidationError> {
     if time < &TimeDateTimeWithTimeZone::now_utc() {
         Err(ValidationError::new("past"))


### PR DESCRIPTION
This is probably temporary because we'll be accepting a tls-encoded hpke config file (probably as a base64'ed json field)