### PR TITLE
rename ApiConfig to Config

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,4 +1,4 @@
-use divviup_api::{ApiConfig, DivviupApi, Queue};
+use divviup_api::{Config, DivviupApi, Queue};
 
 use trillium_http::Stopper;
 use trillium_tokio::CloneCounterObserver;
@@ -7,7 +7,7 @@ use trillium_tokio::CloneCounterObserver;
 async fn main() {
     env_logger::init();
 
-    let config = match ApiConfig::from_env() {
+    let config = match Config::from_env() {
         Ok(config) => config,
         Err(e) => panic!("{e}"),
     };

--- a/src/clients/auth0_client.rs
+++ b/src/clients/auth0_client.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 use crate::{
     clients::{ClientConnExt, ClientError, PostmarkClient},
-    ApiConfig,
+    Config,
 };
 
 #[derive(Debug, Clone)]
@@ -42,7 +42,7 @@ fn generate_password() -> String {
 }
 
 impl Auth0Client {
-    pub fn new(config: &ApiConfig) -> Self {
+    pub fn new(config: &Config) -> Self {
         Self {
             token: Arc::new(RwLock::new(None)),
             client: config.client.clone(),

--- a/src/clients/postmark_client.rs
+++ b/src/clients/postmark_client.rs
@@ -1,6 +1,6 @@
 use crate::{
     clients::{ClientConnExt, ClientError},
-    ApiConfig,
+    Config,
 };
 use email_address::EmailAddress;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -26,7 +26,7 @@ impl FromConn for PostmarkClient {
 }
 
 impl PostmarkClient {
-    pub fn new(config: &ApiConfig) -> Self {
+    pub fn new(config: &Config) -> Self {
         Self {
             token: config.postmark_token.clone(),
             client: config.client.clone(),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -10,7 +10,7 @@ pub(crate) mod oauth2;
 pub(crate) mod origin_router;
 pub(crate) mod session_store;
 
-use crate::{routes, ApiConfig, Db};
+use crate::{routes, Config, Db};
 
 use cors::cors_headers;
 use error::ErrorHandler;
@@ -40,7 +40,7 @@ pub struct DivviupApi {
     #[handler(except = init)]
     handler: Box<dyn Handler>,
     db: Db,
-    config: Arc<ApiConfig>,
+    config: Arc<Config>,
 }
 
 impl DivviupApi {
@@ -53,7 +53,7 @@ impl DivviupApi {
         self.handler.init(info).await
     }
 
-    pub async fn new(config: ApiConfig) -> Self {
+    pub async fn new(config: Config) -> Self {
         let config = Arc::new(config);
         let db = Db::connect(config.database_url.as_ref()).await;
         Self {
@@ -77,7 +77,7 @@ impl DivviupApi {
         &self.db
     }
 
-    pub fn config(&self) -> &ApiConfig {
+    pub fn config(&self) -> &Config {
         &self.config
     }
 }
@@ -88,7 +88,7 @@ impl AsRef<Db> for DivviupApi {
     }
 }
 
-fn api(db: &Db, config: &ApiConfig) -> impl Handler {
+fn api(db: &Db, config: &Config) -> impl Handler {
     (
         compression(),
         #[cfg(feature = "integration-testing")]

--- a/src/handler/assets.rs
+++ b/src/handler/assets.rs
@@ -1,4 +1,4 @@
-use crate::{handler::origin_router, ApiConfig};
+use crate::{handler::origin_router, Config};
 use std::time::Duration;
 use trillium::{
     Conn, Handler,
@@ -11,7 +11,7 @@ use url::Url;
 
 const ONE_YEAR: Duration = Duration::from_secs(60 * 60 * 24 * 365);
 
-pub fn static_assets(config: &ApiConfig) -> impl Handler {
+pub fn static_assets(config: &Config) -> impl Handler {
     origin_router().with_handler(
         config.app_url.as_ref(),
         ReactApp {

--- a/src/handler/cors.rs
+++ b/src/handler/cors.rs
@@ -1,4 +1,4 @@
-use crate::ApiConfig;
+use crate::Config;
 use trillium::{
     Conn, Handler,
     KnownHeaderName::{
@@ -43,13 +43,13 @@ impl Handler for CorsHeaders {
 }
 
 impl CorsHeaders {
-    pub fn new(config: &ApiConfig) -> Self {
+    pub fn new(config: &Config) -> Self {
         let mut origin = config.app_url.to_string();
         origin.pop();
         Self { origin }
     }
 }
 
-pub fn cors_headers(config: &ApiConfig) -> impl Handler {
+pub fn cors_headers(config: &Config) -> impl Handler {
     CorsHeaders::new(config)
 }

--- a/src/handler/misc.rs
+++ b/src/handler/misc.rs
@@ -1,11 +1,11 @@
-use crate::{ApiConfig, PermissionsActor, User};
+use crate::{Config, PermissionsActor, User};
 use trillium::{Conn, Handler, Status};
 use trillium_api::{api, Halt};
 use trillium_redirect::Redirect;
 use trillium_sessions::SessionConnExt;
 
 /// note(jbr): most of these need to find better places to live
-pub fn redirect_if_logged_in(config: &ApiConfig) -> impl Handler {
+pub fn redirect_if_logged_in(config: &Config) -> impl Handler {
     let app_url = config.app_url.to_string();
     api(move |_: &mut Conn, user: Option<User>| {
         let app_url = app_url.clone();
@@ -19,7 +19,7 @@ pub fn redirect_if_logged_in(config: &ApiConfig) -> impl Handler {
     })
 }
 
-pub fn logout_from_auth0(config: &ApiConfig) -> impl Handler {
+pub fn logout_from_auth0(config: &Config) -> impl Handler {
     let mut logout_url = config.auth_url.join("/v2/logout").unwrap();
 
     logout_url.query_pairs_mut().extend_pairs([

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod routes;
 pub mod telemetry;
 mod user;
 
-pub use config::{ApiConfig, ApiConfigError};
+pub use config::{Config, ConfigError};
 pub use db::Db;
 pub use handler::{DivviupApi, Error};
 pub use permissions::{Permissions, PermissionsActor};

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -4,7 +4,7 @@ pub use job::*;
 
 use crate::{
     entity::queue::{ActiveModel, Column, Entity, Model},
-    ApiConfig, Db, DivviupApi,
+    Config, Db, DivviupApi,
 };
 use sea_orm::{
     sea_query::{self, all, Expr},
@@ -27,7 +27,7 @@ pub struct Queue {
     job_state: Arc<SharedJobState>,
 }
 /*
-These configuration variables may eventually be useful to put on ApiConfig
+These configuration variables may eventually be useful to put on Config
 */
 const MAX_RETRY: i32 = 5;
 const QUEUE_CHECK_INTERVAL: Range<u64> = 60_000..120_000;
@@ -53,7 +53,7 @@ impl From<&DivviupApi> for Queue {
 }
 
 impl Queue {
-    pub fn new(db: &Db, config: &ApiConfig) -> Self {
+    pub fn new(db: &Db, config: &Config) -> Self {
         Self {
             observer: Default::default(),
             db: db.clone(),

--- a/src/queue/job.rs
+++ b/src/queue/job.rs
@@ -1,7 +1,7 @@
 use crate::{
     clients::{Auth0Client, ClientError, PostmarkClient},
     entity::Membership,
-    ApiConfig,
+    Config,
 };
 use sea_orm::{ActiveModelTrait, ConnectionTrait, DbErr};
 use serde::{Deserialize, Serialize};
@@ -78,8 +78,8 @@ pub struct SharedJobState {
     pub auth0_client: Auth0Client,
     pub postmark_client: PostmarkClient,
 }
-impl From<&ApiConfig> for SharedJobState {
-    fn from(config: &ApiConfig) -> Self {
+impl From<&Config> for SharedJobState {
+    fn from(config: &Config) -> Self {
         Self {
             auth0_client: Auth0Client::new(config),
             postmark_client: PostmarkClient::new(config),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -14,7 +14,7 @@ use crate::{
         oauth2::{self, OauthClient},
         redirect_if_logged_in, ReplaceMimeTypes,
     },
-    ApiConfig,
+    Config,
 };
 pub use health_check::health_check;
 use trillium::{
@@ -25,7 +25,7 @@ use trillium_api::api;
 use trillium_redirect::redirect;
 use trillium_router::router;
 
-pub fn routes(config: &ApiConfig) -> impl Handler {
+pub fn routes(config: &Config) -> impl Handler {
     let oauth2_client = OauthClient::new(&config.oauth_config());
     let auth0_client = Auth0Client::new(config);
 
@@ -54,7 +54,7 @@ pub fn routes(config: &ApiConfig) -> impl Handler {
         )
 }
 
-fn api_routes(config: &ApiConfig) -> impl Handler {
+fn api_routes(config: &Config) -> impl Handler {
     (
         ReplaceMimeTypes,
         api(actor_required),
@@ -88,7 +88,7 @@ fn api_routes(config: &ApiConfig) -> impl Handler {
     )
 }
 
-fn accounts_routes(config: &ApiConfig) -> impl Handler {
+fn accounts_routes(config: &Config) -> impl Handler {
     router()
         .patch("/", api(accounts::update))
         .get("/", api(accounts::show))

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -4,7 +4,7 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use divviup_api::{
     clients::aggregator_client::api_types::{Encode, HpkeConfig},
     entity::queue,
-    ApiConfig, Db,
+    Config, Db,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, future::Future};
@@ -68,8 +68,8 @@ async fn set_up_schema(db: &Db) {
     set_up_schema_for(&schema, db, ApiTokens).await;
 }
 
-pub fn config(api_mocks: impl Handler) -> ApiConfig {
-    ApiConfig {
+pub fn config(api_mocks: impl Handler) -> Config {
+    Config {
         session_secret: "x".repeat(32),
         api_url: "https://api.example".parse().unwrap(),
         app_url: "https://app.example".parse().unwrap(),


### PR DESCRIPTION
This has been bothering me for a bit, but it's *the* config for this app, so there's no reason it needs to be qualified redundantly as `divviup_api::ApiConfig` so now it's `divviup_api::Config`