### PR TITLE
add an initial version of task form help text

### DIFF
--- a/app/src/ApiClient.ts
+++ b/app/src/ApiClient.ts
@@ -76,9 +76,15 @@ export type NewTask = Omit<
   | "account_id"
   | "created_at"
   | "updated_at"
+  | "vdaf"
 > & {
   hpke_config: string;
   partner_url: string;
+  vdaf: {
+    type: "sum" | "count" | "histogram";
+    bits?: number;
+    buckets?: number;
+  };
 };
 
 export interface UpdateTask {


### PR DESCRIPTION
closes #286 
closes #148 
closes #284

The design is going to take some iteration, but I'd prefer to get a first version merged and fiddle with it over time. The help text displays when the field is focused OR the "more>>" is clicked

## Screenshots

<img width="1532" alt="image" src="https://github.com/divviup/divviup-api/assets/13301/3846656c-131e-4a22-8b28-e9d28bbb694c">
<img width="1532" alt="image" src="https://github.com/divviup/divviup-api/assets/13301/1ed27fcc-9fae-4d41-bd6d-3efe3588c5a7">
<img width="1532" alt="image" src="https://github.com/divviup/divviup-api/assets/13301/67a362fa-7d36-4f7d-94f8-0c77fdf34cc3">
<img width="1532" alt="image" src="https://github.com/divviup/divviup-api/assets/13301/c52722c9-48ac-49b6-bbd0-bd68db6e6344">
