### PR TITLE
Add smoke test of TLS connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -1411,6 +1411,7 @@ dependencies = [
  "prometheus",
  "querystrong",
  "rand",
+ "rcgen",
  "regex",
  "rustc_version",
  "sea-orm",
@@ -2459,7 +2460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2987,6 +2988,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.0",
+ "serde",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3391,6 +3402,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -5808,6 +5832,15 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ features = [
 
 
 [dev-dependencies]
+rcgen = "0.13.1"
 regex = "1.10.4"
 test-support.workspace = true
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -12,5 +12,6 @@ mod jobs;
 mod memberships;
 mod new_task;
 mod tasks;
+mod tls_smoke_test;
 mod users;
 mod vdaf;

--- a/tests/integration/tls_smoke_test.rs
+++ b/tests/integration/tls_smoke_test.rs
@@ -1,0 +1,40 @@
+use rcgen::generate_simple_self_signed;
+use test_support::{assert_eq, *};
+use tokio::{net::TcpListener, spawn};
+use trillium_client::Client;
+use trillium_http::Stopper;
+use trillium_rustls::{rustls::RootCertStore, RustlsAcceptor, RustlsConfig};
+use trillium_tokio::ClientConfig;
+
+#[tokio::test]
+async fn https_connection() {
+    let self_signed = generate_simple_self_signed(["localhost".into()]).unwrap();
+
+    let stopper = Stopper::new();
+    let listener = TcpListener::bind("localhost:0").await.unwrap();
+    let local_addr = listener.local_addr().unwrap();
+    let server_config = trillium_tokio::config()
+        .with_acceptor(RustlsAcceptor::from_single_cert(
+            self_signed.cert.pem().as_bytes(),
+            self_signed.key_pair.serialize_pem().as_bytes(),
+        ))
+        .without_signals()
+        .with_stopper(stopper.clone())
+        .with_prebound_server(listener);
+    spawn(server_config.run_async(|conn: Conn| async { conn.ok("") }));
+
+    let mut root_store = RootCertStore::empty();
+    root_store.add_parsable_certificates([self_signed.cert.der().clone()]);
+
+    let client = Client::new(RustlsConfig::new(
+        trillium_rustls::rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth(),
+        ClientConfig::default(),
+    ));
+    let url = format!("https://localhost:{}/", local_addr.port());
+    let conn = client.get(url).await.unwrap();
+    assert_status!(conn, 200);
+
+    stopper.stop();
+}


### PR DESCRIPTION
This adds a test to check that `rustls` is properly configured, and we can make a TLS connection.