### PR TITLE
Let PATCH /aggregators/{id} refresh aggregator config

### DIFF
--- a/src/api_mocks/aggregator_api.rs
+++ b/src/api_mocks/aggregator_api.rs
@@ -5,7 +5,7 @@ use crate::{
         HpkeKdfId, HpkeKemId, HpkePublicKey, JanusDuration, QueryType, Role, TaskCreate, TaskId,
         TaskIds, TaskResponse, TaskUploadMetrics,
     },
-    entity::aggregator::Feature,
+    entity::aggregator::{Feature, Features},
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use querystrong::QueryStrong;
@@ -35,11 +35,7 @@ pub fn mock() -> impl Handler {
                         vdafs: Default::default(),
                         query_types: Default::default(),
                         protocol: random(),
-                        features: if random() {
-                            Feature::TokenHash.into()
-                        } else {
-                            Default::default()
-                        },
+                        features: Features::from_iter([Feature::TokenHash]),
                     })
                 }),
             )

--- a/src/entity/aggregator/feature.rs
+++ b/src/entity/aggregator/feature.rs
@@ -20,6 +20,22 @@ impl Features {
     pub fn upload_metrics_enabled(&self) -> bool {
         self.0.contains(&Feature::UploadMetrics)
     }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn intersect(&self, other: &Features) -> Self {
+        self.0.intersection(&other.0).cloned().collect()
+    }
+
+    pub fn contains(&self, feature: &Feature) -> bool {
+        self.0.contains(feature)
+    }
 }
 
 impl From<Feature> for Features {

--- a/src/entity/aggregator/update_aggregator.rs
+++ b/src/entity/aggregator/update_aggregator.rs
@@ -3,7 +3,7 @@ use crate::{
     entity::Aggregator,
     Crypter, Error,
 };
-use sea_orm::{ActiveModelTrait, ActiveValue, IntoActiveModel};
+use sea_orm::{ActiveValue, IntoActiveModel};
 use serde::Deserialize;
 use time::OffsetDateTime;
 use trillium_client::Client;
@@ -26,39 +26,40 @@ impl UpdateAggregator {
     ) -> Result<super::ActiveModel, Error> {
         self.validate()?;
         let api_url = aggregator.api_url.clone().into();
+
+        let bearer_token = match self.bearer_token {
+            Some(bearer_token) => bearer_token,
+            None => aggregator.bearer_token(crypter)?,
+        };
+
         let mut aggregator = aggregator.into_active_model();
         if let Some(name) = self.name {
             aggregator.name = ActiveValue::Set(name);
         }
+        let aggregator_config = AggregatorClient::get_config(client, api_url, &bearer_token)
+            .await
+            .map_err(|e| match e {
+                ClientError::HttpStatusNotSuccess {
+                    status: Some(Status::Unauthorized | Status::Forbidden),
+                    ..
+                } => {
+                    let mut validation_errors = ValidationErrors::new();
+                    validation_errors
+                        .add("bearer_token", ValidationError::new("token-not-recognized"));
+                    validation_errors.into()
+                }
 
-        if let Some(bearer_token) = self.bearer_token {
-            let aggregator_config = AggregatorClient::get_config(client, api_url, &bearer_token)
-                .await
-                .map_err(|e| match e {
-                    ClientError::HttpStatusNotSuccess {
-                        status: Some(Status::Unauthorized | Status::Forbidden),
-                        ..
-                    } => {
-                        let mut validation_errors = ValidationErrors::new();
-                        validation_errors
-                            .add("bearer_token", ValidationError::new("token-not-recognized"));
-                        validation_errors.into()
-                    }
+                other => Error::from(other),
+            })?;
 
-                    other => Error::from(other),
-                })?;
-
-            aggregator.query_types = ActiveValue::Set(aggregator_config.query_types.into());
-            aggregator.vdafs = ActiveValue::Set(aggregator_config.vdafs.into());
-            aggregator.encrypted_bearer_token = ActiveValue::Set(crypter.encrypt(
-                aggregator.api_url.as_ref().as_ref().as_bytes(),
-                bearer_token.as_bytes(),
-            )?);
-        }
-
-        if aggregator.is_changed() {
-            aggregator.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
-        }
+        aggregator.query_types = ActiveValue::Set(aggregator_config.query_types.into());
+        aggregator.vdafs = ActiveValue::Set(aggregator_config.vdafs.into());
+        aggregator.features = ActiveValue::Set(aggregator_config.features.into());
+        aggregator.encrypted_bearer_token = ActiveValue::Set(crypter.encrypt(
+            aggregator.api_url.as_ref().as_ref().as_bytes(),
+            bearer_token.as_bytes(),
+        )?);
+        aggregator.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
         Ok(aggregator)
     }
 }


### PR DESCRIPTION
This lets users invoke `PATCH /api/aggregators/{id}` with an empty JSON body `{}` to cleanly refresh the aggregator config. This will also trigger full refreshes when the name or bearer token are updated.

I considered a few alternative approaches before landing on this one:
- Refreshing automatically, periodically, like we do on metrics. This feels kind of bad, because we'd have to tell people to just browse around the UI if/when they update their helper to contain new features. Config reload seems like a deliberate action to me, i.e. "I've updated the aggregator to contain a new feature now I need to tell divviup-api about it". If we want reload done automatically, it may be better done as an async job.
- Having a distinct endpoint for refreshing the aggregator, e.g. `POST /api/aggregators/{id}` or `POST /api/aggregators/reload`. I didn't think this necessary, there wasn't a clear advantage to this over overloading PATCH. 

This does not appear to require OpenAPI spec changes.

I am not carrying forward this change to the UI to be mindful of time commitment, since this is an uncommon need. A workaround for invoking this through the UI would be to execute a no-op name change.