### PR TITLE
add session cleanup and queue cleanup as simple recurring tasks

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -15,7 +15,7 @@ pub use membership::{
 };
 pub use task::{Column as TaskColumn, Entity as Tasks, Model as Task, NewTask, UpdateTask};
 
-pub use session::{Entity as Sessions, Model as Session};
+pub use session::{Column as SessionColumn, Entity as Sessions, Model as Session};
 
 const URL_SAFE_BASE64_CHARS: &[u8] =
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";

--- a/src/entity/queue.rs
+++ b/src/entity/queue.rs
@@ -1,6 +1,6 @@
 use crate::{
     json_newtype,
-    queue::{Job, JobError},
+    queue::{EnqueueJob, Job, JobError},
 };
 use sea_orm::{
     entity::prelude::*,
@@ -63,6 +63,14 @@ impl From<Job> for ActiveModel {
             parent_id: Set(None),
             child_id: Set(None),
         }
+    }
+}
+
+impl From<EnqueueJob> for ActiveModel {
+    fn from(EnqueueJob { job, scheduled }: EnqueueJob) -> Self {
+        let mut am = Self::from(job);
+        am.scheduled_at = Set(scheduled);
+        am
     }
 }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,10 +3,14 @@ pub use crate::entity::queue::JobStatus;
 pub use job::*;
 
 use crate::{
-    entity::queue::{ActiveModel, Entity, Model},
+    entity::queue::{ActiveModel, Column, Entity, Model},
     ApiConfig, Db, DivviupApi,
 };
-use sea_orm::{ActiveModelTrait, DbErr, IntoActiveModel, Set, TransactionTrait};
+use sea_orm::{
+    sea_query::{self, all, Expr},
+    ActiveModelTrait, ColumnTrait, DbErr, EntityTrait, IntoActiveModel, PaginatorTrait,
+    QueryFilter, Set, TransactionTrait,
+};
 use std::{ops::Range, sync::Arc, time::Duration};
 use time::OffsetDateTime;
 use tokio::{
@@ -66,6 +70,26 @@ impl Queue {
     pub fn with_stopper(mut self, stopper: Stopper) -> Self {
         self.stopper = stopper;
         self
+    }
+
+    pub async fn schedule_recurring_tasks_if_needed(&self) -> Result<(), DbErr> {
+        let tx = self.db.begin().await?;
+
+        let jobs = Entity::find()
+            .filter(all![
+                Expr::cust_with_expr("job->>'type' = $1", "SessionCleanup"),
+                Column::ScheduledAt.gt(OffsetDateTime::now_utc()),
+            ])
+            .count(&tx)
+            .await?;
+
+        if jobs == 0 {
+            ActiveModel::from(Job::from(SessionCleanup))
+                .insert(&tx)
+                .await?;
+            tx.commit().await?;
+        }
+        Ok(())
     }
 
     pub async fn perform_one_queue_job(&self) -> Result<Option<Model>, DbErr> {
@@ -152,6 +176,7 @@ impl Queue {
     }
 
     async fn supervise_workers(self) {
+        self.schedule_recurring_tasks_if_needed().await.unwrap();
         let mut join_set = JoinSet::new();
         for _ in 0..QUEUE_WORKER_COUNT {
             self.clone().spawn_worker(&mut join_set);

--- a/src/queue/job.rs
+++ b/src/queue/job.rs
@@ -11,7 +11,7 @@ use trillium::{Method, Status};
 use url::Url;
 
 mod v1;
-pub use v1::{CreateUser, ResetPassword, SendInvitationEmail, SessionCleanup, V1};
+pub use v1::{CreateUser, QueueCleanup, ResetPassword, SendInvitationEmail, SessionCleanup, V1};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "version")]

--- a/src/queue/job/v1.rs
+++ b/src/queue/job/v1.rs
@@ -1,14 +1,18 @@
 mod create_user;
 mod reset_password;
 mod send_invitation_email;
+mod session_cleanup;
 
-use super::{Job, JobError, SharedJobState};
+use crate::queue::EnqueueJob;
+
+use super::{JobError, SharedJobState};
 use sea_orm::ConnectionTrait;
 use serde::{Deserialize, Serialize};
 
 pub use create_user::CreateUser;
 pub use reset_password::ResetPassword;
 pub use send_invitation_email::SendInvitationEmail;
+pub use session_cleanup::SessionCleanup;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]
@@ -16,6 +20,7 @@ pub enum V1 {
     SendInvitationEmail(SendInvitationEmail),
     CreateUser(CreateUser),
     ResetPassword(ResetPassword),
+    SessionCleanup(SessionCleanup),
 }
 
 impl V1 {
@@ -23,11 +28,12 @@ impl V1 {
         &mut self,
         job_state: &SharedJobState,
         db: &impl ConnectionTrait,
-    ) -> Result<Option<Job>, JobError> {
+    ) -> Result<Option<EnqueueJob>, JobError> {
         match self {
             V1::SendInvitationEmail(job) => job.perform(job_state, db).await,
             V1::CreateUser(job) => job.perform(job_state, db).await,
             V1::ResetPassword(job) => job.perform(job_state, db).await,
+            V1::SessionCleanup(job) => job.perform(job_state, db).await,
         }
     }
 }

--- a/src/queue/job/v1.rs
+++ b/src/queue/job/v1.rs
@@ -1,4 +1,5 @@
 mod create_user;
+mod queue_cleanup;
 mod reset_password;
 mod send_invitation_email;
 mod session_cleanup;
@@ -10,6 +11,7 @@ use sea_orm::ConnectionTrait;
 use serde::{Deserialize, Serialize};
 
 pub use create_user::CreateUser;
+pub use queue_cleanup::QueueCleanup;
 pub use reset_password::ResetPassword;
 pub use send_invitation_email::SendInvitationEmail;
 pub use session_cleanup::SessionCleanup;
@@ -21,6 +23,7 @@ pub enum V1 {
     CreateUser(CreateUser),
     ResetPassword(ResetPassword),
     SessionCleanup(SessionCleanup),
+    QueueCleanup(QueueCleanup),
 }
 
 impl V1 {
@@ -34,6 +37,7 @@ impl V1 {
             V1::CreateUser(job) => job.perform(job_state, db).await,
             V1::ResetPassword(job) => job.perform(job_state, db).await,
             V1::SessionCleanup(job) => job.perform(job_state, db).await,
+            V1::QueueCleanup(job) => job.perform(job_state, db).await,
         }
     }
 }

--- a/src/queue/job/v1/create_user.rs
+++ b/src/queue/job/v1/create_user.rs
@@ -2,7 +2,7 @@ use crate::{
     entity::*,
     queue::job::{
         v1::{reset_password::ResetPassword, V1},
-        Job, JobError, SharedJobState,
+        EnqueueJob, Job, JobError, SharedJobState,
     },
 };
 use sea_orm::{ConnectionTrait, EntityTrait};
@@ -19,7 +19,7 @@ impl CreateUser {
         &mut self,
         job_state: &SharedJobState,
         db: &impl ConnectionTrait,
-    ) -> Result<Option<Job>, JobError> {
+    ) -> Result<Option<EnqueueJob>, JobError> {
         let membership = Memberships::find_by_id(self.membership_id)
             .one(db)
             .await?
@@ -31,7 +31,7 @@ impl CreateUser {
             .auth0_client
             .create_user(&membership.user_email)
             .await?;
-        Ok(Some(Job::from(ResetPassword {
+        Ok(Some(EnqueueJob::from(ResetPassword {
             membership_id: self.membership_id,
             user_id,
         })))

--- a/src/queue/job/v1/queue_cleanup.rs
+++ b/src/queue/job/v1/queue_cleanup.rs
@@ -1,0 +1,61 @@
+use crate::{
+    entity::queue::{Column as QueueColumn, Entity as QueueEntity, JobStatus},
+    queue::job::{v1::V1, EnqueueJob, Job, JobError, SharedJobState},
+};
+use sea_orm::{
+    sea_query::{self, all, Expr},
+    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
+};
+use serde::{Deserialize, Serialize};
+use time::{Duration, OffsetDateTime};
+
+const CLEANUP_PERIOD: Duration = Duration::minutes(60);
+const RETENTION_PERIOD: Duration = Duration::weeks(2);
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Copy)]
+pub struct QueueCleanup;
+
+impl QueueCleanup {
+    pub async fn perform(
+        &mut self,
+        _job_state: &SharedJobState,
+        db: &impl ConnectionTrait,
+    ) -> Result<Option<EnqueueJob>, JobError> {
+        QueueEntity::delete_many()
+            .filter(all![
+                Expr::cust_with_expr("job->>'type' = $1", "QueueCleanup"),
+                QueueColumn::ScheduledAt.gt(OffsetDateTime::now_utc()),
+            ])
+            .exec(db)
+            .await?;
+
+        QueueEntity::delete_many()
+            .filter(all![
+                QueueColumn::Status.eq(JobStatus::Success),
+                QueueColumn::UpdatedAt.lt(OffsetDateTime::now_utc() - RETENTION_PERIOD)
+            ])
+            .exec(db)
+            .await?;
+
+        Ok(Some(
+            EnqueueJob::from(QueueCleanup).scheduled_in(CLEANUP_PERIOD),
+        ))
+    }
+}
+
+impl From<QueueCleanup> for Job {
+    fn from(value: QueueCleanup) -> Self {
+        Self::V1(V1::QueueCleanup(value))
+    }
+}
+
+impl PartialEq<Job> for QueueCleanup {
+    fn eq(&self, other: &Job) -> bool {
+        matches!(other, Job::V1(V1::QueueCleanup(c)) if c == self)
+    }
+}
+impl PartialEq<QueueCleanup> for Job {
+    fn eq(&self, other: &QueueCleanup) -> bool {
+        matches!(self, Job::V1(V1::QueueCleanup(j)) if j == other)
+    }
+}

--- a/src/queue/job/v1/reset_password.rs
+++ b/src/queue/job/v1/reset_password.rs
@@ -1,4 +1,4 @@
-use crate::queue::{Job, JobError, SendInvitationEmail, SharedJobState, V1};
+use crate::queue::{EnqueueJob, Job, JobError, SendInvitationEmail, SharedJobState, V1};
 use sea_orm::ConnectionTrait;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -14,9 +14,9 @@ impl ResetPassword {
         &mut self,
         job_state: &SharedJobState,
         _db: &impl ConnectionTrait,
-    ) -> Result<Option<Job>, JobError> {
+    ) -> Result<Option<EnqueueJob>, JobError> {
         let action_url = job_state.auth0_client.password_reset(&self.user_id).await?;
-        Ok(Some(Job::from(SendInvitationEmail {
+        Ok(Some(EnqueueJob::from(SendInvitationEmail {
             membership_id: self.membership_id,
             action_url,
             message_id: Uuid::new_v4(),

--- a/src/queue/job/v1/send_invitation_email.rs
+++ b/src/queue/job/v1/send_invitation_email.rs
@@ -1,6 +1,6 @@
 use crate::{
     entity::*,
-    queue::{Job, JobError, SharedJobState, V1},
+    queue::{EnqueueJob, Job, JobError, SharedJobState, V1},
 };
 use sea_orm::{ConnectionTrait, EntityTrait};
 use serde::{Deserialize, Serialize};
@@ -20,7 +20,7 @@ impl SendInvitationEmail {
         &mut self,
         job_state: &SharedJobState,
         db: &impl ConnectionTrait,
-    ) -> Result<Option<Job>, JobError> {
+    ) -> Result<Option<EnqueueJob>, JobError> {
         let (membership, account) = Memberships::find_by_id(self.membership_id)
             .find_also_related(Accounts)
             .one(db)

--- a/src/queue/job/v1/session_cleanup.rs
+++ b/src/queue/job/v1/session_cleanup.rs
@@ -1,0 +1,54 @@
+use crate::{
+    entity::*,
+    queue::job::{v1::V1, EnqueueJob, Job, JobError, SharedJobState},
+};
+use sea_orm::{
+    sea_query::{self, all, Expr},
+    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
+};
+use serde::{Deserialize, Serialize};
+use time::{Duration, OffsetDateTime};
+
+const PERIOD: Duration = Duration::minutes(60);
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Copy)]
+pub struct SessionCleanup;
+
+impl SessionCleanup {
+    pub async fn perform(
+        &mut self,
+        _job_state: &SharedJobState,
+        db: &impl ConnectionTrait,
+    ) -> Result<Option<EnqueueJob>, JobError> {
+        queue::Entity::delete_many()
+            .filter(all![
+                Expr::cust_with_expr("job->>'type' = $1", "SessionCleanup"),
+                queue::Column::ScheduledAt.gt(OffsetDateTime::now_utc()),
+            ])
+            .exec(db)
+            .await?;
+
+        Sessions::delete_many()
+            .filter(SessionColumn::Expiry.lt(OffsetDateTime::now_utc()))
+            .exec(db)
+            .await?;
+        Ok(Some(EnqueueJob::from(SessionCleanup).scheduled_in(PERIOD)))
+    }
+}
+
+impl From<SessionCleanup> for Job {
+    fn from(value: SessionCleanup) -> Self {
+        Self::V1(V1::SessionCleanup(value))
+    }
+}
+
+impl PartialEq<Job> for SessionCleanup {
+    fn eq(&self, other: &Job) -> bool {
+        matches!(other, Job::V1(V1::SessionCleanup(c)) if c == self)
+    }
+}
+impl PartialEq<SessionCleanup> for Job {
+    fn eq(&self, other: &SessionCleanup) -> bool {
+        matches!(self, Job::V1(V1::SessionCleanup(j)) if j == other)
+    }
+}

--- a/tests/jobs.rs
+++ b/tests/jobs.rs
@@ -22,7 +22,7 @@ async fn create_account(app: DivviupApi, client_logs: ClientLogs) -> TestResult 
         .unwrap()
         .to_string();
     assert_eq!(
-        next,
+        next.job,
         ResetPassword {
             membership_id,
             user_id
@@ -56,7 +56,7 @@ async fn reset_password(app: DivviupApi, client_logs: ClientLogs) -> TestResult 
         .parse()
         .unwrap();
 
-    let Job::V1(V1::SendInvitationEmail(next)) = next else { panic!() };
+    let Job::V1(V1::SendInvitationEmail(next)) = next.job else { panic!() };
     assert_eq!(next.membership_id, membership_id);
     assert_eq!(next.action_url, action_url);
     Ok(())


### PR DESCRIPTION
In this approach, the application checks on start whether there exists a pending {Session|Queue}Cleanup job, and if not, enqueues one. When the {Session|Queue}Cleanup job completes, it schedules itself for a fixed period from now. The first thing a {Session|Queue}Cleanup task does is to delete any other tasks of the same variety.

This is not *provably* exactly-once delivery because potentially two {Session|Queue}Cleanup jobs could enqueue and perform simultaneously, but the likelihood of that is low, as is the cost (we run a noop delete)

Importantly, no ops changes are needed and there is no distinct entrypoint or cron task required.

closes #154 
closes #176 