### PR TITLE
constant time api token comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1065,6 +1065,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sha2 0.10.7",
+ "subtle",
  "test-support",
  "thiserror",
  "time",
@@ -1576,7 +1577,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.11.1",
+ "crypto-mac 0.11.0",
  "digest 0.9.0",
 ]
 
@@ -3545,9 +3546,9 @@ checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1.0.179", features = ["derive"] }
 serde_json = "1.0.104"
 serde_path_to_error = "0.1.14"
 sha2 = "0.10.7"
+subtle = "2.5.0"
 thiserror = "1.0.44"
 time = { version = "0.3.24", features = ["serde", "serde-well-known"] }
 tokio = { version = "1.29.1", features = ["full"] }

--- a/tests/api_tokens.rs
+++ b/tests/api_tokens.rs
@@ -143,8 +143,6 @@ mod index {
 
 mod create {
     use super::{assert_eq, test, *};
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-    use sha2::{Digest, Sha256};
 
     #[test(harness = set_up)]
     async fn success(app: DivviupApi) -> TestResult {
@@ -156,21 +154,16 @@ mod create {
             .run_async(&app)
             .await;
         assert_response!(conn, 201);
-        let mut response: ApiToken = conn.response_json().await;
-        let api_token = response.reload(app.db()).await?.unwrap();
+        let mut api_token: ApiToken = conn.response_json().await;
+        let api_token_from_db = api_token.reload(app.db()).await?.unwrap();
+        let (api_token_from_token, account_from_token) =
+            ApiTokens::load_and_check(&api_token.token.take().unwrap(), app.db())
+                .await
+                .unwrap();
 
-        assert_eq!(&api_token.token_hash, &response.token_hash);
-
-        assert_eq!(
-            &*Sha256::digest(
-                URL_SAFE_NO_PAD
-                    .decode(response.token.take().unwrap())
-                    .unwrap()
-            ),
-            &*api_token.token_hash
-        );
-
-        assert_same_json_representation(&response, &api_token);
+        assert_eq!(api_token, api_token_from_token);
+        assert_eq!(account, account_from_token);
+        assert_same_json_representation(&api_token, &api_token_from_db);
         Ok(())
     }
 
@@ -224,18 +217,14 @@ mod create {
         assert_response!(conn, 201);
         let mut api_token: ApiToken = conn.response_json().await;
         let api_token_from_db = api_token.reload(app.db()).await?.unwrap();
+        let (api_token_from_token, account_from_token) =
+            ApiTokens::load_and_check(&api_token.token.take().unwrap(), app.db())
+                .await
+                .unwrap();
 
-        assert_eq!(
-            &*Sha256::digest(
-                URL_SAFE_NO_PAD
-                    .decode(api_token.token.take().unwrap())
-                    .unwrap()
-            ),
-            &*api_token_from_db.token_hash
-        );
-
+        assert_eq!(api_token, api_token_from_token);
+        assert_eq!(account, account_from_token);
         assert_same_json_representation(&api_token, &api_token_from_db);
-
         Ok(())
     }
 
@@ -252,18 +241,14 @@ mod create {
         assert_response!(conn, 201);
         let mut api_token: ApiToken = conn.response_json().await;
         let api_token_from_db = api_token.reload(app.db()).await?.unwrap();
+        let (api_token_from_token, account_from_token) =
+            ApiTokens::load_and_check(&api_token.token.take().unwrap(), app.db())
+                .await
+                .unwrap();
 
-        assert_eq!(
-            &*Sha256::digest(
-                URL_SAFE_NO_PAD
-                    .decode(api_token.token.take().unwrap())
-                    .unwrap()
-            ),
-            &*api_token_from_db.token_hash
-        );
-
+        assert_eq!(api_token, api_token_from_token);
+        assert_eq!(account, account_from_token);
         assert_same_json_representation(&api_token, &api_token_from_db);
-
         Ok(())
     }
 
@@ -280,16 +265,13 @@ mod create {
         assert_response!(conn, 201);
         let mut api_token: ApiToken = conn.response_json().await;
         let api_token_from_db = api_token.reload(app.db()).await?.unwrap();
+        let (api_token_from_token, account_from_token) =
+            ApiTokens::load_and_check(&api_token.token.take().unwrap(), app.db())
+                .await
+                .unwrap();
 
-        assert_eq!(
-            &*Sha256::digest(
-                URL_SAFE_NO_PAD
-                    .decode(api_token.token.take().unwrap())
-                    .unwrap()
-            ),
-            &*api_token_from_db.token_hash
-        );
-
+        assert_eq!(api_token, api_token_from_token);
+        assert_eq!(account, account_from_token);
         assert_same_json_representation(&api_token, &api_token_from_db);
 
         Ok(())


### PR DESCRIPTION
If we want this change, we will likely either want to delete all existing tokens or add re-add support for the old format

closes #362 

Sessions will have to be addressed outside of this crate

## Token Format

Although this should be treated by external parties as an opaque token, it has the following layout:

```
"DUAT" || url-safe-no-pad-base64( api token uuid as 16 bytes || 32 random bytes )
```

We store a SHA256 digest of the 32 random bytes in conjunction with the uuid. To check the token, we fetch the record by api token uuid and compare the digest of the provided secret bytes with the stored digest.

"DUAT" (Divvi Up Api Token) is used to identify the bearer token format both in order to support new formats in the future and to allow for secrets detection in case of potential customer breaches