### PR TITLE
Fix handling of aggregator API base URLs with path

### DIFF
--- a/src/api_mocks.rs
+++ b/src/api_mocks.rs
@@ -6,6 +6,7 @@ use trillium_logger::{
     logger,
 };
 use trillium_macros::Handler;
+use trillium_router::Router;
 
 pub mod aggregator_api;
 pub mod auth0;
@@ -41,7 +42,9 @@ impl ApiMocks {
             origin_router()
                 .with_handler(postmark_url, postmark::mock())
                 .with_handler(auth0_url, auth0::mock(auth0_url)),
-            aggregator_api::mock(),
+            // Add a path prefix before the aggregator API mock. Aggregator test fixtures must
+            // include this prefix in their URLs.
+            Router::new().all("prefix/*", aggregator_api::mock()),
         )))
     }
 }

--- a/src/clients/aggregator_client.rs
+++ b/src/clients/aggregator_client.rs
@@ -38,7 +38,7 @@ impl AggregatorClient {
 
     pub async fn get_task_ids(&self) -> Result<Vec<String>, ClientError> {
         let mut ids = vec![];
-        let mut path = String::from("/task_ids");
+        let mut path = String::from("task_ids");
         loop {
             let TaskIds {
                 task_ids,
@@ -49,7 +49,7 @@ impl AggregatorClient {
 
             match pagination_token {
                 Some(pagination_token) => {
-                    path = format!("/task_ids?pagination_token={pagination_token}");
+                    path = format!("task_ids?pagination_token={pagination_token}");
                 }
                 None => break Ok(ids),
             }
@@ -57,20 +57,20 @@ impl AggregatorClient {
     }
 
     pub async fn get_task(&self, task_id: &str) -> Result<TaskResponse, ClientError> {
-        self.get(&format!("/tasks/{task_id}")).await
+        self.get(&format!("tasks/{task_id}")).await
     }
 
     pub async fn get_task_metrics(&self, task_id: &str) -> Result<TaskMetrics, ClientError> {
-        self.get(&format!("/tasks/{task_id}/metrics")).await
+        self.get(&format!("tasks/{task_id}/metrics")).await
     }
 
     pub async fn delete_task(&self, task_id: &str) -> Result<(), ClientError> {
-        self.delete(&format!("/tasks/{task_id}")).await
+        self.delete(&format!("tasks/{task_id}")).await
     }
 
     pub async fn create_task(&self, task: &ProvisionableTask) -> Result<TaskResponse, Error> {
         let task_create = TaskCreate::build(&self.aggregator, task)?;
-        self.post("/tasks", &task_create).await.map_err(Into::into)
+        self.post("tasks", &task_create).await.map_err(Into::into)
     }
 
     // private below here

--- a/tests/harness/fixtures.rs
+++ b/tests/harness/fixtures.rs
@@ -100,7 +100,8 @@ pub fn new_aggregator() -> NewAggregator {
     NewAggregator {
         role: Some(Role::Either.as_ref().to_string()),
         name: Some(format!("{}-aggregator", random_name())),
-        api_url: Some(format!("https://api.{}.divviup.org", random_name())),
+        // This path prefix matches that in the ApiMocks router.
+        api_url: Some(format!("https://api.{}.divviup.org/prefix/", random_name())),
         dap_url: Some(format!("https://dap.{}.divviup.org", random_name())),
         bearer_token: Some(random_name()),
     }

--- a/tests/tasks.rs
+++ b/tests/tasks.rs
@@ -249,7 +249,7 @@ mod show {
             aggregator_api_request.url,
             first_party_aggregator
                 .api_url
-                .join(&format!("/tasks/{}/metrics", task.id))
+                .join(&format!("tasks/{}/metrics", task.id))
                 .unwrap()
         );
         let metrics: TaskMetrics = aggregator_api_request.response_json();


### PR DESCRIPTION
Currently, divviup-api accidentally ignores the path component of aggregator API URLs. The various path fragments used with `Url::join()` include leading forward slashes, so they are treated as absolute URLs. This PR fixes those string constants, and changes the aggregator API mock to use a non-empty path prefix, in order to catch regressions.