### PR TITLE
CLI argument tweaks

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,8 +1,3 @@
-# optional
-export RUST_LOG=info
-export HOST=localhost
-export PORT=8080
-
 # mandatory
 export AUTH_URL=https://something.us.auth0.com
 export AUTH_CLIENT_ID=...
@@ -18,3 +13,9 @@ export POSTMARK_TOKEN=looks-like-a-uuid
 export EMAIL_ADDRESS=the@from.address
 export AGGREGATOR_API_URL=https://aggregator.divviup.test
 export AGGREGATOR_DAP_URL=https://aggregator.divviup.test
+
+# optional
+export RUST_LOG=info
+export HOST=localhost
+export PORT=8080
+export DIVVIUP_API_URL=$API_URL

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,6 +42,8 @@ pub const USER_AGENT: &str = concatcp!(
     divviup_client::USER_AGENT
 );
 
+pub const DEFAULT_DIVVIUP_API_URL: &str = "https://api.divviup.org";
+
 #[derive(ValueEnum, Debug, Default, Clone, Copy)]
 enum Output {
     #[default]
@@ -84,13 +86,13 @@ impl Output {
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 struct ClientBin {
-    #[arg(short, long, env)]
+    #[arg(short, long, env = "DIVVIUP_TOKEN", hide_env_values = true)]
     token: String,
 
-    #[arg(short, long, env = "API_URL")]
-    url: Option<Url>,
+    #[arg(short, long, env = "DIVVIUP_API_URL", default_value = DEFAULT_DIVVIUP_API_URL)]
+    url: Url,
 
-    #[arg(short, long, env = "ACCOUNT_ID")]
+    #[arg(short, long, env = "DIVVIUP_ACCOUNT_ID")]
     account_id: Option<Uuid>,
 
     #[arg(short, long, default_value_t)]
@@ -157,11 +159,7 @@ impl ClientBin {
             Client::new(RustlsConfig::<ClientConfig>::default()).with_default_pool(),
         )
         .with_header(KnownHeaderName::UserAgent, HeaderValue::from(USER_AGENT));
-
-        if let Some(url) = self.url.clone() {
-            client.set_url(url);
-        }
-
+        client.set_url(self.url.clone());
         client
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,8 +42,6 @@ pub const USER_AGENT: &str = concatcp!(
     divviup_client::USER_AGENT
 );
 
-pub const DEFAULT_DIVVIUP_API_URL: &str = "https://api.divviup.org";
-
 #[derive(ValueEnum, Debug, Default, Clone, Copy)]
 enum Output {
     #[default]
@@ -89,7 +87,7 @@ struct ClientBin {
     #[arg(short, long, env = "DIVVIUP_TOKEN", hide_env_values = true)]
     token: String,
 
-    #[arg(short, long, env = "DIVVIUP_API_URL", default_value = DEFAULT_DIVVIUP_API_URL)]
+    #[arg(short, long, env = "DIVVIUP_API_URL", default_value = divviup_client::DEFAULT_URL)]
     url: Url,
 
     #[arg(short, long, env = "DIVVIUP_ACCOUNT_ID")]


### PR DESCRIPTION
- Prefix environment variables with DIVVIUP_ (fixes https://github.com/divviup/divviup-api/issues/494). This is a breaking change, but since we have no release of this CLI it should be fine?
- Provide default value for DIVVIUP_API_URL, since we have a production environment now
- Prevent the contents of DIVVIUP_TOKEN being printed in the help text with `hide_env_values`
- Update direnv example to allow divviup CLI to work during local dev