### PR TITLE
Rewrite docker-release CI action

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  DOCKER_BUILDKIT: 1
-
 jobs:
   build-and-push:
     strategy:
@@ -21,7 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
+      - id: git
+        run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
+      - id: get_version
+        run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker-container
+          use: true
       - id: gcp-auth
         name: Authenticate to GCP
         uses: google-github-actions/auth@v1
@@ -36,14 +41,14 @@ jobs:
           registry: us-west2-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
-      - id: get_version
-        run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
-      - run: |-
-          docker build \
-            --tag us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${{ matrix.image.name }}:${{ steps.get_version.outputs.VERSION }} \
-            --build-arg RUST_FEATURES=${{ matrix.image.rust_features }} \
-            --build-arg GIT_REVISION=${GIT_REVISION} \
-            .
-      - run: |-
-          docker push \
-            us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${{ matrix.image.name }}:${{ steps.get_version.outputs.VERSION }}
+      - name: Build and Push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: "us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${{ matrix.image.name }}:${{ steps.get_version.outputs.VERSION }}"
+          build-args: |
+            GIT_REVISION=${{ steps.git.outputs.GIT_REVISION }}
+            RUST_FEATURES=${{ matrix.image.rust_features }}
+          cache-from: |
+            type=gha,scope=main-${{ matrix.image.rust_features }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  DOCKER_BUILDKIT: 1
-
 jobs:
   build:
     strategy:


### PR DESCRIPTION
This rewrites the docker-release workflow using Docker's reusable actions, in order to make use of the layer cache from the main branch. I also removed the now-redundant DOCKER_BUILDKIT=1 environment variable. (docker/build-push-action always uses "buildx")