### PR TITLE
Allow base64 padding characters in bearer tokens

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -33,7 +33,8 @@ pub use api_token::{
 };
 
 mod validators {
-    const BASE64_CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    const BASE64_CHARS: &[u8] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
     pub(super) fn base64(data: &str) -> Result<(), validator::ValidationError> {
         if data


### PR DESCRIPTION
The base64 custom validator is too strict for the aggregator API's purposes, as it doesn't allow `=` padding characters. Janus currently expects to be able to decode aggregator API bearer tokens with the `STANDARD` base64 engine, so bearer tokens must end with two padding characters, given the token length we chose. This PR adds `=` to the validator's allowed alphabet.