### PR TITLE
Add workflow for automatically generating release

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,0 +1,92 @@
+name: make-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: >-
+          JSON array of branches to target. The first branch in the array will
+          be marked as the latest release.
+        required: false
+        type: string
+        default: '["main"]'
+
+jobs:
+  bump-version:
+    strategy:
+      matrix:
+        target_branch: ${{ fromJSON(inputs.target_branch) }}
+    runs-on: ubuntu-latest
+    env:
+      CARGO_EDIT_VERSION: 0.12.2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: '${{ matrix.target_branch }}'
+          token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo edit
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/cargo-edit
+          key: cargo-edit-${{ env.CARGO_EDIT_VERSION }}
+      - name: Add the tool cache directory to the search path
+        run: echo "${{ runner.tool_cache }}/cargo-edit/bin/" >>$GITHUB_PATH
+      - name: Ensure cargo-edit is installed
+        run: |
+          cargo install \
+            --root ${{ runner.tool_cache }}/cargo-edit \
+            --version ${{ env.CARGO_EDIT_VERSION }} \
+            cargo-edit
+      
+      - run: cargo set-version --bump patch
+      - run: git diff
+      - name: Push changes
+        run: |
+          git config user.email "divviup-github-automation@divviup.org"
+          git config user.name "divviup-github-automation"
+          git commit -am "Bump divviup-api patch version, triggered by @${{ github.actor }}"
+          git push
+
+  # This job is kept separate from the previous one to enable retrying it without
+  # bumping the version number again.
+  make-release:
+    strategy:
+      matrix:
+        target_branch: ${{ fromJSON(inputs.target_branch) }}
+    runs-on: ubuntu-latest
+    needs: [bump-version]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: '${{ matrix.target_branch }}'
+          token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Create release
+        run: |
+          # Determine the workspace version.
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -er '.packages[0].version')
+          TARGET_BRANCH="${{ matrix.target_branch }}"
+          FIRST_BRANCH="${{ fromJSON(inputs.target_branch)[0] }}"
+
+          LATEST=
+          if [ "$TARGET_BRANCH" == "$FIRST_BRANCH" ]; then
+              LATEST="--latest=true"
+          else
+              LATEST="--latest=false"
+          fi
+
+          gh release create "$VERSION" \
+              --generate-notes \
+              --target "$TARGET_BRANCH" \
+              $LATEST
+        env:
+          GH_TOKEN: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'


### PR DESCRIPTION
Similar to https://github.com/divviup/janus/pull/2585.

The multi-branch support for this workflow isn't really necessary in this repo, but I kept it in for parity with the other identical workflows in janus and libprio-rs.