### PR TITLE
Add supplemental CLI tool for targeting a particular schema version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,11 +712,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.3.2",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.5.0",
+ "strsim",
 ]
 
 [[package]]
@@ -684,6 +757,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +776,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cmac"
@@ -702,6 +793,12 @@ dependencies = [
  "dbl",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -1677,7 +1774,12 @@ name = "migration"
 version = "0.1.0"
 dependencies = [
  "async-std",
+ "clap 4.3.4",
+ "sea-orm",
  "sea-orm-migration",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1730,6 +1832,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1924,6 +2036,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2536,7 +2654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbf34a2caf70c2e3be9bb1e674e9540f6dfd7c8f40f6f05daf3b9740e476005"
 dependencies = [
  "chrono",
- "clap",
+ "clap 3.2.25",
  "dotenvy",
  "regex",
  "sea-schema",
@@ -2565,7 +2683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "278d3adfd0832b6ffc17d3cfbc574d3695a5c1b38814e0bc8ac238d33f3d87cf"
 dependencies = [
  "async-trait",
- "clap",
+ "clap 3.2.25",
  "dotenvy",
  "futures",
  "sea-orm",
@@ -3051,6 +3169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3293,6 +3417,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3302,12 +3438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3685,6 +3824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,6 +3881,12 @@ dependencies = [
  "proc-macro2",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ ARG GIT_REVISION=unknown
 LABEL revision ${GIT_REVISION}
 EXPOSE 8080
 ENV HOST=0.0.0.0
-COPY --from=builder /src/target/release/migration /migration
 COPY --from=builder /src/target/release/migrate_to /migrate_to
 COPY --from=builder /src/target/release/divviup_api_bin /divviup_api_bin
 ENTRYPOINT ["/divviup_api_bin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,6 @@ LABEL revision ${GIT_REVISION}
 EXPOSE 8080
 ENV HOST=0.0.0.0
 COPY --from=builder /src/target/release/migration /migration
+COPY --from=builder /src/target/release/migrate_to /migrate_to
 COPY --from=builder /src/target/release/divviup_api_bin /divviup_api_bin
 ENTRYPOINT ["/divviup_api_bin"]

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -3,6 +3,7 @@ name = "migration"
 version = "0.1.0"
 edition = "2021"
 publish = false
+default-run = "migration"
 
 [lib]
 name = "migration"
@@ -10,7 +11,14 @@ path = "src/lib.rs"
 
 [dependencies]
 async-std = { version = "1", features = ["attributes", "tokio1"] }
+clap = { version = "4.3.4", features = ["env", "derive"] }
+thiserror = "1.0.40"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
 
 [dependencies.sea-orm-migration]
 version = "0.11.3"
 features = ["runtime-tokio-rustls", "sqlx-postgres"]
+
+[dev-dependencies]
+sea-orm = { version = "0.11.3", features = ["sqlx-sqlite"] }

--- a/migration/README.md
+++ b/migration/README.md
@@ -1,4 +1,12 @@
-# Running Migrator CLI
+There are two commands in this crate which assist with running database migrations.
+
+All commands require that you either export `DATABASE_URL` or provide a `--database-url`
+flag, containing a valid [PostgreSQL connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
+(e.g. `postgres://username:password@hostname:port/database`).
+
+## Running Migrator CLI
+
+This is the standard migrator CLI that comes with SeaORM.
 
 - Generate a new migration file
     ```sh
@@ -40,7 +48,7 @@
     cargo run -- status
     ```
 
-# Running extended migrator CLI
+## Running extended migrator CLI
 
 There is a CLI at `bin/migrate_to.rs` that covers some gaps in the standard SeaORM
 migrator CLI. It's most useful for running in automation.

--- a/migration/README.md
+++ b/migration/README.md
@@ -39,3 +39,21 @@
     ```sh
     cargo run -- status
     ```
+
+# Running extended migrator CLI
+
+There is a CLI at `bin/migrate_to.rs` that covers some gaps in the standard SeaORM
+migrator CLI. It's most useful for running in automation.
+
+- To apply all migrations up to the given migration
+    ```sh
+    cargo run --bin migrate_to -- up MIGRATION_NAME
+    ```
+- To dry-run all migrations up to the given migration
+    ```sh
+    cargo run --bin migrate_to -- --dry-run up MIGRATION_NAME
+    ```
+- To downgrade migrations down to the given migration
+    ```sh
+    cargo run --bin migrate_to -- down MIGRATION_NAME
+    ```

--- a/migration/README.md
+++ b/migration/README.md
@@ -1,9 +1,10 @@
 There are two commands in this crate which assist with running database migrations.
 
 All commands require that you either export `DATABASE_URL` or provide a `--database-url`
-flag, containing a valid [PostgreSQL connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
+flag, containing a valid [PostgreSQL connection string][pgsql-conn-str]
 (e.g. `postgres://username:password@hostname:port/database`).
 
+[pgsql-conn-str]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 ## Running Migrator CLI
 
 This is the standard migrator CLI that comes with SeaORM.

--- a/migration/src/bin/migrate_to.rs
+++ b/migration/src/bin/migrate_to.rs
@@ -1,0 +1,384 @@
+use clap::{builder::PossibleValuesParser, command, Parser, ValueEnum};
+use migration::{
+    sea_orm::{ConnectOptions, Database, DatabaseConnection, EntityTrait, QueryOrder},
+    MigratorTrait,
+};
+use sea_orm_migration::{prelude::*, seaql_migrations};
+use tracing::{info, Level};
+
+#[derive(Copy, Clone, ValueEnum, Debug)]
+enum Direction {
+    Up,
+    Down,
+}
+
+/// Wraps the SeaORM migration library to provide additional features. Lets
+/// you bring migrations up or down to a particular version. Allows dry-run
+/// of migrations.
+#[derive(Parser, Debug)]
+#[command(about, version)]
+struct Args {
+    #[arg(value_enum)]
+    direction: Direction,
+    #[arg(value_parser = available_migrations())]
+    target_version: String,
+    #[arg(short, long)]
+    dry_run: bool,
+    #[arg(short = 'u', long, env = "DATABASE_URL")]
+    database_url: String,
+}
+
+#[async_std::main]
+async fn main() -> Result<(), Error> {
+    let args = Args::parse();
+    tracing_subscriber::fmt()
+        .with_max_level(Level::DEBUG)
+        .init();
+
+    let db = Database::connect(ConnectOptions::new(args.database_url)).await?;
+    migrate_to::<migration::Migrator>(&db, args.dry_run, args.direction, &args.target_version)
+        .await?;
+    Ok(())
+}
+
+async fn migrate_to<M: MigratorTrait>(
+    db: &DatabaseConnection,
+    dry_run: bool,
+    dir: Direction,
+    target: &str,
+) -> Result<(), Error> {
+    let latest_index = match latest_applied_migration(db).await {
+        Ok(m) => migration_index::<M>(&m).ok_or(Error::DBMigrationNotFound)?,
+        Err(_) => -1, // Empty database.
+    };
+    let target_index =
+        migration_index::<M>(target).ok_or(Error::MigrationNotFound(target.to_string()))?;
+    if target_index == latest_index {
+        info!("no action taken, already at desired version");
+        return Ok(());
+    }
+
+    match dir {
+        Direction::Up => match target_index - latest_index {
+            num_migrations if num_migrations > 0 => {
+                info!("executing {num_migrations} migration(s) to {target}");
+                if !dry_run {
+                    M::up(db, Some(num_migrations as u32))
+                        .await
+                        .map_err(Error::from)?
+                }
+                Ok(())
+            }
+            _ => Err(Error::VersionTooOld(target.to_string())),
+        },
+        Direction::Down => match latest_index - target_index {
+            num_migrations if num_migrations > 0 => {
+                info!("executing {num_migrations} migration(s) to {target}");
+                if !dry_run {
+                    M::down(db, Some(num_migrations as u32))
+                        .await
+                        .map_err(Error::from)?
+                }
+                Ok(())
+            }
+            _ => Err(Error::VersionTooNew(target.to_string())),
+        },
+    }
+}
+
+fn migration_index<M: MigratorTrait>(version: &str) -> Option<i64> {
+    M::migrations()
+        .iter()
+        .position(|m| m.name() == version)
+        .map(|i| i as i64)
+}
+
+async fn latest_applied_migration(db: &DatabaseConnection) -> Result<String, Error> {
+    Ok(seaql_migrations::Entity::find()
+        .order_by_desc(seaql_migrations::Column::Version)
+        .one(db)
+        .await?
+        .ok_or(Error::DbNotInitialized)?
+        .version)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error("DB error: {0}")]
+    Db(#[from] sea_orm::DbErr),
+    #[error("DB is not initialized with migrations table")]
+    DbNotInitialized,
+    #[error("migration applied to DB is not found in available migrations")]
+    DBMigrationNotFound,
+    #[error("migration version {0} not found in avaliable migrations")]
+    MigrationNotFound(String),
+    #[error("migration version {0} is older than the latest applied migration")]
+    VersionTooOld(String),
+    #[error("migration version {0} is newer than the latest applied migration")]
+    VersionTooNew(String),
+}
+
+fn available_migrations() -> PossibleValuesParser {
+    PossibleValuesParser::new(
+        // Leak memory to give migration names 'static lifetime, so clap can
+        // use them.
+        migration::Migrator::migrations()
+            .into_iter()
+            .map(|m| Box::leak(Box::new(m.name().to_owned())) as &'static str)
+            .collect::<Vec<_>>(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_migration {
+        ($name:ident, $table_name:ident) => {
+            #[allow(non_camel_case_types)]
+            struct $name;
+
+            impl MigrationName for $name {
+                fn name(&self) -> &str {
+                    stringify!($name)
+                }
+            }
+
+            #[async_trait::async_trait]
+            impl MigrationTrait for $name {
+                async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+                    manager
+                        .create_table(
+                            Table::create()
+                                .table($table_name::Table)
+                                .col(ColumnDef::new($table_name::Id).uuid().primary_key())
+                                .to_owned(),
+                        )
+                        .await?;
+                    Ok(())
+                }
+                async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+                    manager
+                        .drop_table(Table::drop().table($table_name::Table).to_owned())
+                        .await
+                }
+            }
+
+            #[derive(Iden)]
+            enum $table_name {
+                Table,
+                Id,
+            }
+        };
+    }
+    test_migration!(m20230101_000000_test_migration_1, TestTable1);
+    test_migration!(m20230201_000000_test_migration_2, TestTable2);
+    test_migration!(m20230301_000000_test_migration_3, TestTable3);
+    test_migration!(m20230401_000000_test_migration_4, TestTable4);
+    test_migration!(m20230501_000000_test_migration_5, TestTable5);
+
+    struct TestMigrator;
+
+    #[async_trait::async_trait]
+    impl MigratorTrait for TestMigrator {
+        fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+            vec![
+                Box::new(m20230101_000000_test_migration_1),
+                Box::new(m20230201_000000_test_migration_2),
+                Box::new(m20230301_000000_test_migration_3),
+                Box::new(m20230401_000000_test_migration_4),
+                Box::new(m20230501_000000_test_migration_5),
+            ]
+        }
+    }
+
+    fn all_migrations() -> Vec<&'static str> {
+        vec![
+            "m20230101_000000_test_migration_1",
+            "m20230201_000000_test_migration_2",
+            "m20230301_000000_test_migration_3",
+            "m20230401_000000_test_migration_4",
+            "m20230501_000000_test_migration_5",
+        ]
+    }
+
+    async fn test_database() -> DatabaseConnection {
+        Database::connect(ConnectOptions::new("sqlite::memory:".to_string()))
+            .await
+            .unwrap()
+    }
+
+    async fn applied_migrations(db: &DatabaseConnection) -> Vec<String> {
+        seaql_migrations::Entity::find()
+            .order_by_asc(seaql_migrations::Column::Version)
+            .all(db)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.version)
+            .collect()
+    }
+
+    #[async_std::test]
+    async fn migrate_to_up() {
+        {
+            let db = test_database().await;
+
+            // To latest
+            migrate_to::<TestMigrator>(
+                &db,
+                false,
+                Direction::Up,
+                "m20230501_000000_test_migration_5",
+            )
+            .await
+            .unwrap();
+            assert_eq!(applied_migrations(&db).await, all_migrations());
+
+            // Ensure no-op
+            migrate_to::<TestMigrator>(
+                &db,
+                false,
+                Direction::Up,
+                "m20230501_000000_test_migration_5",
+            )
+            .await
+            .unwrap();
+            assert_eq!(applied_migrations(&db).await, all_migrations());
+        }
+        {
+            let db = test_database().await;
+
+            // To first
+            migrate_to::<TestMigrator>(
+                &db,
+                false,
+                Direction::Up,
+                "m20230101_000000_test_migration_1",
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                applied_migrations(&db).await,
+                vec!["m20230101_000000_test_migration_1"]
+            );
+
+            // Dry run
+            migrate_to::<TestMigrator>(
+                &db,
+                true,
+                Direction::Up,
+                "m20230101_000000_test_migration_1",
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                applied_migrations(&db).await,
+                vec!["m20230101_000000_test_migration_1"]
+            );
+
+            // To third
+            migrate_to::<TestMigrator>(
+                &db,
+                false,
+                Direction::Up,
+                "m20230301_000000_test_migration_3",
+            )
+            .await
+            .unwrap();
+            assert_eq!(applied_migrations(&db).await, all_migrations()[..3]);
+
+            // To non-existent
+            let result = migrate_to::<TestMigrator>(&db, false, Direction::Up, "foobar").await;
+            assert!(matches!(result, Err(Error::MigrationNotFound(_))));
+            assert_eq!(applied_migrations(&db).await, all_migrations()[..3]);
+
+            // To old version
+            let result = migrate_to::<TestMigrator>(
+                &db,
+                false,
+                Direction::Up,
+                "m20230101_000000_test_migration_1",
+            )
+            .await;
+            assert!(matches!(result, Err(Error::VersionTooOld(_))));
+            assert_eq!(applied_migrations(&db).await, all_migrations()[..3]);
+        }
+    }
+
+    #[async_std::test]
+    async fn migrate_to_down() {
+        let db = test_database().await;
+
+        // To latest
+        migrate_to::<TestMigrator>(
+            &db,
+            false,
+            Direction::Up,
+            "m20230501_000000_test_migration_5",
+        )
+        .await
+        .unwrap();
+        assert_eq!(applied_migrations(&db).await, all_migrations());
+
+        // Ensure no-op
+        migrate_to::<TestMigrator>(
+            &db,
+            false,
+            Direction::Down,
+            "m20230501_000000_test_migration_5",
+        )
+        .await
+        .unwrap();
+        assert_eq!(applied_migrations(&db).await, all_migrations());
+
+        // Dry-run
+        migrate_to::<TestMigrator>(
+            &db,
+            true,
+            Direction::Down,
+            "m20230301_000000_test_migration_3",
+        )
+        .await
+        .unwrap();
+        assert_eq!(applied_migrations(&db).await, all_migrations());
+
+        // To third
+        migrate_to::<TestMigrator>(
+            &db,
+            false,
+            Direction::Down,
+            "m20230301_000000_test_migration_3",
+        )
+        .await
+        .unwrap();
+        assert_eq!(applied_migrations(&db).await, all_migrations()[..3]);
+
+        // To newer version
+        let result = migrate_to::<TestMigrator>(
+            &db,
+            false,
+            Direction::Down,
+            "m20230401_000000_test_migration_4",
+        )
+        .await;
+        assert!(matches!(result, Err(Error::VersionTooNew(_))));
+        assert_eq!(applied_migrations(&db).await, all_migrations()[..3]);
+
+        // To non-existent version
+        let result = migrate_to::<TestMigrator>(&db, false, Direction::Down, "foobar").await;
+        assert!(matches!(result, Err(Error::MigrationNotFound(_))));
+        assert_eq!(applied_migrations(&db).await, all_migrations()[..3]);
+
+        // Upgrade back to fourth, ensure we can still upgrade again.
+        migrate_to::<TestMigrator>(
+            &db,
+            false,
+            Direction::Up,
+            "m20230401_000000_test_migration_4",
+        )
+        .await
+        .unwrap();
+        assert_eq!(applied_migrations(&db).await, all_migrations()[..4]);
+    }
+}

--- a/migration/src/bin/migrate_to.rs
+++ b/migration/src/bin/migrate_to.rs
@@ -381,4 +381,13 @@ mod tests {
         .unwrap();
         assert_eq!(applied_migrations(&db).await, all_migrations()[..4]);
     }
+
+    #[test]
+    fn ensure_migrations_are_sorted() {
+        // Migrations in migration::Migrator must be in lexicographic order, otherwise
+        // this CLI will not work correctly.
+        assert!(migration::Migrator::migrations()
+            .windows(2)
+            .all(|window| window[0].name() <= window[1].name()))
+    }
 }

--- a/migration/src/bin/migrate_to.rs
+++ b/migration/src/bin/migrate_to.rs
@@ -4,7 +4,8 @@ use migration::{
     MigratorTrait,
 };
 use sea_orm_migration::{prelude::*, seaql_migrations};
-use tracing::{info, Level};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Copy, Clone, ValueEnum, Debug)]
 enum Direction {
@@ -32,7 +33,7 @@ struct Args {
 async fn main() -> Result<(), Error> {
     let args = Args::parse();
     tracing_subscriber::fmt()
-        .with_max_level(Level::DEBUG)
+        .with_env_filter(EnvFilter::from_default_env())
         .init();
 
     let db = Database::connect(ConnectOptions::new(args.database_url)).await?;

--- a/migration/src/bin/migrate_to.rs
+++ b/migration/src/bin/migrate_to.rs
@@ -49,8 +49,9 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-// Applied migrations must be a subset of the migrations available by the
-// MigratorTrait for this CLI to be operated safely.
+/// Checks that the database is compatible with the given migrator. Applied
+/// migrations must be a subset of the migrations available by the MigratorTrait
+/// for this CLI to be operated safely.
 async fn check_database_is_compatible<M: MigratorTrait>(
     db: &DatabaseConnection,
 ) -> Result<(), Error> {

--- a/migration/src/bin/migrate_to.rs
+++ b/migration/src/bin/migrate_to.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Error> {
 async fn migrate_to<M: MigratorTrait>(
     db: &DatabaseConnection,
     dry_run: bool,
-    dir: Direction,
+    direction: Direction,
     target: &str,
 ) -> Result<(), Error> {
     let latest_index = match latest_applied_migration(db).await {
@@ -59,7 +59,7 @@ async fn migrate_to<M: MigratorTrait>(
         return Ok(());
     }
 
-    match dir {
+    match direction {
         Direction::Up => match target_index - latest_index {
             num_migrations if num_migrations > 0 => {
                 info!("executing {num_migrations} migration(s) to {target}");


### PR DESCRIPTION
Supports https://github.com/divviup/janus-ops/issues/630.

Covers two gaps in the SeaORM migrator CLI that implementing our database ops strategy difficult:
- Support up/downgrading the database up/down to an exact migration. This lets us track the version of the database in source control.
- Dry-run changes

This is done by wrapping the already existing SeaORM migration APIs. We can determine how many migrations need to be applied by comparing the indexes of the target and current versions in the vec of all migrations.