### PR TITLE
Fix broken down migration, add missing table call

### DIFF
--- a/migration/src/m20230211_233835_create_accounts.rs
+++ b/migration/src/m20230211_233835_create_accounts.rs
@@ -50,7 +50,12 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_foreign_key(ForeignKey::drop().name("fkey-task-account-id").to_owned())
+            .drop_foreign_key(
+                ForeignKey::drop()
+                    .name("fkey-task-account-id")
+                    .table(Task::Table)
+                    .to_owned(),
+            )
             .await?;
         manager
             .drop_table(Table::drop().table(Account::Table).to_owned())


### PR DESCRIPTION
Fixes https://github.com/divviup/divviup-api/issues/194.

Previously, the generated sql was
```sql
ALTER TABLE
  DROP CONSTRAINT "fkey-task-account-id"
```

Which is a syntax error. After this change, the sql becomes
```sql
ALTER TABLE
  "task" DROP CONSTRAINT "fkey-task-account-id"
```