### PR TITLE
Return 200 from /health, bump version to 0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-api"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "async-lock",
  "async-session",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "divviup-api"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 publish = false
 default-run = "divviup_api_bin"

--- a/src/routes/health_check.rs
+++ b/src/routes/health_check.rs
@@ -13,7 +13,7 @@ impl Handler for HealthCheck {
         if self.0.execute_unprepared("select 1").await.is_err() {
             return conn.halt().with_status(500);
         }
-        conn.halt().with_status(Status::NoContent)
+        conn.halt().with_status(Status::Ok)
     }
 }
 

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -3,6 +3,6 @@ use harness::{test, *};
 
 #[test(harness = set_up)]
 async fn health_check(app: DivviupApi) -> TestResult {
-    assert_status!(get("/health").with_api_host().run_async(&app).await, 204);
+    assert_ok!(get("/health").with_api_host().run_async(&app).await);
     Ok(())
 }


### PR DESCRIPTION
This partially reverts #83, changing the success status code of the `/health` endpoint from 204 No Content back to 200 OK. Google Cloud load balancers [require that HTTP health checks return 200](https://cloud.google.com/load-balancing/docs/health-check-concepts#criteria-protocol-http), so we have to stick to this.