### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-api"
-version = "0.1.18"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "async-lock 3.3.0",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-cli"
-version = "0.1.18"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.0",
  "clap",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-client"
-version = "0.1.18"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.0",
  "divviup-api",
@@ -2544,7 +2544,7 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "migration"
-version = "0.1.18"
+version = "0.2.0"
 dependencies = [
  "async-std",
  "clap",
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.1.18"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.0",
  "divviup-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,15 @@
 members = [".", "migration", "client", "test-support", "cli"]
 
 [workspace.package]
-version = "0.1.18"
+version = "0.2.0"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://divviup.org"
 repository = "https://github.com/divviup/divviup-api"
 
 [workspace.dependencies]
-divviup-client = { path = "./client", version = "0.1.18" }
-divviup-cli = { path = "./cli", version = "0.1.18" }
+divviup-client = { path = "./client", version = "0.2.0" }
+divviup-cli = { path = "./cli", version = "0.2.0" }
 divviup-api.path = "."
 test-support.path = "./test-support"
 


### PR DESCRIPTION
This bumps the version of workspace crates to 0.2.0, because `divviup_client::Client::new()` takes an `impl trillium_server_common::client::Connector` as an argument, and we just changed to an incompatible version of that crate.