### PR TITLE
ui: Present metrics using system locale

### DIFF
--- a/app/src/tasks/TaskDetail/Metrics.tsx
+++ b/app/src/tasks/TaskDetail/Metrics.tsx
@@ -6,13 +6,13 @@ import Card from "react-bootstrap/Card";
 import ListGroup from "react-bootstrap/ListGroup";
 import { DateTime } from "luxon";
 import Placeholder from "react-bootstrap/Placeholder";
-import { OutLink } from "../../util";
+import { OutLink, numberFormat } from "../../util";
 
 function FailedMetric({ name, counter }: { name: string; counter: number }) {
   if (counter > 0) {
     return (
       <ListGroup.Item>
-        {name}: {counter}
+        {name}: {numberFormat.format(counter)}
       </ListGroup.Item>
     );
   } else {

--- a/app/src/util.tsx
+++ b/app/src/util.tsx
@@ -169,3 +169,5 @@ export function OutLink({
     </a>
   );
 }
+
+export const numberFormat = Intl.NumberFormat();


### PR DESCRIPTION
Make these numbers more legible, with respect to the system locale.
<img width="696" alt="image" src="https://github.com/divviup/divviup-api/assets/57697428/ee6feda7-8010-4922-9be8-c92b77c3fe02">
