### PR TITLE
add publish-crates workflow

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,21 @@
+name: publish-crates
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  CARGO_REGISTRY_TOKEN: ${{ secrets.DIVVIUP_GITHUB_AUTOMATION_CRATES_IO_API_TOKEN }}
+
+jobs:
+  crate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+    - name: "Publish divviup-client"
+      run: cargo publish --package divviup-client
+    - name: "Publish divviup-cli"
+      run: cargo publish --package divviup-cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da74e2b81409b1b743f8f0c62cc6254afefb8b8e50bbfe3735550f7aeefa3448"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1025,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+checksum = "4939f9ed1444bd8c896d37f3090012fa6e7834fe84ef8c9daa166109515732f9"
 
 [[package]]
 name = "crc32fast"
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.0.9"
+version = "0.0.30"
 dependencies = [
  "base64 0.21.5",
  "divviup-api",
@@ -5108,9 +5108,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -5118,9 +5118,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
@@ -5133,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5145,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5155,9 +5155,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5168,15 +5168,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-cli"
-version = "0.0.1"
+version = "0.0.30"
 dependencies = [
  "base64 0.21.5",
  "clap",
@@ -1333,10 +1333,11 @@ dependencies = [
 
 [[package]]
 name = "divviup-client"
-version = "0.0.1"
+version = "0.0.30"
 dependencies = [
  "base64 0.21.5",
  "divviup-api",
+ "divviup-client",
  "email_address",
  "fastrand 2.0.1",
  "futures-lite 2.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ license = "MPL-2.0"
 homepage = "https://divviup.org"
 repository = "https://github.com/divviup/divviup-api"
 
+[workspace.dependencies]
+divviup-client = { path = "./client", version = "0.0.30" }
+divviup-cli = { path = "./cli", version = "0.0.30" }
+divviup-api = { path = ".", version = "0.0.30" }
+test-support = { path = "./test-support", version = "0.0.30" }
 
 [package]
 name = "divviup-api"
@@ -39,7 +44,7 @@ janus_messages = "0.6.1"
 log = "0.4.20"
 opentelemetry = { version = "0.20.0", features = ["metrics", "rt-tokio"] }
 opentelemetry-prometheus = { version = "0.13.0", features = [
-    "prometheus-encoding",
+        "prometheus-encoding",
 ] }
 prio = "0.15.3"
 prometheus = "0.13.3"
@@ -59,7 +64,12 @@ tracing-chrome = "0.7.1"
 tracing-log = "0.2.0"
 tracing-opentelemetry = "0.21.0"
 tracing-stackdriver = "0.8.0"
-tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter", "std", "fmt"] }
+tracing-subscriber = { version = "0.3.17", features = [
+        "json",
+        "env-filter",
+        "std",
+        "fmt",
+] }
 trillium-api = { version = "0.2.0-rc.7", default-features = false }
 trillium-caching-headers = "0.2.1"
 trillium-client = { version = "0.4.5", features = ["json"] }
@@ -91,17 +101,17 @@ features = ["pkce-plain"]
 [dependencies.sea-orm]
 version = "0.12.4"
 features = [
-    "runtime-tokio-rustls",
-    "macros",
-    "sqlx-postgres",
-    "with-uuid",
-    "with-time",
+        "runtime-tokio-rustls",
+        "macros",
+        "sqlx-postgres",
+        "with-uuid",
+        "with-time",
 ]
 
 
 [dev-dependencies]
 regex = "1.10.2"
-test-support = { path = "./test-support" }
+test-support.workspace = true
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/divviup/divviup-api"
 [workspace.dependencies]
 divviup-client = { path = "./client", version = "0.0.30" }
 divviup-cli = { path = "./cli", version = "0.0.30" }
-divviup-api = { path = ".", version = "0.0.30" }
-test-support = { path = "./test-support", version = "0.0.30" }
+divviup-api.path = "."
+test-support.path = "./test-support"
 
 [package]
 name = "divviup-api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,22 @@
-[package]
-name = "divviup-api"
+[workspace]
+members = [".", "migration", "client", "test-support", "cli"]
+
+[workspace.package]
 version = "0.0.30"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://divviup.org"
 repository = "https://github.com/divviup/divviup-api"
+
+
+[package]
+name = "divviup-api"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 publish = false
+repository.workspace = true
+version.workspace = true
 default-run = "divviup_api_bin"
 
 [features]
@@ -13,8 +24,6 @@ default = []
 api-mocks = ["dep:trillium-testing"]
 integration-testing = []
 
-[workspace]
-members = [".", "migration", "client", "test-support", "cli"]
 
 [dependencies]
 aes-gcm = "0.10.3"
@@ -88,6 +97,7 @@ features = [
     "with-uuid",
     "with-time",
 ]
+
 
 [dev-dependencies]
 regex = "1.10.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 version.workspace = true
+description = "Command line utility for divviup.org"
 
 [features]
 default = ["hpke"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.4.7", features = ["derive", "env"] }
 thiserror = "1.0.50"
-divviup-client = { path = "../client", version = "0.0.30" }
+divviup-client = { workspace = true }
 trillium-rustls = "0.4.0"
 trillium-tokio = "0.3.2"
 serde = "1.0.190"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "divviup-cli"
-version = "0.0.1"
-edition = "2021"
-license = "MPL-2.0"
-homepage = "https://divviup.org"
-repository = "https://github.com/divviup/divviup-api"
-publish = false
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 default = ["hpke"]
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.4.7", features = ["derive", "env"] }
 thiserror = "1.0.50"
-divviup-client = { path = "../client" }
+divviup-client = { path = "../client", version = "0.0.30" }
 trillium-rustls = "0.4.0"
 trillium-tokio = "0.3.2"
 serde = "1.0.190"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -37,4 +37,4 @@ trillium-macros = "0.0.4"
 trillium-testing = { version = "0.5.0", features = ["tokio"] }
 trillium-rustls = "0.4.0"
 trillium-tokio = "0.3.2"
-divviup-client =  { workspace = true, features = ["admin"] }
+divviup-client =  { path = ".", features = ["admin"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 version.workspace = true
+description = "Async rust client for divviup.org"
 
 [features]
 default = []

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,13 +27,13 @@ pad-adapter = "0.1.1"
 janus_messages = "0.6.1"
 
 [dev-dependencies]
-divviup-api = { version = "0.0.30", path = ".." }
+divviup-api.workspace = true
 fastrand = "2.0.1"
 futures-lite = "2.0.0"
-test-support = { path = "../test-support" }
+test-support.workspace = true
 trillium = "0.2.11"
 trillium-macros = "0.0.4"
 trillium-testing = { version = "0.5.0", features = ["tokio"] }
 trillium-rustls = "0.4.0"
 trillium-tokio = "0.3.2"
-divviup-client =  { path = ".", features = ["admin"] }
+divviup-client =  { workspace = true, features = ["admin"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "divviup-client"
-version = "0.0.1"
-edition = "2021"
-license = "MPL-2.0"
-homepage = "https://divviup.org"
-repository = "https://github.com/divviup/divviup-api"
-publish = false
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = true
+repository.workspace = true
+version.workspace = true
 
 [features]
-default = ["admin"]
+default = []
 admin = []
 
 [dependencies]
@@ -27,7 +27,7 @@ pad-adapter = "0.1.1"
 janus_messages = "0.6.1"
 
 [dev-dependencies]
-divviup-api = { version = "*", path = ".." }
+divviup-api = { version = "0.0.30", path = ".." }
 fastrand = "2.0.1"
 futures-lite = "2.0.0"
 test-support = { path = "../test-support" }
@@ -36,3 +36,4 @@ trillium-macros = "0.0.4"
 trillium-testing = { version = "0.5.0", features = ["tokio"] }
 trillium-rustls = "0.4.0"
 trillium-tokio = "0.3.2"
+divviup-client =  { path = ".", features = ["admin"] }

--- a/test-support/Cargo.toml
+++ b/test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-support"
-version = "0.0.9"
+version.workspace = true
 edition = "2021"
 publish = false
 
@@ -10,7 +10,7 @@ time = "0.3.30"
 trillium = "0.2.11"
 trillium-macros = "0.0.4"
 trillium-testing = { version = "0.5.0", features = ["tokio"] }
-divviup-api = { version = "*", path = ".." }
+divviup-api.workspace = true
 serde = "1.0.190"
 serde_json = "1.0.108"
 thiserror = "1.0.50"


### PR DESCRIPTION
This pr locks versions between the cli, the client, and the api, but that may not be desirable. I'd appreciate review on whether we should have distinct semver-meaningful versions for each crate or whether we want to bump everything all at once like janus. Also, we may want to have a discussion about what merits a semver-minor change, since we recently quietly introduced a breaking change to the api