### PR TITLE
Change names of GitHub Actions CI jobs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  build_docker:
     strategy:
       matrix:
         rust-features: ["default", "integration-testing"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
   ASSET_DIR: ./app/build
 
 jobs:
-  build:
+  build_rust:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -10,7 +10,7 @@ env:
   REACT_APP_API_URL: https://api.example
 
 jobs:
-  build:
+  build_ts:
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
We need to set up required checks in this repository's branch protection rules, in order for our automerge script to work properly. However, we can only identify checks by the name of jobs within a workflow, and their identities are not scoped by the workflow name. Thus, we currently can't require both the Rust "build" job and the TypeScript "build" job. This PR changes the name of each "build" job to be unique.