### PR TITLE
Bump version to 0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-api"
-version = "0.0.4"
+version = "0.0.6"
 dependencies = [
  "async-lock",
  "async-session",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "divviup-api"
-version = "0.0.4"
+version = "0.0.6"
 edition = "2021"
 publish = false
 default-run = "divviup_api_bin"


### PR DESCRIPTION
This prepares for a new release with all of the recent API changes. (note that there was an 0.0.5 release already)