### PR TITLE
Create collector credential in right path

### DIFF
--- a/cli/src/collector_credentials.rs
+++ b/cli/src/collector_credentials.rs
@@ -174,7 +174,7 @@ impl CollectorCredentialAction {
                 // of the output settings of this CLI. The credential file should be treated as
                 // opaque, so we don't grant user control over its encoding.
                 if save {
-                    let path = current_dir()?.with_file_name(name).with_extension("json");
+                    let path = current_dir()?.join(name).with_extension("json");
                     let mut file = File::create(path.clone())?;
                     file.write_all(&serde_json::to_vec_pretty(&credential).unwrap())?;
                     println!(


### PR DESCRIPTION
Using `PathBuf::with_file_name` on a path without a separator at the end replaces the last path component instead of appending. `PathBuf::join` has the desired effect (see playground [1]).

This bug was causing `divviup collector-credential generate --save` to write out the JSON file in `../whatever.json` instead of `./whatever.json`.

[1]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=889ea3cc338d2a55801c1602a6c97b5c