### PR TITLE
use rfc3339 instead of iso8601

### DIFF
--- a/client/src/account.rs
+++ b/client/src/account.rs
@@ -6,9 +6,9 @@ use uuid::Uuid;
 pub struct Account {
     pub id: Uuid,
     pub name: String,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub admin: bool,
 }

--- a/client/src/aggregator.rs
+++ b/client/src/aggregator.rs
@@ -16,12 +16,12 @@ pub struct Aggregator {
     pub id: Uuid,
     // an account_id of None indicates a shared Aggregator
     pub account_id: Option<Uuid>,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     // a deleted_at of Some indicates a tombstoned/inactivated Aggregator
-    #[serde(default, with = "::time::serde::iso8601::option")]
+    #[serde(default, with = "::time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
     pub role: Role,
     pub name: String,

--- a/client/src/api_token.rs
+++ b/client/src/api_token.rs
@@ -7,13 +7,13 @@ pub struct ApiToken {
     pub id: Uuid,
     pub account_id: Uuid,
     pub token_hash: String,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(default, with = "::time::serde::iso8601::option")]
+    #[serde(default, with = "::time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
-    #[serde(default, with = "::time::serde::iso8601::option")]
+    #[serde(default, with = "::time::serde::rfc3339::option")]
     pub last_used_at: Option<OffsetDateTime>,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub name: Option<String>,
     pub token: Option<String>,

--- a/client/src/hpke_configs.rs
+++ b/client/src/hpke_configs.rs
@@ -7,11 +7,11 @@ use uuid::Uuid;
 pub struct HpkeConfig {
     pub id: Uuid,
     pub contents: HpkeConfigContents,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(default, with = "::time::serde::iso8601::option")]
+    #[serde(default, with = "::time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub name: Option<String>,
 }

--- a/client/src/task.rs
+++ b/client/src/task.rs
@@ -10,14 +10,14 @@ pub struct Task {
     pub vdaf: Vdaf,
     pub min_batch_size: u64,
     pub max_batch_size: Option<u64>,
-    #[serde(with = "time::serde::iso8601")]
+    #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::iso8601")]
+    #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub time_precision_seconds: u32,
     pub report_count: u32,
     pub aggregate_collection_count: u32,
-    #[serde(default, with = "time::serde::iso8601::option")]
+    #[serde(default, with = "time::serde::rfc3339::option")]
     pub expiration: Option<OffsetDateTime>,
     pub leader_aggregator_id: Uuid,
     pub helper_aggregator_id: Uuid,

--- a/src/entity/account.rs
+++ b/src/entity/account.rs
@@ -20,10 +20,10 @@ pub struct Model {
 
     pub name: String,
 
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
 
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
 
     pub admin: bool,

--- a/src/entity/aggregator.rs
+++ b/src/entity/aggregator.rs
@@ -30,12 +30,12 @@ pub struct Model {
     pub id: Uuid,
     // an account_id of None indicates a shared Aggregator
     pub account_id: Option<Uuid>,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     // a deleted_at of Some indicates a tombstoned/inactivated Aggregator
-    #[serde(default, with = "time::serde::iso8601::option")]
+    #[serde(default, with = "time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
     pub role: Role,
     pub name: String,

--- a/src/entity/api_token.rs
+++ b/src/entity/api_token.rs
@@ -23,13 +23,13 @@ pub struct Model {
     pub account_id: Uuid,
     #[serde(with = "url_safe_base64")]
     pub token_hash: Vec<u8>,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(default, with = "::time::serde::iso8601::option")]
+    #[serde(default, with = "::time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
-    #[serde(default, with = "::time::serde::iso8601::option")]
+    #[serde(default, with = "::time::serde::rfc3339::option")]
     pub last_used_at: Option<OffsetDateTime>,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub name: Option<String>,
     #[sea_orm(ignore)]

--- a/src/entity/hpke_config.rs
+++ b/src/entity/hpke_config.rs
@@ -19,11 +19,11 @@ pub struct Model {
     pub id: Uuid,
     pub account_id: Uuid,
     pub contents: Codec<janus_messages::HpkeConfig>,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(default, with = "::time::serde::iso8601::option")]
+    #[serde(default, with = "::time::serde::rfc3339::option")]
     pub deleted_at: Option<OffsetDateTime>,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub name: Option<String>,
 }

--- a/src/entity/membership.rs
+++ b/src/entity/membership.rs
@@ -19,7 +19,7 @@ pub struct Model {
     pub id: Uuid,
     pub account_id: Uuid,
     pub user_email: String,
-    #[serde(with = "::time::serde::iso8601")]
+    #[serde(with = "::time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
 }
 

--- a/src/entity/queue.rs
+++ b/src/entity/queue.rs
@@ -16,11 +16,11 @@ use uuid::Uuid;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
-    #[serde(with = "time::serde::iso8601")]
+    #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::iso8601")]
+    #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
-    #[serde(default, with = "time::serde::iso8601::option")]
+    #[serde(default, with = "time::serde::rfc3339::option")]
     pub scheduled_at: Option<OffsetDateTime>,
     pub failure_count: i32,
     pub status: JobStatus,

--- a/src/entity/task.rs
+++ b/src/entity/task.rs
@@ -38,14 +38,14 @@ pub struct Model {
     pub vdaf: Json<Vdaf>,
     pub min_batch_size: i64,
     pub max_batch_size: Option<i64>,
-    #[serde(with = "time::serde::iso8601")]
+    #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::iso8601")]
+    #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub time_precision_seconds: i32,
     pub report_count: i32,
     pub aggregate_collection_count: i32,
-    #[serde(default, with = "time::serde::iso8601::option")]
+    #[serde(default, with = "time::serde::rfc3339::option")]
     pub expiration: Option<OffsetDateTime>,
     pub leader_aggregator_id: Uuid,
     pub helper_aggregator_id: Uuid,

--- a/src/user.rs
+++ b/src/user.rs
@@ -21,7 +21,7 @@ pub struct User {
     pub nickname: String,
     pub picture: Option<String>,
     pub sub: String,
-    #[serde(with = "time::serde::iso8601")]
+    #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub admin: Option<bool>,
 }


### PR DESCRIPTION
closes #412 — the motivation behind this is that openapi assumes all timestamps are rfc3339 and on further investigation of the formats, that seems to be the better and more standard choice for json serialization. I believe that this is not a breaking change to the api because rfc3339 is a "profile" of iso8601, and so any parser of iso8601 can transparently support rfc3339.