### PR TITLE
upgrade trillium-api, still rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4098,9 +4098,9 @@ dependencies = [
 
 [[package]]
 name = "trillium-api"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09858200af96cce5cb8c5353df2ed6f5048b62856b35c733af4eecae8479211c"
+checksum = "fcba1c3eea6f5d3b7cbe56fdf059ff5ecf1f4707770140094a3692c8b4a7891a"
 dependencies = [
  "log",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ time = { version = "0.3.30", features = ["serde", "serde-well-known"] }
 tokio = { version = "1.33.0", features = ["full"] }
 tracing = "0.1.39"
 trillium = "0.2.11"
-trillium-api = { version = "0.2.0-rc.4", default-features = false }
+trillium-api = { version = "0.2.0-rc.5", default-features = false }
 trillium-caching-headers = "0.2.1"
 trillium-client = { version = "0.4.5", features = ["json"] }
 trillium-compression = "0.1.0"


### PR DESCRIPTION
the big difference in this version is that the full lifecycle of returned Handlers are called, so for example returning a WebSocket handler is possible, or returning a Handler with an after_send