### PR TITLE
taskId -> id for sample TS code

### DIFF
--- a/app/src/tasks/TaskDetail/ClientConfig.tsx
+++ b/app/src/tasks/TaskDetail/ClientConfig.tsx
@@ -47,14 +47,14 @@ function TsClientConfig() {
     [task, leaderAggregator, helperAggregator],
     ([task, leader, helper]) => ({
       ...task.vdaf,
-      taskId: task.id,
+      id: task.id,
       leader: leader.dap_url,
       helper: helper.dap_url,
       timePrecisionSeconds: task.time_precision_seconds,
     }),
     {
       type: null,
-      taskId: null,
+      id: null,
       leader: null,
       helper: null,
       timePrecisionSeconds: null,


### PR DESCRIPTION
The sample TS/JS code on `https://app.staging.divviup.org/accounts/{accountId}/tasks/{taskId}` reads:
```typescript
import Task from "@divviup/dap";

const task = new Task({
  type: "count",
  taskId: "rU9XlLAicxOIikqRzwtx8y0hLEuDnRNoQ7ODLe6uAaY",
  leader: "https://staging-dap-07.api.divviup.org/",
  helper: "https://staging-dap-07-byoh.api.divviup.org/",
  timePrecisionSeconds: 60
});

await task.sendMeasurement(...); // your measurement here
```
where `taskId` should actually be `id`, to align with the changes we introduced here https://github.com/divviup/divviup-ts/commit/d4b1ec4bae283da3ae569d472ab6a2014bada841.