### PR TITLE
Put migrations in lexicographic order, and have migrate_to tests run in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Collect coverage data
-        run: cargo llvm-cov nextest --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --lcov --output-path lcov.info --workspace
       - name: Upload coverage data to coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -29,9 +29,9 @@ impl MigratorTrait for Migrator {
             Box::new(m20230512_200213_make_task_max_batch_size_a_big_integer::Migration),
             Box::new(m20230512_202411_add_two_urls_to_every_task::Migration),
             Box::new(m20230616_223923_create_aggregators::Migration),
-            Box::new(m20230626_183248_add_is_first_party_to_aggregators::Migration),
             Box::new(m20230620_195535_add_aggregators_to_tasks::Migration),
             Box::new(m20230622_232534_make_aggregator_api_url_mandatory::Migration),
+            Box::new(m20230626_183248_add_is_first_party_to_aggregators::Migration),
             Box::new(m20230630_175314_create_api_tokens::Migration),
         ]
     }


### PR DESCRIPTION
Fixes the error here https://github.com/divviup/janus-ops/pull/887#issuecomment-1622076383.

The migrations must be in lexicographic order for the `migrate_to` CLI to work properly. There exists a test to check for this, but it wasn't being run in CI.