### PR TITLE
Fix React hooks

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -7,6 +7,7 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "prettier"
   ],
   "parser": "@typescript-eslint/parser",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -50,6 +50,7 @@
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "postcss-nesting": "^12.0.2",
         "prettier": "^3.1.1",
         "source-map-explorer": "^2.5.3",
@@ -3525,6 +3526,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {

--- a/app/package.json
+++ b/app/package.json
@@ -72,6 +72,7 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "postcss-nesting": "^12.0.2",
     "prettier": "^3.1.1",
     "source-map-explorer": "^2.5.3",

--- a/app/src/accounts/NextSteps/AggregatorTypeSelection.tsx
+++ b/app/src/accounts/NextSteps/AggregatorTypeSelection.tsx
@@ -10,7 +10,6 @@ import {
 import {
   Await,
   useFetcher,
-  useNavigate,
   useParams,
   useLoaderData,
   useRevalidator,
@@ -38,7 +37,6 @@ export default function AggregatorTypeSelection() {
   >(null);
 
   const fetcher = useFetcher();
-  const navigate = useNavigate();
   const { accountId } = useParams() as { accountId: string };
   const [showAggregatorForm, setShowAggregatorForm] =
     React.useState<boolean>(false);
@@ -56,7 +54,7 @@ export default function AggregatorTypeSelection() {
     } else {
       setShowAggregatorForm(true);
     }
-  }, [useSharedAggregators, navigate, fetcher]);
+  }, [useSharedAggregators, fetcher, accountId]);
 
   const partnerAggregators = React.useMemo(
     () =>

--- a/app/src/accounts/NextSteps/InlineCollectorCredentials.tsx
+++ b/app/src/accounts/NextSteps/InlineCollectorCredentials.tsx
@@ -18,7 +18,7 @@ function SaveApiToken({ onToken }: { onToken: (token: string) => void }) {
 
   React.useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data) onToken(fetcher.data.token);
-  }, [fetcher.data, fetcher.state]);
+  }, [fetcher.data, fetcher.state, onToken]);
 
   if (fetcher.state === "idle" && fetcher.data) {
     const { token } = fetcher.data;
@@ -70,7 +70,14 @@ export default function InlineCollectorCredentials() {
           setAnyCollectorCredentials(collectorCredentials.length > 0);
           setInFlight(false);
         });
-    }, [apiClient, setInFlight, setAnyCollectorCredentials]),
+    }, [
+      apiClient,
+      inFlight,
+      setInFlight,
+      anyCollectorCredentials,
+      setAnyCollectorCredentials,
+      accountId,
+    ]),
     1000,
   );
 

--- a/app/src/layout/ErrorPage.tsx
+++ b/app/src/layout/ErrorPage.tsx
@@ -7,18 +7,19 @@ import React from "react";
 
 export default function ErrorPage({ apiClient }: { apiClient: ApiClient }) {
   const error = useRouteError();
+
+  const doLoginRedirect =
+    error instanceof AxiosError && error.response?.status === 403;
+  React.useEffect(() => {
+    if (doLoginRedirect) {
+      apiClient.loginUrl().then((url) => {
+        window.location.replace(url);
+      });
+    }
+  }, [doLoginRedirect, apiClient]);
+
   if (error instanceof AxiosError) {
     switch (error.response?.status) {
-      case 403: {
-        React.useEffect(() => {
-          apiClient.loginUrl().then((url) => {
-            window.location.replace(url);
-          });
-        }, [error, apiClient]);
-
-        return <></>;
-      }
-
       case 404: {
         return (
           <Layout error>

--- a/app/src/shared-aggregators/SharedAggregatorForm.tsx
+++ b/app/src/shared-aggregators/SharedAggregatorForm.tsx
@@ -1,7 +1,7 @@
 import { FormikHelpers } from "formik";
 import ApiClient, { NewAggregator, formikErrors } from "../ApiClient";
 import { AggregatorForm } from "../aggregators/AggregatorForm";
-import { useNavigate, useRevalidator } from "react-router-dom";
+import { useRevalidator } from "react-router-dom";
 import { ApiClientContext } from "../ApiClientContext";
 import React from "react";
 
@@ -22,13 +22,12 @@ async function submit(
 }
 
 export default function SharedAggreatorForm() {
-  const navigate = useNavigate();
   const apiClient = React.useContext(ApiClientContext);
   const { revalidate } = useRevalidator();
   const handleSubmit = React.useCallback(
     (values: NewAggregator, actions: FormikHelpers<NewAggregator>) =>
       submit(apiClient, values, actions, revalidate),
-    [apiClient, navigate, revalidate],
+    [apiClient, revalidate],
   );
 
   return (

--- a/app/src/tasks/TaskDetail/TaskTitle.tsx
+++ b/app/src/tasks/TaskDetail/TaskTitle.tsx
@@ -56,7 +56,7 @@ export default function TaskTitle() {
         );
       }
     },
-    [fetcher, name, originalName, taskId, task],
+    [fetcher, name, originalName, accountId, taskId],
   );
 
   if (isEditingName) {

--- a/app/src/tasks/TaskForm/CollectorCredentialSelect.tsx
+++ b/app/src/tasks/TaskForm/CollectorCredentialSelect.tsx
@@ -27,11 +27,12 @@ export default function CollectorCredentialSelect(props: Props) {
     [collectorCredentials, leader],
   );
 
+  const setFieldValue = props.setFieldValue;
   React.useEffect(() => {
     if (enabledCredentials.length === 1) {
-      props.setFieldValue("collector_credential_id", enabledCredentials[0].id);
+      setFieldValue("collector_credential_id", enabledCredentials[0].id);
     }
-  }, [enabledCredentials, props.setFieldValue]);
+  }, [enabledCredentials, setFieldValue]);
 
   return (
     <TaskFormGroup controlId="collector_credential_id">

--- a/app/src/tasks/TaskForm/index.tsx
+++ b/app/src/tasks/TaskForm/index.tsx
@@ -84,7 +84,7 @@ export default function TaskForm() {
     (event: React.FocusEvent<HTMLFormElement>) => {
       setFocusedField(event.target.name as unknown as Field<NewTask>);
     },
-    [setFocusedField, navigate],
+    [setFocusedField],
   );
 
   return (

--- a/app/src/util.tsx
+++ b/app/src/util.tsx
@@ -2,7 +2,7 @@ import Breadcrumb from "react-bootstrap/Breadcrumb";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import { LinkContainer } from "react-router-bootstrap";
-import React, { Suspense } from "react";
+import React, { Suspense, useRef } from "react";
 import { Await, useRouteLoaderData, useLoaderData } from "react-router-dom";
 import { Account } from "./ApiClient";
 import Placeholder from "react-bootstrap/Placeholder";
@@ -120,13 +120,37 @@ export function usePromise<T>(promise: PromiseLike<T>, initialState: T): T {
   return state;
 }
 
+// Adapted from https://github.com/lbfalvy/react-utils/blob/8c6e750bc6a2450c201ac34c2905aecb43b8350a/src/useArray.ts
+/**
+ * Ensures referential equality of an array whenever its elements are equal.
+ * This allows use of an array in a list of dependencies without unnecessary
+ * updates, or changed dependency array length warnings from trying to spread
+ * an array into a dependency array.
+ * @param input Array
+ * @returns Memoized array
+ */
+function useArray<T extends unknown[]>(input: T): T {
+  const ref = useRef<T>(input);
+  const cur = ref.current;
+  if (input.length === cur.length && input.every((v, i) => v === cur[i])) {
+    return cur;
+  } else {
+    ref.current = input;
+    return input;
+  }
+}
+
 export function usePromiseAll<U, T extends unknown[]>(
   promises: [...T],
   then: (arr: { [P in keyof T]: Awaited<T[P]> }) => U | PromiseLike<U>,
   initialState: U,
 ): U {
+  const memoizedPromises = useArray(promises);
   return usePromise(
-    React.useMemo(() => Promise.all(promises).then(then), promises),
+    React.useMemo(
+      () => Promise.all(memoizedPromises).then(then),
+      [memoizedPromises, then],
+    ),
     initialState,
   );
 }

--- a/app/src/util.tsx
+++ b/app/src/util.tsx
@@ -66,14 +66,14 @@ export function Copy({
   children(copy: undefined | (() => void), copied: boolean): React.ReactElement;
   clipboardContents: string;
 }) {
-  if ("clipboard" in navigator) {
-    const [copied, setCopied] = React.useState(false);
-    const copy = React.useCallback(() => {
-      navigator.clipboard.writeText(clipboardContents).then(() => {
-        setCopied(true);
-      });
-    }, [setCopied, clipboardContents]);
+  const [copied, setCopied] = React.useState(false);
+  const copy = React.useCallback(() => {
+    navigator.clipboard.writeText(clipboardContents).then(() => {
+      setCopied(true);
+    });
+  }, [setCopied, clipboardContents]);
 
+  if ("clipboard" in navigator) {
     return (
       <OverlayTrigger
         overlay={<Tooltip>{copied ? "Copied!" : "Click to copy"}</Tooltip>}


### PR DESCRIPTION
This adds `eslint-plugin-react-hooks` and fixes the issues it finds. (missing dependencies, extra dependencies, and conditionally calling hooks)

I've fixed all the simple issues so far, but there are two issues left that I need to do some more reading/testing for.

`usePromiseAll` doesn't play nice with the linter, because it can only reason about dependency lists passed as array literals. However, `useMemo(..., [promises])` would defeat the purpose of the memoization, because the promises argument will likely be a freshly constructed array on each render, and it would get re-evaluated even if the promises inside are shallowly equal. I think the answer here is to mostly leave the code as-is, concatenate the missing `then` dependency onto the list, and ignore the lints on this line.

The other remaining error is the conditionally called `useEffect` in `ErrorPage`. The documentation is not clear on whether `react-router-dom`'s `navigate` callback plays nice with navigating to URLs outside of the router, but if it does, we could swap window.location manipulation out with that for consistency's sake. I think part of the awkwardness here is because navigation typically happens in event callbacks. Here, at least, the navigation is wrapped inside an effect, and not triggered during component rendering itself. To fix the immediate issue, I think we could pass the error into the effect, and move the if block into its setup callback. At an architectural level, it might make more sense to move the responsibility for login page redirects to whatever effect pulls in data from API requests. Then, we could perform the same redirect earlier, before passing an error through props to a different effect, and simplify the `ErrorPage` component.