### PR TITLE
Handle chunk length VDAF parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,7 @@ dependencies = [
  "oauth2",
  "opentelemetry",
  "opentelemetry-prometheus",
+ "prio 0.15.2",
  "querystrong",
  "rand",
  "regex",
@@ -1900,7 +1901,7 @@ dependencies = [
  "derivative",
  "hex",
  "num_enum",
- "prio",
+ "prio 0.12.2",
  "rand",
  "serde",
  "thiserror",
@@ -2545,6 +2546,23 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "prio"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06023d4cf59f8c136ac9a11affa42d25f1ecf251a5065585be0b9d7a07c01217"
+dependencies = [
+ "aes",
+ "byteorder",
+ "ctr",
+ "getrandom",
+ "rand_core 0.6.4",
+ "serde",
+ "sha3",
  "subtle",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ opentelemetry = { version = "0.19.0", features = ["metrics"] }
 opentelemetry-prometheus = { version = "0.12.0", features = [
     "prometheus-encoding",
 ] }
+prio = "0.15.2"
 querystrong = "0.3.0"
 rand = "0.8.5"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/client/src/task.rs
+++ b/client/src/task.rs
@@ -49,16 +49,32 @@ pub enum Vdaf {
     Sum { bits: u8 },
 
     #[serde(rename = "count_vec")]
-    CountVec { length: u64 },
+    CountVec {
+        length: u64,
+        chunk_length: Option<u64>,
+    },
 
     #[serde(rename = "sum_vec")]
-    SumVec { bits: u8, length: u64 },
+    SumVec {
+        bits: u8,
+        length: u64,
+        chunk_length: Option<u64>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum Histogram {
-    Categorical { buckets: Vec<String> },
-    Continuous { buckets: Vec<u64> },
-    Length { length: u64 },
+    Categorical {
+        buckets: Vec<String>,
+        chunk_length: Option<u64>,
+    },
+    Continuous {
+        buckets: Vec<u64>,
+        chunk_length: Option<u64>,
+    },
+    Length {
+        length: u64,
+        chunk_length: Option<u64>,
+    },
 }

--- a/documentation/openapi.yml
+++ b/documentation/openapi.yml
@@ -752,8 +752,15 @@ components:
         bits:
           type: number
         buckets:
-          type: array
-          item: number
+          oneOf:
+            - type: array
+              items:
+                type: number
+            - type: array
+              items:
+                type: string
+        chunk_length:
+          type: number
       required: [type]
     ApiToken:
       type: object

--- a/src/entity/task/new_task.rs
+++ b/src/entity/task/new_task.rs
@@ -229,6 +229,12 @@ impl NewTask {
         Some(aggregator_vdaf)
     }
 
+    fn populate_chunk_length(&mut self, protocol: &Protocol) {
+        if let Some(vdaf) = &mut self.vdaf {
+            vdaf.populate_chunk_length(protocol);
+        }
+    }
+
     fn validate_query_type_is_supported(
         &self,
         leader: &Aggregator,
@@ -241,8 +247,8 @@ impl NewTask {
         }
     }
 
-    pub async fn validate(
-        &self,
+    pub async fn normalize_and_validate(
+        &mut self,
         account: Account,
         db: &impl ConnectionTrait,
     ) -> Result<ProvisionableTask, ValidationErrors> {
@@ -253,6 +259,7 @@ impl NewTask {
 
         let aggregator_vdaf = if let Some((leader, helper, protocol)) = aggregators.as_ref() {
             self.validate_query_type_is_supported(leader, helper, &mut errors);
+            self.populate_chunk_length(protocol);
             self.validate_vdaf_is_supported(leader, helper, protocol, &mut errors)
         } else {
             None

--- a/src/entity/task/vdaf.rs
+++ b/src/entity/task/vdaf.rs
@@ -2,6 +2,7 @@ use crate::{
     clients::aggregator_client::api_types::{AggregatorVdaf, HistogramType},
     entity::{aggregator::VdafName, Protocol},
 };
+use prio::vdaf::prio3::optimal_chunk_length;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, hash::Hash};
 use validator::{Validate, ValidationError, ValidationErrors};
@@ -19,12 +20,22 @@ impl Histogram {
         match self {
             Histogram::Categorical(CategoricalBuckets {
                 buckets: Some(buckets),
+                ..
             }) => buckets.len() as u64,
             Histogram::Continuous(ContinuousBuckets {
                 buckets: Some(buckets),
+                ..
             }) => buckets.len() as u64 + 1,
-            Histogram::Opaque(BucketLength { length }) => *length,
+            Histogram::Opaque(BucketLength { length, .. }) => *length,
             _ => 0,
+        }
+    }
+
+    pub fn chunk_length(&self) -> Option<u64> {
+        match self {
+            Histogram::Categorical(CategoricalBuckets { chunk_length, .. })
+            | Histogram::Continuous(ContinuousBuckets { chunk_length, .. })
+            | Histogram::Opaque(BucketLength { chunk_length, .. }) => *chunk_length,
         }
     }
 
@@ -34,19 +45,38 @@ impl Histogram {
     ) -> Result<AggregatorVdaf, ValidationErrors> {
         match (protocol, self) {
             (Protocol::Dap07, histogram) => {
-                Ok(AggregatorVdaf::Prio3Histogram(HistogramType::Opaque {
-                    length: histogram.length(),
-                }))
+                if let Some(chunk_length) = histogram.chunk_length() {
+                    Ok(AggregatorVdaf::Prio3Histogram(HistogramType::Opaque {
+                        length: histogram.length(),
+                        chunk_length: Some(chunk_length),
+                    }))
+                } else {
+                    panic!("chunk_length was not populated");
+                }
             }
 
             (
                 Protocol::Dap04,
                 Self::Continuous(ContinuousBuckets {
                     buckets: Some(buckets),
+                    chunk_length: None,
                 }),
             ) => Ok(AggregatorVdaf::Prio3Histogram(HistogramType::Buckets {
                 buckets: buckets.clone(),
+                chunk_length: None,
             })),
+
+            (
+                Protocol::Dap04,
+                Self::Continuous(ContinuousBuckets {
+                    buckets: _,
+                    chunk_length: Some(_),
+                }),
+            ) => {
+                let mut errors = ValidationErrors::new();
+                errors.add("chunk_length", ValidationError::new("not-allowed"));
+                Err(errors)
+            }
 
             (Protocol::Dap04, Self::Categorical(_)) => {
                 let mut errors = ValidationErrors::new();
@@ -67,18 +97,27 @@ impl Histogram {
 pub struct ContinuousBuckets {
     #[validate(required, length(min = 1), custom = "increasing", custom = "unique")]
     pub buckets: Option<Vec<u64>>,
+
+    #[validate(range(min = 1))]
+    pub chunk_length: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Validate, Debug, Clone, Eq, PartialEq)]
 pub struct CategoricalBuckets {
     #[validate(required, length(min = 1), custom = "unique")]
     pub buckets: Option<Vec<String>>,
+
+    #[validate(range(min = 1))]
+    pub chunk_length: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Validate, Debug, Clone, Eq, PartialEq, Copy)]
 pub struct BucketLength {
     #[validate(range(min = 1))]
     pub length: u64,
+
+    #[validate(range(min = 1))]
+    pub chunk_length: Option<u64>,
 }
 
 fn unique<T: Hash + Eq>(buckets: &[T]) -> Result<(), ValidationError> {
@@ -114,6 +153,9 @@ pub struct Sum {
 pub struct CountVec {
     #[validate(required)]
     pub length: Option<u64>,
+
+    #[validate(range(min = 1))]
+    pub chunk_length: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Validate, Debug, Clone, Copy, Eq, PartialEq)]
@@ -123,6 +165,9 @@ pub struct SumVec {
 
     #[validate(required)]
     pub length: Option<u64>,
+
+    #[validate(range(min = 1))]
+    pub chunk_length: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -170,14 +215,103 @@ impl Vdaf {
             Self::SumVec(SumVec {
                 length: Some(length),
                 bits: Some(bits),
+                chunk_length,
             }) => Ok(AggregatorVdaf::Prio3SumVec {
                 bits: *bits,
                 length: *length,
+                chunk_length: *chunk_length,
             }),
             Self::CountVec(CountVec {
                 length: Some(length),
-            }) => Ok(AggregatorVdaf::Prio3CountVec { length: *length }),
+                chunk_length,
+            }) => Ok(AggregatorVdaf::Prio3CountVec {
+                length: *length,
+                chunk_length: *chunk_length,
+            }),
             _ => Err(ValidationErrors::new()),
+        }
+    }
+
+    pub fn populate_chunk_length(&mut self, protocol: &Protocol) {
+        match (self, protocol) {
+            // Chunk length was already populated, don't change it.
+            (
+                Self::Histogram(Histogram::Continuous(ContinuousBuckets {
+                    chunk_length: Some(_),
+                    ..
+                })),
+                _,
+            )
+            | (
+                Self::Histogram(Histogram::Opaque(BucketLength {
+                    chunk_length: Some(_),
+                    ..
+                })),
+                _,
+            )
+            | (
+                Self::Histogram(Histogram::Categorical(CategoricalBuckets {
+                    chunk_length: Some(_),
+                    ..
+                })),
+                _,
+            )
+            | (
+                Self::CountVec(CountVec {
+                    chunk_length: Some(_),
+                    ..
+                }),
+                _,
+            )
+            | (
+                Self::SumVec(SumVec {
+                    chunk_length: Some(_),
+                    ..
+                }),
+                _,
+            ) => {}
+
+            // Select a chunk length if the protocol version needs it and it isn't set yet.
+            (Self::Histogram(histogram), Protocol::Dap07) => {
+                let length = histogram.length();
+                match histogram {
+                    Histogram::Opaque(BucketLength { chunk_length, .. })
+                    | Histogram::Categorical(CategoricalBuckets { chunk_length, .. })
+                    | Histogram::Continuous(ContinuousBuckets { chunk_length, .. }) => {
+                        *chunk_length = Some(optimal_chunk_length(length as usize) as u64)
+                    }
+                }
+            }
+
+            (
+                Self::CountVec(CountVec {
+                    length: Some(length),
+                    chunk_length: chunk_length @ None,
+                }),
+                Protocol::Dap07,
+            ) => *chunk_length = Some(optimal_chunk_length(*length as usize) as u64),
+
+            (
+                Self::SumVec(SumVec {
+                    bits: Some(bits),
+                    length: Some(length),
+                    chunk_length: chunk_length @ None,
+                }),
+                Protocol::Dap07,
+            ) => {
+                *chunk_length = Some(optimal_chunk_length(*bits as usize * *length as usize) as u64)
+            }
+
+            // Invalid, missing parameters, do nothing.
+            (Self::CountVec(CountVec { length: None, .. }), Protocol::Dap07)
+            | (Self::SumVec(SumVec { bits: None, .. }), Protocol::Dap07)
+            | (Self::SumVec(SumVec { length: None, .. }), Protocol::Dap07) => {}
+
+            // Chunk length is not applicable, either due to VDAF choice or protocol version.
+            (Self::Count, _)
+            | (Self::Sum { .. }, _)
+            | (Self::Unrecognized, _)
+            | (_, Protocol::Dap04) => {}
         }
     }
 }
@@ -211,7 +345,8 @@ mod tests {
     #[test]
     fn validate_continuous_histogram() {
         assert!(ContinuousBuckets {
-            buckets: Some(vec![0, 1, 2])
+            buckets: Some(vec![0, 1, 2]),
+            chunk_length: None,
         }
         .validate()
         .is_ok());
@@ -219,6 +354,7 @@ mod tests {
         assert_errors(
             ContinuousBuckets {
                 buckets: Some(vec![0, 2, 1]),
+                chunk_length: None,
             },
             "buckets",
             &["sorted"],
@@ -227,6 +363,7 @@ mod tests {
         assert_errors(
             ContinuousBuckets {
                 buckets: Some(vec![0, 0, 2]),
+                chunk_length: None,
             },
             "buckets",
             &["unique"],
@@ -236,7 +373,8 @@ mod tests {
     #[test]
     fn validate_categorical_histogram() {
         assert!(CategoricalBuckets {
-            buckets: Some(vec!["a".into(), "b".into()])
+            buckets: Some(vec!["a".into(), "b".into()]),
+            chunk_length: None,
         }
         .validate()
         .is_ok());
@@ -244,6 +382,7 @@ mod tests {
         assert_errors(
             CategoricalBuckets {
                 buckets: Some(vec!["a".into(), "a".into()]),
+                chunk_length: None,
             },
             "buckets",
             &["unique"],

--- a/src/entity/task/vdaf.rs
+++ b/src/entity/task/vdaf.rs
@@ -206,6 +206,8 @@ mod tests {
     use super::*;
     use crate::test::assert_errors;
 
+    mod serde;
+
     #[test]
     fn validate_continuous_histogram() {
         assert!(ContinuousBuckets {

--- a/src/entity/task/vdaf/tests/serde.rs
+++ b/src/entity/task/vdaf/tests/serde.rs
@@ -10,17 +10,43 @@ fn json_vdaf() {
             r#"{"type":"histogram","buckets":["A","B"]}"#,
             Vdaf::Histogram(Histogram::Categorical(CategoricalBuckets {
                 buckets: Some(Vec::from(["A".to_owned(), "B".to_owned()])),
+                chunk_length: None,
+            })),
+        ),
+        (
+            r#"{"type":"histogram","buckets":["A","B"],"chunk_length":2}"#,
+            Vdaf::Histogram(Histogram::Categorical(CategoricalBuckets {
+                buckets: Some(Vec::from(["A".to_owned(), "B".to_owned()])),
+                chunk_length: Some(2),
             })),
         ),
         (
             r#"{"type":"histogram","buckets":[1,10,100]}"#,
             Vdaf::Histogram(Histogram::Continuous(ContinuousBuckets {
                 buckets: Some(Vec::from([1, 10, 100])),
+                chunk_length: None,
+            })),
+        ),
+        (
+            r#"{"type":"histogram","buckets":[1,10,100],"chunk_length":2}"#,
+            Vdaf::Histogram(Histogram::Continuous(ContinuousBuckets {
+                buckets: Some(Vec::from([1, 10, 100])),
+                chunk_length: Some(2),
             })),
         ),
         (
             r#"{"type":"histogram","length":5}"#,
-            Vdaf::Histogram(Histogram::Opaque(BucketLength { length: 5 })),
+            Vdaf::Histogram(Histogram::Opaque(BucketLength {
+                length: 5,
+                chunk_length: None,
+            })),
+        ),
+        (
+            r#"{"type":"histogram","length":5,"chunk_length":2}"#,
+            Vdaf::Histogram(Histogram::Opaque(BucketLength {
+                length: 5,
+                chunk_length: Some(2),
+            })),
         ),
         (
             r#"{"type":"sum","bits":8}"#,
@@ -28,13 +54,32 @@ fn json_vdaf() {
         ),
         (
             r#"{"type":"count_vec","length":5}"#,
-            Vdaf::CountVec(CountVec { length: Some(5) }),
+            Vdaf::CountVec(CountVec {
+                length: Some(5),
+                chunk_length: None,
+            }),
+        ),
+        (
+            r#"{"type":"count_vec","length":5,"chunk_length":2}"#,
+            Vdaf::CountVec(CountVec {
+                length: Some(5),
+                chunk_length: Some(2),
+            }),
         ),
         (
             r#"{"type":"sum_vec","bits":8,"length":10}"#,
             Vdaf::SumVec(SumVec {
                 bits: Some(8),
                 length: Some(10),
+                chunk_length: None,
+            }),
+        ),
+        (
+            r#"{"type":"sum_vec","bits":8,"length":10,"chunk_length":12}"#,
+            Vdaf::SumVec(SumVec {
+                bits: Some(8),
+                length: Some(10),
+                chunk_length: Some(12),
             }),
         ),
         (r#"{"type":"wrong"}"#, Vdaf::Unrecognized),

--- a/src/entity/task/vdaf/tests/serde.rs
+++ b/src/entity/task/vdaf/tests/serde.rs
@@ -1,0 +1,44 @@
+use crate::entity::task::vdaf::{
+    BucketLength, CategoricalBuckets, ContinuousBuckets, CountVec, Histogram, Sum, SumVec, Vdaf,
+};
+
+#[test]
+fn json_vdaf() {
+    for (serialized, vdaf) in [
+        (r#"{"type":"count"}"#, Vdaf::Count),
+        (
+            r#"{"type":"histogram","buckets":["A","B"]}"#,
+            Vdaf::Histogram(Histogram::Categorical(CategoricalBuckets {
+                buckets: Some(Vec::from(["A".to_owned(), "B".to_owned()])),
+            })),
+        ),
+        (
+            r#"{"type":"histogram","buckets":[1,10,100]}"#,
+            Vdaf::Histogram(Histogram::Continuous(ContinuousBuckets {
+                buckets: Some(Vec::from([1, 10, 100])),
+            })),
+        ),
+        (
+            r#"{"type":"histogram","length":5}"#,
+            Vdaf::Histogram(Histogram::Opaque(BucketLength { length: 5 })),
+        ),
+        (
+            r#"{"type":"sum","bits":8}"#,
+            Vdaf::Sum(Sum { bits: Some(8) }),
+        ),
+        (
+            r#"{"type":"count_vec","length":5}"#,
+            Vdaf::CountVec(CountVec { length: Some(5) }),
+        ),
+        (
+            r#"{"type":"sum_vec","bits":8,"length":10}"#,
+            Vdaf::SumVec(SumVec {
+                bits: Some(8),
+                length: Some(10),
+            }),
+        ),
+        (r#"{"type":"wrong"}"#, Vdaf::Unrecognized),
+    ] {
+        assert_eq!(serde_json::from_str::<Vdaf>(serialized).unwrap(), vdaf);
+    }
+}

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -47,10 +47,10 @@ impl FromConn for Task {
 type CreateArgs = (Account, Json<NewTask>, State<Client>, Db);
 pub async fn create(
     conn: &mut Conn,
-    (account, task, State(client), db): CreateArgs,
+    (account, mut task, State(client), db): CreateArgs,
 ) -> Result<impl Handler, Error> {
     let crypter = conn.state().unwrap();
-    task.validate(account, &db)
+    task.normalize_and_validate(account, &db)
         .await?
         .provision(client, crypter)
         .await?


### PR DESCRIPTION
This adds support for the chunk_length parameter in various Prio3 VDAFs. A new optional field is added to various structs holding VDAF parameters. Note that no database migration is required, since all changes are to the semantics of an existing `json` column. Incoming task creation requests (using DAP-07 aggregators) may or may not include a value for chunk_length. If they don't, divviup-api will select a chunk length that minimizes proof lengths. The updated task description, with the complete set of VDAF parameters, will be used for task provisioning in the aggregators and will be persisted to the database. For tasks in DAP-04 aggregators, there's no change, but requests that do specify a chunk_length are rejected for good measure. There will be an additional `"chunk_length": null` in various places, but serde will ignore this.

Outstanding work: This needs a libprio-rs release, and I still need to try the `in_cluster` test locally.

divviup/janus#1963 depends on this, because it expects chunk_length to be specified inside aggregator API requests.