### PR TITLE
`migration` binary is still required for integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ ARG GIT_REVISION=unknown
 LABEL revision ${GIT_REVISION}
 EXPOSE 8080
 ENV HOST=0.0.0.0
+COPY --from=builder /src/target/release/migration /migration
 COPY --from=builder /src/target/release/migrate_to /migrate_to
 COPY --from=builder /src/target/release/divviup_api_bin /divviup_api_bin
 ENTRYPOINT ["/divviup_api_bin"]


### PR DESCRIPTION
Still required by https://github.com/divviup/janus-ops/blob/main/terraform/main_local/divviup_api.tf#L113.