### PR TITLE
collector credential impedance mismatches

### DIFF
--- a/src/entity/collector_credential.rs
+++ b/src/entity/collector_credential.rs
@@ -55,8 +55,9 @@ impl Model {
 
     pub fn new_token() -> (String, String) {
         let token_bytes: [u8; 16] = random();
-        let token_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(token_bytes));
+        // The canonical form of the auth token is the Base64URL unpadded encoding of the bytes.
         let token = URL_SAFE_NO_PAD.encode(token_bytes);
+        let token_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(token.as_bytes()));
         (token, token_hash)
     }
 }

--- a/tests/tasks.rs
+++ b/tests/tasks.rs
@@ -186,7 +186,8 @@ mod create {
             leader_task_create
                 .collector_auth_token_hash
                 .as_ref()
-                .unwrap(),
+                .unwrap()
+                .as_ref(),
             collector_credential.token_hash.as_ref().unwrap()
         );
         assert!(helper_task_create.collector_auth_token_hash.is_none());


### PR DESCRIPTION
Resolves some impedance mismatches with the Janus aggregator API's handling of collector authentication tokens. Specifcally:

 - TaskCreate contains an `AuthenticationTokenHash`, which is not quite the same as an `AuthenticationToken`
 - The canonical form of a Janus bearer token is the unpadded Base64URL encoding of the bytes ([1]), and an authentication token hash is the SHA-256 of the canonical form (2).

[1]: https://github.com/divviup/janus/blob/89a6a954339e526d991bab378fb5596d9eba64b8/core/src/auth_tokens.rs#L197
[2]: https://github.com/divviup/janus/blob/89a6a954339e526d991bab378fb5596d9eba64b8/core/src/auth_tokens.rs#L349