### PR TITLE
DAP-09 support

### DIFF
--- a/src/entity/aggregator/protocol.rs
+++ b/src/entity/aggregator/protocol.rs
@@ -20,14 +20,18 @@ pub enum Protocol {
     #[sea_orm(string_value = "DAP-07")]
     #[serde(rename = "DAP-07")]
     Dap07,
+
+    #[sea_orm(string_value = "DAP-09")]
+    #[serde(rename = "DAP-09")]
+    Dap09,
 }
 
 impl Distribution<Protocol> for Standard {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Protocol {
-        if rng.gen() {
-            Protocol::Dap04
-        } else {
-            Protocol::Dap07
+        match rng.gen_range(0..=2) {
+            0 => Protocol::Dap04,
+            1 => Protocol::Dap07,
+            _ => Protocol::Dap09,
         }
     }
 }
@@ -43,24 +47,30 @@ impl AsRef<str> for Protocol {
         match self {
             Self::Dap04 => "DAP-04",
             Self::Dap07 => "DAP-07",
+            Self::Dap09 => "DAP-09",
         }
     }
 }
 
 #[derive(Debug)]
 pub struct UnrecognizedProtocol(String);
+
 impl Display for UnrecognizedProtocol {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("{} was not a recognized protocol", self.0))
     }
 }
+
 impl Error for UnrecognizedProtocol {}
+
 impl FromStr for Protocol {
     type Err = UnrecognizedProtocol;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match &*s.to_lowercase() {
             "dap-04" => Ok(Self::Dap04),
             "dap-07" => Ok(Self::Dap07),
+            "dap-09" => Ok(Self::Dap09),
             unrecognized => Err(UnrecognizedProtocol(unrecognized.to_string())),
         }
     }

--- a/src/entity/task/vdaf.rs
+++ b/src/entity/task/vdaf.rs
@@ -44,7 +44,7 @@ impl Histogram {
         protocol: &Protocol,
     ) -> Result<AggregatorVdaf, ValidationErrors> {
         match (protocol, self) {
-            (Protocol::Dap07, histogram) => {
+            (Protocol::Dap07 | Protocol::Dap09, histogram) => {
                 if let Some(chunk_length) = histogram.chunk_length() {
                     Ok(AggregatorVdaf::Prio3Histogram(HistogramType::Opaque {
                         length: histogram.length(),
@@ -290,7 +290,7 @@ impl Vdaf {
             ) => {}
 
             // Select a chunk length if the protocol version needs it and it isn't set yet.
-            (Self::Histogram(histogram), Protocol::Dap07) => {
+            (Self::Histogram(histogram), Protocol::Dap07 | Protocol::Dap09) => {
                 let length = histogram.length();
                 match histogram {
                     Histogram::Opaque(BucketLength { chunk_length, .. })
@@ -306,7 +306,7 @@ impl Vdaf {
                     length: Some(length),
                     chunk_length: chunk_length @ None,
                 }),
-                Protocol::Dap07,
+                Protocol::Dap07 | Protocol::Dap09,
             ) => *chunk_length = Some(optimal_chunk_length(*length as usize) as u64),
 
             (
@@ -315,15 +315,15 @@ impl Vdaf {
                     length: Some(length),
                     chunk_length: chunk_length @ None,
                 }),
-                Protocol::Dap07,
+                Protocol::Dap07 | Protocol::Dap09,
             ) => {
                 *chunk_length = Some(optimal_chunk_length(*bits as usize * *length as usize) as u64)
             }
 
             // Invalid, missing parameters, do nothing.
-            (Self::CountVec(CountVec { length: None, .. }), Protocol::Dap07)
-            | (Self::SumVec(SumVec { bits: None, .. }), Protocol::Dap07)
-            | (Self::SumVec(SumVec { length: None, .. }), Protocol::Dap07) => {}
+            (Self::CountVec(CountVec { length: None, .. }), Protocol::Dap07 | Protocol::Dap09)
+            | (Self::SumVec(SumVec { bits: None, .. }), Protocol::Dap07 | Protocol::Dap09)
+            | (Self::SumVec(SumVec { length: None, .. }), Protocol::Dap07 | Protocol::Dap09) => {}
 
             // Chunk length is not applicable, either due to VDAF choice or protocol version.
             (Self::Count, _)


### PR DESCRIPTION
Closes https://github.com/divviup/divviup-api/issues/878.

Adds support for aggregators that report themselves as DAP-09. AFAICT there are no functional changes required, just recognition.