### PR TITLE
Rewrite bucket parameter description for DAP-04

### DIFF
--- a/app/src/tasks/TaskForm.tsx
+++ b/app/src/tasks/TaskForm.tsx
@@ -262,12 +262,15 @@ const helps: {
 
   "vdaf.buckets": {
     title: "Histogram",
-    short: "Selects the number of histogram buckets or counters.",
+    short: "Specifies the boundaries between histogram buckets.",
     long: (
       <p>
-        Determines how many buckets the histogram has. Each client report can
-        only add one to a single bucket/counter. This parameter affects the size
-        of client reports.
+        A comma-separated list of numbers, in ascending order. Each client
+        measurement will only record whether it is below all bucket boundaries,
+        between a particular pair of bucket boundaries, or above all bucket
+        boundaries. Each bucket interval includes its upper boundary value, and
+        excludes its lower boundary value. This parameter affects the size of
+        client reports.
       </p>
     ),
   },


### PR DESCRIPTION
This rewrites the description of the buckets parameter to align with DAP-04. (see https://github.com/divviup/divviup-api/issues/438#issuecomment-1701651428) We should fix this up before directing our partners to start creating histogram tasks. The pre-existing text would be good for DAP-06 tasks, as part of #438.