### PR TITLE
Add --no-cache to apk command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 RUN npm run build
 
 FROM rust:1.69.0-alpine as chef
-RUN apk add libc-dev
+RUN apk --no-cache add libc-dev
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN cargo install cargo-chef
 WORKDIR /src


### PR DESCRIPTION
This adds `--no-cache` to an `apk add` command in the Dockerfile, to remove ~3MB of unneeded files from cached layers. (this doesn't affect image size, since this command is not part of the final stage)