### PR TITLE
Task upload metrics

### DIFF
--- a/app/src/ApiClient.ts
+++ b/app/src/ApiClient.ts
@@ -72,9 +72,15 @@ export interface Task {
   updated_at: string;
   expiration: string | null;
   max_batch_size: number | null;
-  report_count: number;
-  aggregate_collection_count: number;
   collector_credential_id: string;
+  report_counter_interval_collected: number;
+  report_counter_decode_failure: number;
+  report_counter_decrypt_failure: number;
+  report_counter_expired: number;
+  report_counter_outdated_key: number;
+  report_counter_success: number;
+  report_counter_too_early: number;
+  report_counter_task_expired: number;
 }
 
 export interface CollectorAuthToken {
@@ -85,13 +91,20 @@ export interface CollectorAuthToken {
 export type NewTask = Omit<
   Task,
   | "id"
-  | "report_count"
-  | "aggregate_collection_count"
   | "account_id"
   | "created_at"
   | "updated_at"
   | "vdaf"
   | "expiration"
+  | "report_counter_interval_collected"
+  | "report_counter_decode_failure"
+  | "report_counter_decrypt_failure"
+  | "report_counter_expired"
+  | "report_counter_outdated_key"
+  | "report_counter_success"
+  | "report_counter_too_early"
+  | "report_counter_task_expired"
+  | "report_counter_task_expired"
 > & {
   vdaf: {
     type: "sum" | "count" | "histogram";

--- a/app/src/tasks/TaskDetail/Metrics.tsx
+++ b/app/src/tasks/TaskDetail/Metrics.tsx
@@ -6,6 +6,19 @@ import Card from "react-bootstrap/Card";
 import ListGroup from "react-bootstrap/ListGroup";
 import { DateTime } from "luxon";
 import Placeholder from "react-bootstrap/Placeholder";
+import { OutLink } from "../../util";
+
+function FailedMetric({ name, counter }: { name: string; counter: number }) {
+  if (counter > 0) {
+    return (
+      <ListGroup.Item>
+        {name}: {counter}
+      </ListGroup.Item>
+    );
+  } else {
+    return null;
+  }
+}
 
 export default function Metrics() {
   const { task } = useLoaderData() as {
@@ -16,24 +29,52 @@ export default function Metrics() {
     <Col md="6">
       <Card className="my-3">
         <Card.Body>
-          <Card.Title>Metrics</Card.Title>
+          <Card.Title>Upload Metrics</Card.Title>
+          <Card.Subtitle>
+            <OutLink href="https://docs.divviup.org/product-documentation/operational-metrics#upload-metrics">
+              View Documentation
+            </OutLink>
+          </Card.Subtitle>
         </Card.Body>
-        <ListGroup variant="flush">
-          <ListGroup.Item>
-            Report Count:{" "}
-            <Suspense fallback="0">
-              <Await resolve={task}>{(task) => task.report_count}</Await>
-            </Suspense>
-          </ListGroup.Item>
-          <ListGroup.Item>
-            Aggregate Collection Count:{" "}
-            <Suspense fallback="0">
-              <Await resolve={task}>
-                {(task) => task.aggregate_collection_count}
-              </Await>
-            </Suspense>
-          </ListGroup.Item>
-        </ListGroup>
+        <Suspense fallback="0">
+          <Await resolve={task}>
+            {(task: Task) => (
+              <ListGroup variant="flush">
+                <ListGroup.Item>
+                  Successful Uploads: {task.report_counter_success}
+                </ListGroup.Item>
+                <FailedMetric
+                  name="Interval Collected Failure"
+                  counter={task.report_counter_interval_collected}
+                />
+                <FailedMetric
+                  name="Decode Failure"
+                  counter={task.report_counter_decode_failure}
+                />
+                <FailedMetric
+                  name="Decrypt Failure"
+                  counter={task.report_counter_decrypt_failure}
+                />
+                <FailedMetric
+                  name="Report Expired Failure"
+                  counter={task.report_counter_expired}
+                />
+                <FailedMetric
+                  name="Outdated Key Failure"
+                  counter={task.report_counter_outdated_key}
+                />
+                <FailedMetric
+                  name="Report Too Early Failure"
+                  counter={task.report_counter_too_early}
+                />
+                <FailedMetric
+                  name="Task Expired Failure"
+                  counter={task.report_counter_task_expired}
+                />
+              </ListGroup>
+            )}
+          </Await>
+        </Suspense>
         <Card.Footer className="text-muted">
           Last updated{" "}
           <Suspense fallback={<Placeholder animation="glow" xs={6} />}>

--- a/app/src/tasks/TaskDetail/Metrics.tsx
+++ b/app/src/tasks/TaskDetail/Metrics.tsx
@@ -1,0 +1,54 @@
+import { Await, useLoaderData } from "react-router-dom";
+import Col from "react-bootstrap/Col";
+import { Suspense } from "react";
+import { Task } from "../../ApiClient";
+import Card from "react-bootstrap/Card";
+import ListGroup from "react-bootstrap/ListGroup";
+import { DateTime } from "luxon";
+import Placeholder from "react-bootstrap/Placeholder";
+
+export default function Metrics() {
+  const { task } = useLoaderData() as {
+    task: Promise<Task>;
+  };
+
+  return (
+    <Col md="6">
+      <Card className="my-3">
+        <Card.Body>
+          <Card.Title>Metrics</Card.Title>
+        </Card.Body>
+        <ListGroup variant="flush">
+          <ListGroup.Item>
+            Report Count:{" "}
+            <Suspense fallback="0">
+              <Await resolve={task}>{(task) => task.report_count}</Await>
+            </Suspense>
+          </ListGroup.Item>
+          <ListGroup.Item>
+            Aggregate Collection Count:{" "}
+            <Suspense fallback="0">
+              <Await resolve={task}>
+                {(task) => task.aggregate_collection_count}
+              </Await>
+            </Suspense>
+          </ListGroup.Item>
+        </ListGroup>
+        <Card.Footer className="text-muted">
+          Last updated{" "}
+          <Suspense fallback={<Placeholder animation="glow" xs={6} />}>
+            <Await resolve={task}>
+              {(task) => (
+                <relative-time datetime={task.updated_at} format="relative">
+                  {DateTime.fromISO(task.updated_at)
+                    .toLocal()
+                    .toLocaleString(DateTime.DATETIME_SHORT)}
+                </relative-time>
+              )}
+            </Await>
+          </Suspense>
+        </Card.Footer>
+      </Card>
+    </Col>
+  );
+}

--- a/app/src/tasks/TaskDetail/Metrics.tsx
+++ b/app/src/tasks/TaskDetail/Metrics.tsx
@@ -32,7 +32,7 @@ function UploadMetrics(task: Promise<Task>) {
             </OutLink>
           </Card.Subtitle>
         </Card.Body>
-        <Suspense fallback="0">
+        <Suspense fallback={<Placeholder animation="glow" xs={2} />}>
           <Await resolve={task}>
             {(task: Task) => (
               <ListGroup variant="flush">
@@ -73,7 +73,7 @@ function UploadMetrics(task: Promise<Task>) {
         </Suspense>
         <Card.Footer className="text-muted">
           Last updated{" "}
-          <Suspense fallback={<Placeholder animation="glow" xs={6} />}>
+          <Suspense fallback={<Placeholder animation="glow" xs={1} />}>
             <Await resolve={task}>
               {(task) => (
                 <relative-time datetime={task.updated_at} format="relative">
@@ -97,10 +97,10 @@ export default function Metrics() {
   };
 
   return (
-    <Suspense fallback="0">
+    <Suspense fallback={<Placeholder animation="glow" xs={2} />}>
       <Await resolve={leaderAggregator}>
         {(leaderAggregator) => {
-          if (leaderAggregator.features.contains("UploadMetrics")) {
+          if (leaderAggregator.features.includes("UploadMetrics")) {
             return UploadMetrics(task);
           }
         }}

--- a/app/src/tasks/TaskDetail/Metrics.tsx
+++ b/app/src/tasks/TaskDetail/Metrics.tsx
@@ -1,7 +1,7 @@
 import { Await, useLoaderData } from "react-router-dom";
 import Col from "react-bootstrap/Col";
 import { Suspense } from "react";
-import { Task } from "../../ApiClient";
+import { Aggregator, Task } from "../../ApiClient";
 import Card from "react-bootstrap/Card";
 import ListGroup from "react-bootstrap/ListGroup";
 import { DateTime } from "luxon";
@@ -20,11 +20,7 @@ function FailedMetric({ name, counter }: { name: string; counter: number }) {
   }
 }
 
-export default function Metrics() {
-  const { task } = useLoaderData() as {
-    task: Promise<Task>;
-  };
-
+function UploadMetrics(task: Promise<Task>) {
   return (
     <Col md="6">
       <Card className="my-3">
@@ -91,5 +87,24 @@ export default function Metrics() {
         </Card.Footer>
       </Card>
     </Col>
+  );
+}
+
+export default function Metrics() {
+  const { task, leaderAggregator } = useLoaderData() as {
+    task: Promise<Task>;
+    leaderAggregator: Promise<Aggregator>;
+  };
+
+  return (
+    <Suspense fallback="0">
+      <Await resolve={leaderAggregator}>
+        {(leaderAggregator) => {
+          if (leaderAggregator.features.contains("UploadMetrics")) {
+            return UploadMetrics(task);
+          }
+        }}
+      </Await>
+    </Suspense>
   );
 }

--- a/app/src/tasks/TaskDetail/Metrics.tsx
+++ b/app/src/tasks/TaskDetail/Metrics.tsx
@@ -20,7 +20,7 @@ function FailedMetric({ name, counter }: { name: string; counter: number }) {
   }
 }
 
-function UploadMetrics(task: Promise<Task>) {
+function UploadMetrics({ task }: { task: Promise<Task> }) {
   return (
     <Col md="6">
       <Card className="my-3">
@@ -101,7 +101,7 @@ export default function Metrics() {
       <Await resolve={leaderAggregator}>
         {(leaderAggregator) => {
           if (leaderAggregator.features.includes("UploadMetrics")) {
-            return UploadMetrics(task);
+            return <UploadMetrics task={task} />;
           }
         }}
       </Await>

--- a/app/src/tasks/TaskDetail/index.tsx
+++ b/app/src/tasks/TaskDetail/index.tsx
@@ -14,6 +14,7 @@ import { AccountBreadcrumbs } from "../../util";
 import Placeholder from "react-bootstrap/Placeholder";
 import TaskTitle from "./TaskTitle";
 import CollectorAuthTokens from "./CollectorAuthTokens";
+import Metrics from "./Metrics";
 import ClientConfig from "./ClientConfig";
 import TaskPropertyTable from "./TaskPropertyTable";
 
@@ -28,6 +29,7 @@ export default function TaskDetail() {
       <Row>
         <TaskPropertyTable />
         <ClientConfig />
+        <Metrics />
         <CollectorAuthTokens />
       </Row>
     </>

--- a/client/src/task.rs
+++ b/client/src/task.rs
@@ -15,13 +15,23 @@ pub struct Task {
     #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub time_precision_seconds: u32,
+    #[deprecated = "Not populated. Will be removed in a future release."]
     pub report_count: u32,
+    #[deprecated = "Not populated. Will be removed in a future release."]
     pub aggregate_collection_count: u32,
     #[serde(default, with = "time::serde::rfc3339::option")]
     pub expiration: Option<OffsetDateTime>,
     pub leader_aggregator_id: Uuid,
     pub helper_aggregator_id: Uuid,
     pub collector_credential_id: Uuid,
+    pub report_counter_interval_collected: i64,
+    pub report_counter_decode_failure: i64,
+    pub report_counter_decrypt_failure: i64,
+    pub report_counter_expired: i64,
+    pub report_counter_outdated_key: i64,
+    pub report_counter_success: i64,
+    pub report_counter_too_early: i64,
+    pub report_counter_task_expired: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]

--- a/documentation/openapi.yml
+++ b/documentation/openapi.yml
@@ -711,8 +711,10 @@ components:
           type: number
         report_count:
           type: number
-        aggregate_collection-count:
+          deprecated: true
+        aggregate_collection_count:
           type: number
+          deprecated: true
         expiration:
           type: string
           format: date-time
@@ -726,6 +728,22 @@ components:
         collector_credential_id:
           type: string
           format: uuid
+        report_counter_interval_collected:
+          type: number
+        report_counter_decode_failure:
+          type: number
+        report_counter_decrypt_failure:
+          type: number
+        report_counter_expired:
+          type: number
+        report_counter_outdated_key:
+          type: number
+        report_counter_success:
+          type: number
+        report_counter_too_early:
+          type: number
+        report_counter_task_expired:
+          type: number
     Membership:
       type: object
       properties:

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -22,6 +22,7 @@ mod m20230907_175501_add_aggregator_onboarding_boolean_to_account;
 mod m20231012_205810_add_features_to_aggregators;
 mod m20231012_225001_rename_hpke_configs_to_collector_credentials;
 mod m20231012_233117_add_token_hash_to_collector_credential;
+mod m20240214_215101_upload_metrics;
 
 pub struct Migrator;
 
@@ -51,6 +52,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20231012_205810_add_features_to_aggregators::Migration),
             Box::new(m20231012_225001_rename_hpke_configs_to_collector_credentials::Migration),
             Box::new(m20231012_233117_add_token_hash_to_collector_credential::Migration),
+            Box::new(m20240214_215101_upload_metrics::Migration),
         ]
     }
 }

--- a/migration/src/m20240214_215101_upload_metrics.rs
+++ b/migration/src/m20240214_215101_upload_metrics.rs
@@ -1,0 +1,109 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Task::Table)
+                    .add_column(
+                        ColumnDef::new(Task::ReportCounterIntervalCollected)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::ReportCounterDecodeFailure)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::ReportCounterDecryptFailure)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::ReportCounterExpired)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::ReportCounterOutdatedKey)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::ReportCounterSuccess)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::ReportCounterTooEarly)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::ReportCounterTaskExpired)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .drop_column(Task::ReportCount)
+                    .drop_column(Task::AggregateCollectionCount)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Task::Table)
+                    .drop_column(Task::ReportCounterIntervalCollected)
+                    .drop_column(Task::ReportCounterDecodeFailure)
+                    .drop_column(Task::ReportCounterDecryptFailure)
+                    .drop_column(Task::ReportCounterExpired)
+                    .drop_column(Task::ReportCounterOutdatedKey)
+                    .drop_column(Task::ReportCounterSuccess)
+                    .drop_column(Task::ReportCounterTooEarly)
+                    .drop_column(Task::ReportCounterTaskExpired)
+                    // These columns cache transient state. We don't have to worry about refilling
+                    // them if we have to execute a down migration, since we'll fetch them from
+                    // the source again eventually.
+                    .add_column(
+                        ColumnDef::new(Task::ReportCount)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregateCollectionCount)
+                            .integer()
+                            .default(0)
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum Task {
+    Table,
+
+    ReportCounterIntervalCollected,
+    ReportCounterDecodeFailure,
+    ReportCounterDecryptFailure,
+    ReportCounterExpired,
+    ReportCounterOutdatedKey,
+    ReportCounterSuccess,
+    ReportCounterTooEarly,
+    ReportCounterTaskExpired,
+
+    ReportCount,
+    AggregateCollectionCount,
+}

--- a/src/api_mocks/aggregator_api.rs
+++ b/src/api_mocks/aggregator_api.rs
@@ -3,7 +3,7 @@ use crate::{
     clients::aggregator_client::api_types::{
         AggregatorApiConfig, AggregatorVdaf, AuthenticationToken, HpkeAeadId, HpkeConfig,
         HpkeKdfId, HpkeKemId, HpkePublicKey, JanusDuration, QueryType, Role, TaskCreate, TaskId,
-        TaskIds, TaskMetrics, TaskResponse,
+        TaskIds, TaskResponse, TaskUploadMetrics,
     },
     entity::aggregator::Feature,
 };
@@ -47,7 +47,10 @@ pub fn mock() -> impl Handler {
             .get("/tasks/:task_id", api(get_task))
             .get("/task_ids", api(task_ids))
             .delete("/tasks/:task_id", Status::Ok)
-            .get("/tasks/:task_id/metrics", api(get_task_metrics)),
+            .get(
+                "/tasks/:task_id/metrics/uploads",
+                api(get_task_upload_metrics),
+            ),
     )
 }
 
@@ -68,10 +71,16 @@ async fn bearer_token_check(conn: Conn) -> Conn {
     }
 }
 
-async fn get_task_metrics(_: &mut Conn, (): ()) -> Json<TaskMetrics> {
-    Json(TaskMetrics {
-        reports: fastrand::u64(..1000),
-        report_aggregations: fastrand::u64(..1000),
+async fn get_task_upload_metrics(_: &mut Conn, (): ()) -> Json<TaskUploadMetrics> {
+    Json(TaskUploadMetrics {
+        interval_collected: fastrand::u64(..1000),
+        report_decode_failure: fastrand::u64(..1000),
+        report_decrypt_failure: fastrand::u64(..1000),
+        report_expired: fastrand::u64(..1000),
+        report_outdated_key: fastrand::u64(..1000),
+        report_success: fastrand::u64(..1000),
+        report_too_early: fastrand::u64(..1000),
+        task_expired: fastrand::u64(..1000),
     })
 }
 

--- a/src/api_mocks/aggregator_api.rs
+++ b/src/api_mocks/aggregator_api.rs
@@ -5,7 +5,7 @@ use crate::{
         HpkeKdfId, HpkeKemId, HpkePublicKey, JanusDuration, QueryType, Role, TaskCreate, TaskId,
         TaskIds, TaskResponse, TaskUploadMetrics,
     },
-    entity::aggregator::Feature,
+    entity::aggregator::{Feature, Features},
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use querystrong::QueryStrong;
@@ -35,11 +35,7 @@ pub fn mock() -> impl Handler {
                         vdafs: Default::default(),
                         query_types: Default::default(),
                         protocol: random(),
-                        features: if random() {
-                            Feature::TokenHash.into()
-                        } else {
-                            Default::default()
-                        },
+                        features: Features::from_iter([Feature::TokenHash]),
                     })
                 }),
             )

--- a/src/clients/aggregator_client.rs
+++ b/src/clients/aggregator_client.rs
@@ -7,7 +7,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use trillium_client::{Client, KnownHeaderName};
 use url::Url;
 pub mod api_types;
-pub use api_types::{AggregatorApiConfig, TaskCreate, TaskIds, TaskMetrics, TaskResponse};
+pub use api_types::{AggregatorApiConfig, TaskCreate, TaskIds, TaskResponse, TaskUploadMetrics};
 
 const CONTENT_TYPE: &str = "application/vnd.janus.aggregator+json;version=0.1";
 
@@ -76,8 +76,11 @@ impl AggregatorClient {
         self.get(&format!("tasks/{task_id}")).await
     }
 
-    pub async fn get_task_metrics(&self, task_id: &str) -> Result<TaskMetrics, ClientError> {
-        self.get(&format!("tasks/{task_id}/metrics")).await
+    pub async fn get_task_upload_metrics(
+        &self,
+        task_id: &str,
+    ) -> Result<TaskUploadMetrics, ClientError> {
+        self.get(&format!("tasks/{task_id}/metrics/uploads")).await
     }
 
     pub async fn delete_task(&self, task_id: &str) -> Result<(), ClientError> {

--- a/src/clients/aggregator_client/api_types.rs
+++ b/src/clients/aggregator_client/api_types.rs
@@ -4,7 +4,7 @@ use crate::{
             Features, QueryTypeName, QueryTypeNameSet, Role as AggregatorRole, VdafNameSet,
         },
         task::vdaf::{BucketLength, ContinuousBuckets, CountVec, Histogram, Sum, SumVec, Vdaf},
-        Aggregator, Protocol, ProvisionableTask,
+        Aggregator, Protocol, ProvisionableTask, Task,
     },
     handler::Error,
 };
@@ -351,9 +351,36 @@ pub struct TaskIds {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TaskMetrics {
-    pub reports: u64,
-    pub report_aggregations: u64,
+pub struct TaskUploadMetrics {
+    /// Reports that fell into a time interval that had already been collected.
+    pub interval_collected: u64,
+    /// Reports that could not be decoded.
+    pub report_decode_failure: u64,
+    /// Reports that could not be decrypted.
+    pub report_decrypt_failure: u64,
+    /// Reports that contained a timestamp too far in the past.
+    pub report_expired: u64,
+    /// Reports that were encrypted with an old or unknown HPKE key.
+    pub report_outdated_key: u64,
+    /// Reports that were successfully uploaded.
+    pub report_success: u64,
+    /// Reports that contain a timestamp too far in the future.
+    pub report_too_early: u64,
+    /// Reports that were submitted to the task after the task's expiry.
+    pub task_expired: u64,
+}
+
+impl PartialEq<Task> for TaskUploadMetrics {
+    fn eq(&self, other: &Task) -> bool {
+        other.report_counter_interval_collected == self.interval_collected as i64
+            && other.report_counter_decode_failure == self.report_decode_failure as i64
+            && other.report_counter_decrypt_failure == self.report_decrypt_failure as i64
+            && other.report_counter_expired == self.report_expired as i64
+            && other.report_counter_outdated_key == self.report_outdated_key as i64
+            && other.report_counter_success == self.report_success as i64
+            && other.report_counter_too_early == self.report_too_early as i64
+            && other.report_counter_task_expired == self.task_expired as i64
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/clients/aggregator_client/api_types.rs
+++ b/src/clients/aggregator_client/api_types.rs
@@ -350,7 +350,7 @@ pub struct TaskIds {
     pub pagination_token: Option<String>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TaskUploadMetrics {
     /// Reports that fell into a time interval that had already been collected.
     pub interval_collected: u64,

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,13 +49,13 @@ pub struct Config {
     /// See [`TokioConsoleConfig::listen_address`].
     pub tokio_console_listen_address: SocketAddr,
     /// Enables refreshing upload metrics from Janus. Enabled by default.
-    pub enable_metrics_refresh: bool,
+    pub metrics_refresh_enabled: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct FeatureFlags {
     /// Enables refreshing upload metrics from Janus. Enabled by default.
-    pub enable_metrics_refresh: bool,
+    pub metrics_refresh_enabled: bool,
 }
 
 #[derive(Debug, Error)]
@@ -149,7 +149,7 @@ impl Config {
                 "TOKIO_CONSOLE_LISTEN_ADDRESS",
                 "127.0.0.1:6669".parse().unwrap(),
             )?,
-            enable_metrics_refresh: var_optional("ENABLE_METRICS_REFRESH", true)?,
+            metrics_refresh_enabled: var_optional("ENABLE_METRICS_REFRESH", true)?,
         })
     }
 
@@ -181,7 +181,7 @@ impl Config {
 
     pub fn feature_flags(&self) -> FeatureFlags {
         FeatureFlags {
-            enable_metrics_refresh: self.enable_metrics_refresh,
+            metrics_refresh_enabled: self.metrics_refresh_enabled,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,14 @@ pub struct Config {
     pub tokio_console_enabled: bool,
     /// See [`TokioConsoleConfig::listen_address`].
     pub tokio_console_listen_address: SocketAddr,
+    /// Enables refreshing upload metrics from Janus. Enabled by default.
+    pub enable_upload_metrics: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FeatureFlags {
+    /// Enables refreshing upload metrics from Janus. Enabled by default.
+    pub enable_upload_metrics: bool,
 }
 
 #[derive(Debug, Error)]
@@ -141,6 +149,7 @@ impl Config {
                 "TOKIO_CONSOLE_LISTEN_ADDRESS",
                 "127.0.0.1:6669".parse().unwrap(),
             )?,
+            enable_upload_metrics: var_optional("ENABLE_UPLOAD_METRICS", true)?,
         })
     }
 
@@ -167,6 +176,12 @@ impl Config {
                 listen_address: Some(self.tokio_console_listen_address),
             },
             chrome: self.trace_chrome,
+        }
+    }
+
+    pub fn feature_flags(&self) -> FeatureFlags {
+        FeatureFlags {
+            enable_upload_metrics: self.enable_upload_metrics,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,13 +49,13 @@ pub struct Config {
     /// See [`TokioConsoleConfig::listen_address`].
     pub tokio_console_listen_address: SocketAddr,
     /// Enables refreshing upload metrics from Janus. Enabled by default.
-    pub enable_upload_metrics: bool,
+    pub enable_metrics_refresh: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct FeatureFlags {
     /// Enables refreshing upload metrics from Janus. Enabled by default.
-    pub enable_upload_metrics: bool,
+    pub enable_metrics_refresh: bool,
 }
 
 #[derive(Debug, Error)]
@@ -149,7 +149,7 @@ impl Config {
                 "TOKIO_CONSOLE_LISTEN_ADDRESS",
                 "127.0.0.1:6669".parse().unwrap(),
             )?,
-            enable_upload_metrics: var_optional("ENABLE_UPLOAD_METRICS", true)?,
+            enable_metrics_refresh: var_optional("ENABLE_METRICS_REFRESH", true)?,
         })
     }
 
@@ -181,7 +181,7 @@ impl Config {
 
     pub fn feature_flags(&self) -> FeatureFlags {
         FeatureFlags {
-            enable_upload_metrics: self.enable_upload_metrics,
+            enable_metrics_refresh: self.enable_metrics_refresh,
         }
     }
 }

--- a/src/entity/aggregator/feature.rs
+++ b/src/entity/aggregator/feature.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Feature {
     TokenHash,
+    UploadMetrics,
     #[serde(untagged)]
     Unknown(String),
 }
@@ -14,6 +15,10 @@ pub struct Features(HashSet<Feature>);
 impl Features {
     pub fn token_hash_enabled(&self) -> bool {
         self.0.contains(&Feature::TokenHash)
+    }
+
+    pub fn upload_metrics_enabled(&self) -> bool {
+        self.0.contains(&Feature::UploadMetrics)
     }
 }
 
@@ -44,7 +49,7 @@ mod tests {
     }
 
     #[test]
-    fn features_token_hash() {
+    fn features() {
         assert_eq!(
             serde_json::from_value::<Features>(json!(["TokenHash"])).unwrap(),
             Features::from_iter([Feature::TokenHash])
@@ -53,6 +58,10 @@ mod tests {
             serde_json::from_value::<Features>(json!(["TokenHash", "TokenHash", "TokenHash"]))
                 .unwrap(),
             Features::from_iter([Feature::TokenHash])
+        );
+        assert_eq!(
+            serde_json::from_value::<Features>(json!(["TokenHash", "UploadMetrics"])).unwrap(),
+            Features::from_iter([Feature::TokenHash, Feature::UploadMetrics])
         );
     }
 

--- a/src/entity/aggregator/feature.rs
+++ b/src/entity/aggregator/feature.rs
@@ -20,6 +20,22 @@ impl Features {
     pub fn upload_metrics_enabled(&self) -> bool {
         self.0.contains(&Feature::UploadMetrics)
     }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn intersect(&self, other: &Features) -> Self {
+        self.0.intersection(&other.0).cloned().collect()
+    }
+
+    pub fn contains(&self, feature: &Feature) -> bool {
+        self.0.contains(feature)
+    }
 }
 
 impl From<Feature> for Features {

--- a/src/entity/aggregator/update_aggregator.rs
+++ b/src/entity/aggregator/update_aggregator.rs
@@ -3,7 +3,7 @@ use crate::{
     entity::Aggregator,
     Crypter, Error,
 };
-use sea_orm::{ActiveModelTrait, ActiveValue, IntoActiveModel};
+use sea_orm::{ActiveValue, IntoActiveModel};
 use serde::Deserialize;
 use time::OffsetDateTime;
 use trillium_client::Client;
@@ -26,39 +26,40 @@ impl UpdateAggregator {
     ) -> Result<super::ActiveModel, Error> {
         self.validate()?;
         let api_url = aggregator.api_url.clone().into();
+
+        let bearer_token = match self.bearer_token {
+            Some(bearer_token) => bearer_token,
+            None => aggregator.bearer_token(crypter)?,
+        };
+
         let mut aggregator = aggregator.into_active_model();
         if let Some(name) = self.name {
             aggregator.name = ActiveValue::Set(name);
         }
+        let aggregator_config = AggregatorClient::get_config(client, api_url, &bearer_token)
+            .await
+            .map_err(|e| match e {
+                ClientError::HttpStatusNotSuccess {
+                    status: Some(Status::Unauthorized | Status::Forbidden),
+                    ..
+                } => {
+                    let mut validation_errors = ValidationErrors::new();
+                    validation_errors
+                        .add("bearer_token", ValidationError::new("token-not-recognized"));
+                    validation_errors.into()
+                }
 
-        if let Some(bearer_token) = self.bearer_token {
-            let aggregator_config = AggregatorClient::get_config(client, api_url, &bearer_token)
-                .await
-                .map_err(|e| match e {
-                    ClientError::HttpStatusNotSuccess {
-                        status: Some(Status::Unauthorized | Status::Forbidden),
-                        ..
-                    } => {
-                        let mut validation_errors = ValidationErrors::new();
-                        validation_errors
-                            .add("bearer_token", ValidationError::new("token-not-recognized"));
-                        validation_errors.into()
-                    }
+                other => Error::from(other),
+            })?;
 
-                    other => Error::from(other),
-                })?;
-
-            aggregator.query_types = ActiveValue::Set(aggregator_config.query_types.into());
-            aggregator.vdafs = ActiveValue::Set(aggregator_config.vdafs.into());
-            aggregator.encrypted_bearer_token = ActiveValue::Set(crypter.encrypt(
-                aggregator.api_url.as_ref().as_ref().as_bytes(),
-                bearer_token.as_bytes(),
-            )?);
-        }
-
-        if aggregator.is_changed() {
-            aggregator.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
-        }
+        aggregator.query_types = ActiveValue::Set(aggregator_config.query_types.into());
+        aggregator.vdafs = ActiveValue::Set(aggregator_config.vdafs.into());
+        aggregator.features = ActiveValue::Set(aggregator_config.features.into());
+        aggregator.encrypted_bearer_token = ActiveValue::Set(crypter.encrypt(
+            aggregator.api_url.as_ref().as_ref().as_bytes(),
+            bearer_token.as_bytes(),
+        )?);
+        aggregator.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
         Ok(aggregator)
     }
 }

--- a/src/entity/task.rs
+++ b/src/entity/task.rs
@@ -43,6 +43,16 @@ pub struct Model {
     #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub time_precision_seconds: i32,
+
+    /// Deprecated metrics field. Never populated, only reads zero.
+    #[sea_orm(ignore)]
+    #[serde(default)]
+    pub report_count: i32,
+    /// Deprecated metrics field. Never populated, only reads zero.
+    #[sea_orm(ignore)]
+    #[serde(default)]
+    pub aggregate_collection_count: i32,
+
     #[serde(default, with = "time::serde::rfc3339::option")]
     pub expiration: Option<OffsetDateTime>,
     pub leader_aggregator_id: Uuid,

--- a/src/entity/task.rs
+++ b/src/entity/task.rs
@@ -1,5 +1,5 @@
 use crate::{
-    clients::aggregator_client::{api_types::TaskResponse, TaskMetrics},
+    clients::aggregator_client::api_types::{TaskResponse, TaskUploadMetrics},
     entity::{
         account, membership, AccountColumn, Accounts, Aggregator, AggregatorColumn, Aggregators,
         CollectorCredentialColumn, CollectorCredentials,
@@ -43,25 +43,49 @@ pub struct Model {
     #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub time_precision_seconds: i32,
-    pub report_count: i32,
-    pub aggregate_collection_count: i32,
     #[serde(default, with = "time::serde::rfc3339::option")]
     pub expiration: Option<OffsetDateTime>,
     pub leader_aggregator_id: Uuid,
     pub helper_aggregator_id: Uuid,
     pub collector_credential_id: Uuid,
+
+    pub report_counter_interval_collected: i64,
+    pub report_counter_decode_failure: i64,
+    pub report_counter_decrypt_failure: i64,
+    pub report_counter_expired: i64,
+    pub report_counter_outdated_key: i64,
+    pub report_counter_success: i64,
+    pub report_counter_too_early: i64,
+    pub report_counter_task_expired: i64,
 }
 
 impl Model {
-    pub async fn update_metrics(
+    pub async fn update_task_upload_metrics(
         self,
-        metrics: TaskMetrics,
+        metrics: TaskUploadMetrics,
         db: impl ConnectionTrait,
     ) -> Result<Self, DbErr> {
         let mut task = self.into_active_model();
-        task.report_count = ActiveValue::Set(metrics.reports.try_into().unwrap_or(i32::MAX));
-        task.aggregate_collection_count =
-            ActiveValue::Set(metrics.report_aggregations.try_into().unwrap_or(i32::MAX));
+        task.report_counter_interval_collected =
+            ActiveValue::Set(metrics.interval_collected.try_into().unwrap_or(i64::MAX));
+        task.report_counter_decode_failure =
+            ActiveValue::Set(metrics.report_decode_failure.try_into().unwrap_or(i64::MAX));
+        task.report_counter_decrypt_failure = ActiveValue::Set(
+            metrics
+                .report_decrypt_failure
+                .try_into()
+                .unwrap_or(i64::MAX),
+        );
+        task.report_counter_expired =
+            ActiveValue::Set(metrics.report_expired.try_into().unwrap_or(i64::MAX));
+        task.report_counter_outdated_key =
+            ActiveValue::Set(metrics.report_outdated_key.try_into().unwrap_or(i64::MAX));
+        task.report_counter_success =
+            ActiveValue::Set(metrics.report_success.try_into().unwrap_or(i64::MAX));
+        task.report_counter_too_early =
+            ActiveValue::Set(metrics.report_too_early.try_into().unwrap_or(i64::MAX));
+        task.report_counter_task_expired =
+            ActiveValue::Set(metrics.task_expired.try_into().unwrap_or(i64::MAX));
         task.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
         task.update(&db).await
     }

--- a/src/entity/task/provisionable_task.rs
+++ b/src/entity/task/provisionable_task.rs
@@ -116,12 +116,18 @@ impl ProvisionableTask {
             created_at: OffsetDateTime::now_utc(),
             updated_at: OffsetDateTime::now_utc(),
             time_precision_seconds: self.time_precision_seconds.try_into()?,
-            report_count: 0,
-            aggregate_collection_count: 0,
             expiration: self.expiration,
             leader_aggregator_id: self.leader_aggregator.id,
             helper_aggregator_id: self.helper_aggregator.id,
             collector_credential_id: self.collector_credential.id,
+            report_counter_interval_collected: 0,
+            report_counter_decode_failure: 0,
+            report_counter_decrypt_failure: 0,
+            report_counter_expired: 0,
+            report_counter_outdated_key: 0,
+            report_counter_success: 0,
+            report_counter_too_early: 0,
+            report_counter_task_expired: 0,
         }
         .into_active_model())
     }

--- a/src/entity/task/provisionable_task.rs
+++ b/src/entity/task/provisionable_task.rs
@@ -116,6 +116,8 @@ impl ProvisionableTask {
             created_at: OffsetDateTime::now_utc(),
             updated_at: OffsetDateTime::now_utc(),
             time_precision_seconds: self.time_precision_seconds.try_into()?,
+            report_count: 0,
+            aggregate_collection_count: 0,
             expiration: self.expiration,
             leader_aggregator_id: self.leader_aggregator.id,
             helper_aggregator_id: self.helper_aggregator.id,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -133,6 +133,7 @@ fn api(db: &Db, config: &Config) -> impl Handler {
             ),
             state(config.client.clone()),
             state(config.crypter.clone()),
+            state(config.feature_flags()),
             instrument_handler(cors_headers(config)),
             cache_control([Private, MustRevalidate]),
             db.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod telemetry;
 pub mod trace;
 mod user;
 
-pub use config::{Config, ConfigError};
+pub use config::{Config, ConfigError, FeatureFlags};
 pub use crypter::Crypter;
 pub use db::Db;
 pub use handler::{custom_mime_types::CONTENT_TYPE, DivviupApi, Error};

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -30,32 +30,29 @@ pub fn routes(config: &Config) -> impl Handler {
     let oauth2_client = OauthClient::new(&config.oauth_config());
     let auth0_client = Auth0Client::new(config);
 
-    (
-        state(config.feature_flags()),
-        router()
-            .get(
-                "/login",
-                (
-                    redirect_if_logged_in(config),
-                    state(oauth2_client.clone()),
-                    oauth2::redirect,
-                ),
-            )
-            .get("/logout", (destroy_session, logout_from_auth0(config)))
-            .get(
-                "/callback",
-                (
-                    state(oauth2_client),
-                    oauth2::callback,
-                    redirect(config.app_url.to_string()),
-                ),
-            )
-            .any(
-                &[Get, Post, Delete, Patch],
-                "/api/*",
-                (state(auth0_client), api_routes()),
+    router()
+        .get(
+            "/login",
+            (
+                redirect_if_logged_in(config),
+                state(oauth2_client.clone()),
+                oauth2::redirect,
             ),
-    )
+        )
+        .get("/logout", (destroy_session, logout_from_auth0(config)))
+        .get(
+            "/callback",
+            (
+                state(oauth2_client),
+                oauth2::callback,
+                redirect(config.app_url.to_string()),
+            ),
+        )
+        .any(
+            &[Get, Post, Delete, Patch],
+            "/api/*",
+            (state(auth0_client), api_routes()),
+        )
 }
 
 fn api_routes() -> impl Handler {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -30,29 +30,32 @@ pub fn routes(config: &Config) -> impl Handler {
     let oauth2_client = OauthClient::new(&config.oauth_config());
     let auth0_client = Auth0Client::new(config);
 
-    router()
-        .get(
-            "/login",
-            (
-                redirect_if_logged_in(config),
-                state(oauth2_client.clone()),
-                oauth2::redirect,
+    (
+        state(config.feature_flags()),
+        router()
+            .get(
+                "/login",
+                (
+                    redirect_if_logged_in(config),
+                    state(oauth2_client.clone()),
+                    oauth2::redirect,
+                ),
+            )
+            .get("/logout", (destroy_session, logout_from_auth0(config)))
+            .get(
+                "/callback",
+                (
+                    state(oauth2_client),
+                    oauth2::callback,
+                    redirect(config.app_url.to_string()),
+                ),
+            )
+            .any(
+                &[Get, Post, Delete, Patch],
+                "/api/*",
+                (state(auth0_client), api_routes()),
             ),
-        )
-        .get("/logout", (destroy_session, logout_from_auth0(config)))
-        .get(
-            "/callback",
-            (
-                state(oauth2_client),
-                oauth2::callback,
-                redirect(config.app_url.to_string()),
-            ),
-        )
-        .any(
-            &[Get, Post, Delete, Patch],
-            "/api/*",
-            (state(auth0_client), api_routes()),
-        )
+    )
 }
 
 fn api_routes() -> impl Handler {

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -1,9 +1,10 @@
 use crate::{
     entity::{Account, NewTask, Task, Tasks, UpdateTask},
-    Db, Error, Permissions, PermissionsActor,
+    Crypter, Db, Error, Permissions, PermissionsActor,
 };
 use sea_orm::{ActiveModelTrait, EntityTrait, ModelTrait};
-
+use std::time::Duration;
+use time::OffsetDateTime;
 use trillium::{Conn, Handler, Status};
 use trillium_api::{FromConn, Json, State};
 use trillium_caching_headers::CachingHeadersExt;
@@ -59,7 +60,32 @@ pub async fn create(
         .map(|task| (Status::Created, Json(task)))
 }
 
-pub async fn show(conn: &mut Conn, task: Task) -> Result<Json<Task>, Error> {
+async fn refresh_metrics_if_needed(
+    task: Task,
+    db: Db,
+    client: Client,
+    crypter: &Crypter,
+) -> Result<Task, Error> {
+    if OffsetDateTime::now_utc() - task.updated_at <= Duration::from_secs(5 * 60) {
+        return Ok(task);
+    }
+    if let Some(aggregator) = task.first_party_aggregator(&db).await? {
+        let metrics = aggregator
+            .client(client, crypter)?
+            .get_task_metrics(&task.id)
+            .await?;
+        task.update_metrics(metrics, db).await.map_err(Into::into)
+    } else {
+        Ok(task)
+    }
+}
+
+pub async fn show(
+    conn: &mut Conn,
+    (task, db, State(client)): (Task, Db, State<Client>),
+) -> Result<Json<Task>, Error> {
+    let crypter = conn.state().unwrap();
+    let task = refresh_metrics_if_needed(task, db, client, crypter).await?;
     conn.set_last_modified(task.updated_at.into());
     Ok(Json(task))
 }

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -89,7 +89,7 @@ pub async fn show(
     conn: &mut Conn,
     (task, db, State(client), State(feature_flags)): (Task, Db, State<Client>, State<FeatureFlags>),
 ) -> Result<Json<Task>, Error> {
-    let task = if feature_flags.enable_upload_metrics {
+    let task = if feature_flags.enable_metrics_refresh {
         let crypter = conn.state().unwrap();
         refresh_metrics_if_needed(task, db, client, crypter).await?
     } else {

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -72,9 +72,11 @@ async fn refresh_metrics_if_needed(
     if let Some(aggregator) = task.first_party_aggregator(&db).await? {
         let metrics = aggregator
             .client(client, crypter)?
-            .get_task_metrics(&task.id)
+            .get_task_upload_metrics(&task.id)
             .await?;
-        task.update_metrics(metrics, db).await.map_err(Into::into)
+        task.update_task_upload_metrics(metrics, db)
+            .await
+            .map_err(Into::into)
     } else {
         Ok(task)
     }

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -89,7 +89,7 @@ pub async fn show(
     conn: &mut Conn,
     (task, db, State(client), State(feature_flags)): (Task, Db, State<Client>, State<FeatureFlags>),
 ) -> Result<Json<Task>, Error> {
-    let task = if feature_flags.enable_metrics_refresh {
+    let task = if feature_flags.metrics_refresh_enabled {
         let crypter = conn.state().unwrap();
         refresh_metrics_if_needed(task, db, client, crypter).await?
     } else {

--- a/test-support/src/fixtures.rs
+++ b/test-support/src/fixtures.rs
@@ -113,6 +113,8 @@ pub async fn task(app: &DivviupApi, account: &Account) -> Task {
         created_at: OffsetDateTime::now_utc(),
         updated_at: OffsetDateTime::now_utc(),
         time_precision_seconds: 60,
+        report_count: 0,
+        aggregate_collection_count: 0,
         expiration: Some(
             OffsetDateTime::now_utc() + divviup_api::entity::task::DEFAULT_EXPIRATION_DURATION,
         ),

--- a/test-support/src/fixtures.rs
+++ b/test-support/src/fixtures.rs
@@ -113,14 +113,20 @@ pub async fn task(app: &DivviupApi, account: &Account) -> Task {
         created_at: OffsetDateTime::now_utc(),
         updated_at: OffsetDateTime::now_utc(),
         time_precision_seconds: 60,
-        report_count: 0,
-        aggregate_collection_count: 0,
         expiration: Some(
             OffsetDateTime::now_utc() + divviup_api::entity::task::DEFAULT_EXPIRATION_DURATION,
         ),
         leader_aggregator_id: leader_aggregator.id,
         helper_aggregator_id: helper_aggregator.id,
         collector_credential_id: collector_credential.id,
+        report_counter_interval_collected: 0,
+        report_counter_decode_failure: 0,
+        report_counter_decrypt_failure: 0,
+        report_counter_expired: 0,
+        report_counter_outdated_key: 0,
+        report_counter_success: 0,
+        report_counter_too_early: 0,
+        report_counter_task_expired: 0,
     }
     .into_active_model()
     .insert(app.db())

--- a/test-support/src/lib.rs
+++ b/test-support/src/lib.rs
@@ -101,7 +101,7 @@ pub fn config(api_mocks: impl Handler) -> Config {
         trace_chrome: false,
         tokio_console_enabled: false,
         tokio_console_listen_address: "127.0.0.1:6669".parse().unwrap(),
-        enable_metrics_refresh: true,
+        metrics_refresh_enabled: true,
     }
 }
 

--- a/test-support/src/lib.rs
+++ b/test-support/src/lib.rs
@@ -101,7 +101,7 @@ pub fn config(api_mocks: impl Handler) -> Config {
         trace_chrome: false,
         tokio_console_enabled: false,
         tokio_console_listen_address: "127.0.0.1:6669".parse().unwrap(),
-        enable_upload_metrics: true,
+        enable_metrics_refresh: true,
     }
 }
 

--- a/test-support/src/lib.rs
+++ b/test-support/src/lib.rs
@@ -101,6 +101,7 @@ pub fn config(api_mocks: impl Handler) -> Config {
         trace_chrome: false,
         tokio_console_enabled: false,
         tokio_console_listen_address: "127.0.0.1:6669".parse().unwrap(),
+        enable_upload_metrics: true,
     }
 }
 

--- a/tests/integration/tasks.rs
+++ b/tests/integration/tasks.rs
@@ -486,18 +486,14 @@ mod show {
             aggregator_api_request.url,
             first_party_aggregator
                 .api_url
-                .join(&format!("tasks/{}/metrics", task.id))
+                .join(&format!("tasks/{}/metrics/uploads", task.id))
                 .unwrap()
         );
-        let metrics: TaskMetrics = aggregator_api_request.response_json();
+        let metrics: TaskUploadMetrics = aggregator_api_request.response_json();
 
         let response_task: Task = conn.response_json().await;
 
-        assert_eq!(response_task.report_count, metrics.reports as i32);
-        assert_eq!(
-            response_task.aggregate_collection_count,
-            metrics.report_aggregations as i32
-        );
+        assert_eq!(metrics, response_task);
         assert!(response_task.updated_at > task.updated_at);
 
         let mut conn = get(format!("/api/tasks/{}", task.id))
@@ -506,14 +502,7 @@ mod show {
             .run_async(&app)
             .await;
         let second_response_task: Task = conn.response_json().await;
-        assert_eq!(
-            second_response_task.report_count,
-            response_task.report_count
-        );
-        assert_eq!(
-            second_response_task.aggregate_collection_count,
-            response_task.aggregate_collection_count
-        );
+        assert_eq!(metrics, second_response_task);
         assert_eq!(second_response_task.updated_at, response_task.updated_at);
 
         Ok(())

--- a/tests/integration/tasks.rs
+++ b/tests/integration/tasks.rs
@@ -1,5 +1,6 @@
 use divviup_api::clients::aggregator_client::*;
 use test_support::*;
+use trillium::Handler;
 
 mod index {
     use super::{assert_eq, test, *};
@@ -504,6 +505,39 @@ mod show {
         let second_response_task: Task = conn.response_json().await;
         assert_eq!(metrics, second_response_task);
         assert_eq!(second_response_task.updated_at, response_task.updated_at);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn metrics_refresh_disabled() -> TestResult {
+        let api_mocks = ApiMocks::new();
+        let client_logs = api_mocks.client_logs();
+
+        let mut config = config(api_mocks);
+        config.enable_upload_metrics = false;
+
+        let mut app = DivviupApi::new(config).await;
+        set_up_schema(app.db()).await;
+        let mut info = "testing".into();
+        app.init(&mut info).await;
+
+        let (user, account, ..) = fixtures::member(&app).await;
+        let task = fixtures::task(&app, &account).await;
+        let mut task = task.into_active_model();
+        task.updated_at = ActiveValue::Set(OffsetDateTime::now_utc() - Duration::minutes(10));
+
+        let task = task.update(app.db()).await?;
+
+        let conn = get(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_state(user.clone())
+            .run_async(&app)
+            .await;
+        assert_ok!(conn);
+
+        // Ensure the aggregator API was never contacted.
+        assert!(client_logs.logs().is_empty());
 
         Ok(())
     }

--- a/tests/integration/tasks.rs
+++ b/tests/integration/tasks.rs
@@ -519,7 +519,7 @@ mod show {
         let client_logs = api_mocks.client_logs();
 
         let mut config = config(api_mocks);
-        config.enable_upload_metrics = false;
+        config.enable_metrics_refresh = false;
 
         let mut app = DivviupApi::new(config).await;
         set_up_schema(app.db()).await;

--- a/tests/integration/tasks.rs
+++ b/tests/integration/tasks.rs
@@ -463,6 +463,62 @@ mod show {
         Ok(())
     }
 
+    #[test(harness = with_client_logs)]
+    async fn metrics_caching(app: DivviupApi, client_logs: ClientLogs) -> TestResult {
+        let (user, account, ..) = fixtures::member(&app).await;
+        let task = fixtures::task(&app, &account).await;
+        let mut task = task.into_active_model();
+        task.updated_at = ActiveValue::Set(OffsetDateTime::now_utc() - Duration::minutes(10));
+
+        let task = task.update(app.db()).await?;
+
+        let first_party_aggregator = task.first_party_aggregator(app.db()).await?.unwrap();
+
+        let mut conn = get(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_state(user.clone())
+            .run_async(&app)
+            .await;
+        assert_ok!(conn);
+
+        let aggregator_api_request = client_logs.last();
+        assert_eq!(
+            aggregator_api_request.url,
+            first_party_aggregator
+                .api_url
+                .join(&format!("tasks/{}/metrics", task.id))
+                .unwrap()
+        );
+        let metrics: TaskMetrics = aggregator_api_request.response_json();
+
+        let response_task: Task = conn.response_json().await;
+
+        assert_eq!(response_task.report_count, metrics.reports as i32);
+        assert_eq!(
+            response_task.aggregate_collection_count,
+            metrics.report_aggregations as i32
+        );
+        assert!(response_task.updated_at > task.updated_at);
+
+        let mut conn = get(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_state(user)
+            .run_async(&app)
+            .await;
+        let second_response_task: Task = conn.response_json().await;
+        assert_eq!(
+            second_response_task.report_count,
+            response_task.report_count
+        );
+        assert_eq!(
+            second_response_task.aggregate_collection_count,
+            response_task.aggregate_collection_count
+        );
+        assert_eq!(second_response_task.updated_at, response_task.updated_at);
+
+        Ok(())
+    }
+
     #[test(harness = set_up)]
     async fn not_member(app: DivviupApi) -> TestResult {
         let user = fixtures::user();

--- a/tests/integration/tasks.rs
+++ b/tests/integration/tasks.rs
@@ -526,7 +526,7 @@ mod show {
         let conn = get(format!("/api/tasks/{}", task.id))
             .with_api_headers()
             .with_state(FeatureFlags {
-                enable_metrics_refresh: false,
+                metrics_refresh_enabled: false,
             })
             .with_state(user.clone())
             .run_async(&app)


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2293.

Replaces the older, slower metrics with monotonic upload counters.

Error counts are hidden if they're non-zero, while the successful reports counter always displays. A documentation link is provided for what these metrics mean, and how to troubleshoot error metrics.

<img width="673" alt="image" src="https://github.com/divviup/divviup-api/assets/57697428/20f982ea-5196-47c5-9ab8-f47cc84aaf9f">
<img width="673" alt="image" src="https://github.com/divviup/divviup-api/assets/57697428/e76192a6-162f-4fb5-bbbc-7784960819eb">

I think there's more we could do here wrt making this information more... informational, i.e. giving more time-series information--but I think this accomplishes the initial goal set out in the issue of "rough error detection". I'd like to take this as MVP and iterate it as there's more demand for it.
