### PR TITLE
Update validator to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,9 +5166,9 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da339118f018cc70ebf01fafc103360528aad53717e4bf311db929cb01cb9345"
+checksum = "ecda4130ab69f138bc9ec971ac01c173ce053d993cc600eb01633be50a8f0b1a"
 dependencies = [
  "idna",
  "once_cell",
@@ -5182,15 +5182,15 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e88ea23b8f5e59230bff8a2f03c0ee0054a61d5b8343a38946bcd406fe624c"
+checksum = "c1829bd6a78a15a6a689dd17921ad614e281224a34b233b15be4a11affa61c1b"
 dependencies = [
  "darling",
+ "once_cell",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "regex",
  "syn 2.0.50",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ trillium-tokio = "0.3.4"
 typenum = "1.17.0"
 url = "2.5.0"
 uuid = { version = "1.8.0", features = ["v4", "fast-rng", "serde"] }
-validator = { version = "0.17.0", features = ["derive"] }
+validator = { version = "0.18.0", features = ["derive"] }
 trillium-opentelemetry = { version = "0.6.0", default-features = false, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio", "logs", "metrics"] }
 opentelemetry-otlp = { version = "0.15.0", optional = true }

--- a/src/entity/aggregator/new_aggregator.rs
+++ b/src/entity/aggregator/new_aggregator.rs
@@ -27,11 +27,7 @@ pub struct NewAggregator {
 }
 
 #[cfg_attr(feature = "integration-testing", allow(dead_code))]
-fn https(url_opt: &Option<String>) -> Result<(), ValidationError> {
-    let Some(url) = url_opt else {
-        return Ok(());
-    };
-
+fn https(url: &String) -> Result<(), ValidationError> {
     let url = url::Url::from_str(url).map_err(|_| ValidationError::new("https-url"))?;
     if url.scheme() != "https" {
         return Err(ValidationError::new("https-url"));

--- a/src/entity/task/new_task.rs
+++ b/src/entity/task/new_task.rs
@@ -21,7 +21,7 @@ pub struct NewTask {
     #[validate(required)]
     pub helper_aggregator_id: Option<String>,
 
-    #[validate(required_nested)]
+    #[validate(required, nested)]
     pub vdaf: Option<Vdaf>,
 
     #[validate(required, range(min = 100))]

--- a/src/entity/task/vdaf.rs
+++ b/src/entity/task/vdaf.rs
@@ -120,11 +120,7 @@ pub struct BucketLength {
     pub chunk_length: Option<u64>,
 }
 
-fn unique<T: Hash + Eq>(buckets_opt: &Option<Vec<T>>) -> Result<(), ValidationError> {
-    let Some(buckets) = buckets_opt else {
-        return Ok(());
-    };
-
+fn unique<T: Hash + Eq>(buckets: &Vec<T>) -> Result<(), ValidationError> {
     if buckets.len() == buckets.iter().collect::<HashSet<_>>().len() {
         Ok(())
     } else {
@@ -132,11 +128,7 @@ fn unique<T: Hash + Eq>(buckets_opt: &Option<Vec<T>>) -> Result<(), ValidationEr
     }
 }
 
-fn increasing(buckets_opt: &Option<Vec<u64>>) -> Result<(), ValidationError> {
-    let Some(buckets) = buckets_opt else {
-        return Ok(());
-    };
-
+fn increasing(buckets: &Vec<u64>) -> Result<(), ValidationError> {
     let Some(mut last) = buckets.first().copied() else {
         return Ok(());
     };
@@ -151,14 +143,14 @@ fn increasing(buckets_opt: &Option<Vec<u64>>) -> Result<(), ValidationError> {
     Ok(())
 }
 
-fn increasing_and_unique(buckets_opt: &Option<Vec<u64>>) -> Result<(), ValidationError> {
+fn increasing_and_unique(buckets: &Vec<u64>) -> Result<(), ValidationError> {
     // Due to limitations in the Validate derive macro, only one custom validator may be applied
     // to each field. This function thus combines two custom validations into one. Unfortunately,
     // only one error `ValidationError` may be added to the struct-level `ValidationErrors` by a
     // single custom validation, so we must short-circuit if one of the two wrapped validations
     // fails. See https://github.com/Keats/validator/issues/308.
-    increasing(buckets_opt)?;
-    unique(buckets_opt)
+    increasing(buckets)?;
+    unique(buckets)
 }
 
 #[derive(Serialize, Deserialize, Validate, Debug, Clone, Copy, Eq, PartialEq)]


### PR DESCRIPTION
This updates `validator` to 0.18.0, and addresses two breaking changes (one of which reverts a change in 0.17.0).