### PR TITLE
Disable color output in migrate_to

### DIFF
--- a/migration/src/bin/migrate_to.rs
+++ b/migration/src/bin/migrate_to.rs
@@ -36,6 +36,7 @@ async fn main() -> Result<(), Error> {
     let args = Args::parse();
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(false)
         .init();
 
     let db = Database::connect(ConnectOptions::new(args.database_url)).await?;


### PR DESCRIPTION
Color is not rendered in GitHub markdown, making output difficult to read when its posted in comments https://github.com/divviup/janus-ops/pull/866#issuecomment-1603459620. Disable color logging in `migrate_to`.