### PR TITLE
Update to opentelemetry 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
  "prio 0.15.3",
+ "prometheus",
  "querystrong",
  "rand",
  "regex",
@@ -2253,9 +2254,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -2263,25 +2264,27 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9f186f6293ebb693caddd0595e66b74a6068fa51048e26e0bf9c95478c639c"
+checksum = "c7d81bc254e2d572120363a2b16cdb0d715d301b5789be0cfc26ad87e4e10e53"
 dependencies = [
- "opentelemetry",
+ "once_cell",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prometheus",
  "protobuf",
 ]
 
 [[package]]
 name = "opentelemetry_api"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
 dependencies = [
- "fnv",
  "futures-channel",
  "futures-util",
  "indexmap 1.9.3",
+ "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -2290,21 +2293,21 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "dashmap",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "once_cell",
  "opentelemetry_api",
+ "ordered-float",
  "percent-encoding",
  "rand",
+ "regex",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,12 @@ futures-lite = "1.13.0"
 git-version = "0.3.5"
 janus_messages = "0.5.22"
 log = "0.4.20"
-opentelemetry = { version = "0.19.0", features = ["metrics"] }
-opentelemetry-prometheus = { version = "0.12.0", features = [
+opentelemetry = { version = "0.20.0", features = ["metrics"] }
+opentelemetry-prometheus = { version = "0.13.0", features = [
     "prometheus-encoding",
 ] }
 prio = "0.15.3"
+prometheus = "0.13.3"
 querystrong = "0.3.0"
 rand = "0.8.5"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -2,54 +2,45 @@ use git_version::git_version;
 use opentelemetry::{
     global,
     metrics::MetricsError,
-    sdk::{
-        export::metrics::aggregation::stateless_temporality_selector,
-        metrics::{controllers, processors, selectors::simple::histogram},
-    },
-    Context, KeyValue,
+    sdk::{metrics::MeterProvider, Resource},
+    KeyValue,
 };
-use std::sync::Arc;
+use prometheus::Registry;
 
 /// Install a Prometheus metrics provider and exporter. The
 /// OpenTelemetry global API can be used to create and update
 /// instruments, and they will be sent through this exporter.
 pub fn metrics_exporter() -> Result<impl trillium::Handler, MetricsError> {
-    let exporter = Arc::new(
-        opentelemetry_prometheus::exporter(
-            controllers::basic(processors::factory(
-                histogram([
-                    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
-                ]),
-                stateless_temporality_selector(),
-            ))
-            .build(),
-        )
-        .try_init()?,
-    );
+    let registry = Registry::new();
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .build()?;
 
-    // Record the binary's version information in a build info metric.
-    let meter = global::meter("divviup-api");
-    let gauge = meter
-        .u64_observable_gauge("divviup_api_build_info")
-        .with_description("Build-time version information")
-        .init();
+    // Note that the implementation of `Default` pulls in attributes set via environment variables.
+    let default_resource = Resource::default();
+
     let mut git_revision: &str = git_version!(fallback = "unknown");
     if git_revision == "unknown" {
         if let Some(value) = option_env!("GIT_REVISION") {
             git_revision = value;
         }
     }
-    gauge.observe(
-        &Context::current(),
-        1,
-        &[
-            KeyValue::new("version", env!("CARGO_PKG_VERSION")),
-            KeyValue::new("revision", git_revision),
-            KeyValue::new("rust_version", env!("RUSTC_SEMVER")),
-        ],
-    );
+    let version_info_resource = Resource::new([
+        KeyValue::new(
+            "service.version",
+            format!("{}-{}", env!("CARGO_PKG_VERSION"), git_revision),
+        ),
+        KeyValue::new("process.runtime.name", "Rust"),
+        KeyValue::new("process.runtime.version", env!("RUSTC_SEMVER")),
+    ]);
 
-    Ok(trillium_prometheus::text_format_handler(
-        exporter.registry().clone(),
-    ))
+    let resource = version_info_resource.merge(&default_resource);
+
+    let meter_provider = MeterProvider::builder()
+        .with_reader(exporter)
+        .with_resource(resource)
+        .build();
+    global::set_meter_provider(meter_provider);
+
+    Ok(trillium_prometheus::text_format_handler(registry))
 }


### PR DESCRIPTION
This updates opentelemetry and opentelemetry-prometheus, and rewrites the exporter setup code. I also replaced `divviup_api_build_info` with the built in `target_info` gauge, by supplying some resource attributes. Sample output:

```
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{process_runtime_name="Rust",process_runtime_version="1.73.0",service_name="divviup-api",service_version="0.0.28-64a2e79"} 1
```

See divviup/janus#1664 and divviup/janus#1845 for comparison.