### PR TITLE
fix revalidation on memberships

### DIFF
--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -152,6 +152,10 @@ function buildRouter(apiClient: ApiClient) {
                     });
                   },
 
+                  shouldRevalidate(_) {
+                    return true;
+                  },
+
                   async action({ params, request }) {
                     let data = Object.fromEntries(await request.formData());
                     switch (request.method) {


### PR DESCRIPTION
I'm not entirely clear on why this is necessary, but it does seem to resolve outstanding cache invalidation issues with removing memberships