### PR TITLE
Fix bug in deserializing unknown aggregator features

### DIFF
--- a/src/entity/aggregator/feature.rs
+++ b/src/entity/aggregator/feature.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Feature {
     TokenHash,
+    #[serde(untagged)]
     Unknown(String),
 }
 
@@ -25,5 +26,72 @@ impl From<Feature> for Features {
 impl FromIterator<Feature> for Features {
     fn from_iter<T: IntoIterator<Item = Feature>>(iter: T) -> Self {
         Self(iter.into_iter().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::entity::aggregator::{Feature, Features};
+
+    #[test]
+    fn features_none() {
+        assert_eq!(
+            serde_json::from_value::<Features>(json!([])).unwrap(),
+            Features::from_iter([])
+        )
+    }
+
+    #[test]
+    fn features_token_hash() {
+        assert_eq!(
+            serde_json::from_value::<Features>(json!(["TokenHash"])).unwrap(),
+            Features::from_iter([Feature::TokenHash])
+        );
+        assert_eq!(
+            serde_json::from_value::<Features>(json!(["TokenHash", "TokenHash", "TokenHash"]))
+                .unwrap(),
+            Features::from_iter([Feature::TokenHash])
+        );
+    }
+
+    #[test]
+    fn features_unknown() {
+        assert_eq!(
+            serde_json::from_value::<Features>(json!(["UnspecifiedUnknownFeature"])).unwrap(),
+            Features::from_iter([Feature::Unknown("UnspecifiedUnknownFeature".to_string())])
+        );
+
+        assert_eq!(
+            serde_json::from_value::<Features>(json!([
+                "UnspecifiedUnknownFeature",
+                "UnspecifiedUnknownFeature",
+                "UnspecifiedUnknownFeature"
+            ]))
+            .unwrap(),
+            Features::from_iter([Feature::Unknown("UnspecifiedUnknownFeature".to_string())])
+        );
+
+        assert_eq!(
+            serde_json::from_value::<Features>(json!([
+                "UnspecifiedUnknownFeature",
+                "AnotherUnspecifiedUnknownFeature"
+            ]))
+            .unwrap(),
+            Features::from_iter([
+                Feature::Unknown("UnspecifiedUnknownFeature".to_string()),
+                Feature::Unknown("AnotherUnspecifiedUnknownFeature".to_string())
+            ])
+        );
+
+        assert_eq!(
+            serde_json::from_value::<Features>(json!(["UnspecifiedUnknownFeature", "TokenHash"]))
+                .unwrap(),
+            Features::from_iter([
+                Feature::TokenHash,
+                Feature::Unknown("UnspecifiedUnknownFeature".to_string())
+            ])
+        );
     }
 }


### PR DESCRIPTION
Also tests some edge cases, perhaps to a gratuitous extent.

See https://serde.rs/variant-attrs.html#untagged for the fix, although this documentation is unclear. The issue that I got this from is more clear https://github.com/serde-rs/serde/issues/912#issuecomment-1868785603.