### PR TITLE
remove last-modified-at headers from index routes

### DIFF
--- a/src/routes/accounts.rs
+++ b/src/routes/accounts.rs
@@ -46,7 +46,7 @@ pub async fn show(conn: &mut Conn, account: Account) -> Json<Account> {
     Json(account)
 }
 
-pub async fn index(conn: &mut Conn, (user, db): (User, Db)) -> Result<impl Handler, Error> {
+pub async fn index(_: &mut Conn, (user, db): (User, Db)) -> Result<impl Handler, Error> {
     let accounts = if user.is_admin() {
         Accounts::find().all(&db).await?
     } else {
@@ -56,10 +56,6 @@ pub async fn index(conn: &mut Conn, (user, db): (User, Db)) -> Result<impl Handl
             .all(&db)
             .await?
     };
-
-    if let Some(last_modified) = accounts.iter().map(|account| account.updated_at).max() {
-        conn.set_last_modified(last_modified.into());
-    }
 
     Ok(Json(accounts))
 }

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -57,17 +57,12 @@ async fn index(conn: &mut Conn, db: Db) -> Result<Json<Vec<Model>>, Error> {
         _ => {}
     }
 
-    let queue = find
-        .order_by_desc(Column::UpdatedAt)
+    find.order_by_desc(Column::UpdatedAt)
         .limit(100)
         .all(&db)
-        .await?;
-
-    if let Some(first) = queue.first() {
-        conn.set_last_modified(first.updated_at.into());
-    }
-
-    Ok(Json(queue))
+        .await
+        .map(Json)
+        .map_err(Error::from)
 }
 
 async fn show(conn: &mut Conn, queue_job: Model) -> Json<Model> {

--- a/src/routes/aggregators.rs
+++ b/src/routes/aggregators.rs
@@ -12,6 +12,7 @@ use sea_orm::{
 };
 use trillium::{Conn, Handler, Status};
 use trillium_api::{FromConn, Json};
+use trillium_caching_headers::CachingHeadersExt;
 use trillium_router::RouterConnExt;
 use uuid::Uuid;
 
@@ -62,7 +63,8 @@ impl FromConn for Aggregator {
     }
 }
 
-pub async fn show(_: &mut Conn, aggregator: Aggregator) -> Json<Aggregator> {
+pub async fn show(conn: &mut Conn, aggregator: Aggregator) -> Json<Aggregator> {
+    conn.set_last_modified(aggregator.updated_at.into());
     Json(aggregator)
 }
 

--- a/src/routes/memberships.rs
+++ b/src/routes/memberships.rs
@@ -12,19 +12,16 @@ use sea_orm::{
 };
 use trillium::{Conn, Handler, Status};
 use trillium_api::Json;
-use trillium_caching_headers::CachingHeadersExt;
+
 use trillium_router::RouterConnExt;
 
-pub async fn index(conn: &mut Conn, (account, db): (Account, Db)) -> Result<impl Handler, Error> {
-    let memberships = account.find_related(Memberships).all(&db).await?;
-    if let Some(last_modified) = memberships
-        .iter()
-        .map(|membership| membership.created_at)
-        .max()
-    {
-        conn.set_last_modified(last_modified.into());
-    }
-    Ok(Json(memberships))
+pub async fn index(_: &mut Conn, (account, db): (Account, Db)) -> Result<impl Handler, Error> {
+    account
+        .find_related(Memberships)
+        .all(&db)
+        .await
+        .map_err(Error::from)
+        .map(Json)
 }
 
 pub async fn create(

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -14,12 +14,13 @@ use trillium_caching_headers::CachingHeadersExt;
 use trillium_client::Client;
 use trillium_router::RouterConnExt;
 
-pub async fn index(conn: &mut Conn, (account, db): (Account, Db)) -> Result<impl Handler, Error> {
-    let tasks = account.find_related(Tasks).all(&db).await?;
-    if let Some(last_modified) = tasks.iter().map(|task| task.updated_at).max() {
-        conn.set_last_modified(last_modified.into());
-    }
-    Ok(Json(tasks))
+pub async fn index(_: &mut Conn, (account, db): (Account, Db)) -> Result<impl Handler, Error> {
+    account
+        .find_related(Tasks)
+        .all(&db)
+        .await
+        .map(Json)
+        .map_err(Error::from)
 }
 
 #[trillium::async_trait]

--- a/tests/api_tokens.rs
+++ b/tests/api_tokens.rs
@@ -29,7 +29,7 @@ mod index {
         assert_ok!(conn);
 
         let api_tokens: Vec<ApiToken> = conn.response_json().await;
-        assert_same_json_representation(&api_tokens, &vec![token1, token2]);
+        assert_same_json_representation(&api_tokens, &vec![token2, token1]);
         Ok(())
     }
 
@@ -86,7 +86,7 @@ mod index {
 
         assert_ok!(conn);
         let api_tokens: Vec<ApiToken> = conn.response_json().await;
-        assert_same_json_representation(&api_tokens, &vec![api_token1, api_token2]);
+        assert_same_json_representation(&api_tokens, &vec![api_token2, api_token1]);
         Ok(())
     }
 }


### PR DESCRIPTION
they were resulting in cache-invalidation errors because the max updated_at timestamp did not change on older record deletion

closes #285 
(possibly) closes #191