### PR TITLE
Rustls provider followup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,7 +3620,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ trillium-macros = "0.0.6"
 trillium-prometheus = "0.1.0"
 trillium-redirect = "0.1.2"
 trillium-router = "0.4.1"
-trillium-rustls = { version = "0.7.0", default-features = false, features = ["client"] }
+trillium-rustls = "0.7.0"
 trillium-sessions = "0.4.3"
 trillium-static-compiled = "0.5.2"
 trillium-testing = { version = "0.6.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ trillium-macros = "0.0.6"
 trillium-prometheus = "0.1.0"
 trillium-redirect = "0.1.2"
 trillium-router = "0.4.1"
-trillium-rustls = { version = "0.7.0", default-features = false, features = ["client", "ring"] }
+trillium-rustls = { version = "0.7.0", default-features = false, features = ["client"] }
 trillium-sessions = "0.4.3"
 trillium-static-compiled = "0.5.2"
 trillium-testing = { version = "0.6.1", optional = true }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -178,6 +178,7 @@ impl ClientBin {
 }
 
 pub fn main() -> ExitCode {
+    let _ = trillium_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
     env_logger::init();
     let args = ClientBin::parse();
     trillium_tokio::block_on(async move { args.run().await })

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -178,7 +178,11 @@ impl ClientBin {
 }
 
 pub fn main() -> ExitCode {
+    // Choose aws-lc-rs as the default rustls crypto provider. This is what's currently enabled by
+    // the default Cargo feature. Specifying a default provider here prevents runtime errors if
+    // another dependency also enables the ring feature.
     let _ = trillium_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     env_logger::init();
     let args = ClientBin::parse();
     trillium_tokio::block_on(async move { args.run().await })

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -7,6 +7,8 @@ use trillium_tokio::CloneCounterObserver;
 
 #[tokio::main]
 async fn main() {
+    let _ = trillium_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let config = match Config::from_env() {
         Ok(config) => config,
         Err(e) => {

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -7,6 +7,9 @@ use trillium_tokio::CloneCounterObserver;
 
 #[tokio::main]
 async fn main() {
+    // Choose aws-lc-rs as the default rustls crypto provider. This is what's currently enabled by
+    // the default Cargo feature. Specifying a default provider here prevents runtime errors if
+    // another dependency also enables the ring feature.
     let _ = trillium_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let config = match Config::from_env() {


### PR DESCRIPTION
This fixes a runtime issue with rustls two ways, by installing a default crypto provider on startup, and by dropping a `ring` crate feature, in favor of the new defaults. I plan to add a TLS smoke test as well, but that will have to follow on in a subsequent PR.