### PR TITLE
UI display support for time bucketed fixed size

### DIFF
--- a/app/src/ApiClient.ts
+++ b/app/src/ApiClient.ts
@@ -72,6 +72,7 @@ export interface Task {
   updated_at: string;
   expiration: string | null;
   max_batch_size: number | null;
+  batch_time_window_size_seconds: number | null;
   collector_credential_id: string;
   report_counter_interval_collected: number;
   report_counter_decode_failure: number;

--- a/app/src/tasks/TaskDetail/TaskPropertyTable.tsx
+++ b/app/src/tasks/TaskDetail/TaskPropertyTable.tsx
@@ -44,7 +44,13 @@ export default function TaskPropertyTable() {
               </Await>
             </Suspense>
           </ListGroup.Item>
-          <Suspense fallback={<Placeholder animation="glow" xs={6} />}>
+          <Suspense
+            fallback={
+              <ListGroup.Item>
+                <Placeholder animation="glow" xs={6} />
+              </ListGroup.Item>
+            }
+          >
             <Await resolve={task}>
               {(task) => {
                 let queryType;
@@ -79,8 +85,8 @@ export default function TaskPropertyTable() {
                 return (
                   <>
                     <ListGroup.Item>Query Type: {queryType}</ListGroup.Item>
-                    {maxBatchSize}
                     {batchTimeWindowSize}
+                    {maxBatchSize}
                   </>
                 );
               }}

--- a/app/src/tasks/TaskDetail/TaskPropertyTable.tsx
+++ b/app/src/tasks/TaskDetail/TaskPropertyTable.tsx
@@ -44,18 +44,48 @@ export default function TaskPropertyTable() {
               </Await>
             </Suspense>
           </ListGroup.Item>
-          <ListGroup.Item>
-            Query Type:{" "}
-            <Suspense fallback={<Placeholder animation="glow" xs={6} />}>
-              <Await resolve={task}>
-                {(task) =>
-                  typeof task.max_batch_size === "number"
-                    ? `Fixed maximum batch size ${task.max_batch_size}`
-                    : "Time Interval"
+          <Suspense fallback={<Placeholder animation="glow" xs={6} />}>
+            <Await resolve={task}>
+              {(task) => {
+                let queryType;
+                let maxBatchSize;
+                let batchTimeWindowSize;
+
+                if (typeof task.max_batch_size === "number") {
+                  maxBatchSize = (
+                    <ListGroup.Item>
+                      Maximum Batch Size: {task.max_batch_size}
+                    </ListGroup.Item>
+                  );
+
+                  if (typeof task.batch_time_window_size_seconds === "number") {
+                    queryType = "Time-bucketed Fixed Size";
+
+                    batchTimeWindowSize = (
+                      <ListGroup.Item>
+                        Batch Time Window Size:{" "}
+                        {humanizeDuration(
+                          1000 * task.batch_time_window_size_seconds,
+                        )}
+                      </ListGroup.Item>
+                    );
+                  } else {
+                    queryType = "Fixed Size";
+                  }
+                } else {
+                  queryType = "Time Interval";
                 }
-              </Await>
-            </Suspense>
-          </ListGroup.Item>
+
+                return (
+                  <>
+                    <ListGroup.Item>Query Type: {queryType}</ListGroup.Item>
+                    {maxBatchSize}
+                    {batchTimeWindowSize}
+                  </>
+                );
+              }}
+            </Await>
+          </Suspense>
           <ListGroup.Item>
             Minimum Batch Size:{" "}
             <Suspense fallback={<Placeholder animation="glow" xs={6} />}>


### PR DESCRIPTION
Displays time bucketed fixed size tasks, and cleans up the handling of normal fixed size tasks. Supports https://github.com/divviup/divviup-api/issues/291.

I'm content to leave UI support at this, for now, since building out the form is more complex. For now, tasks of this query type will need to be created through the API/CLI.

Fixed size:
<img width="664" alt="image" src="https://github.com/divviup/divviup-api/assets/57697428/d8937e99-ef8e-4e53-bb31-b95dc15b0cde">

Time interval:
<img width="664" alt="image" src="https://github.com/divviup/divviup-api/assets/57697428/4c51071f-865e-420a-922c-b0aa5680fdeb">
 
Time bucketed fixed size:
<img width="664" alt="image" src="https://github.com/divviup/divviup-api/assets/57697428/e70ce8db-5132-4fb0-9784-7896f770e0e0">
