### PR TITLE
Task expiration and deletion

### DIFF
--- a/cli/src/tasks.rs
+++ b/cli/src/tasks.rs
@@ -164,7 +164,7 @@ impl TaskAction {
             TaskAction::CollectorAuthTokens { task_id } => {
                 output.display(client.task_collector_auth_tokens(&task_id).await?)
             }
-            TaskAction::Delete { task_id } => output.display(client.delete_task(&task_id).await?),
+            TaskAction::Delete { task_id } => client.delete_task(&task_id).await?,
             TaskAction::SetExpiration {
                 task_id,
                 expiration,

--- a/client/src/task.rs
+++ b/client/src/task.rs
@@ -15,6 +15,8 @@ pub struct Task {
     pub created_at: OffsetDateTime,
     #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub deleted_at: Option<OffsetDateTime>,
     pub time_precision_seconds: u32,
     #[deprecated = "Not populated. Will be removed in a future release."]
     pub report_count: u32,

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -24,6 +24,7 @@ mod m20231012_225001_rename_hpke_configs_to_collector_credentials;
 mod m20231012_233117_add_token_hash_to_collector_credential;
 mod m20240214_215101_upload_metrics;
 mod m20240411_195358_time_bucketed_fixed_size;
+mod m20240416_172920_task_deleted_at;
 
 pub struct Migrator;
 
@@ -55,6 +56,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20231012_233117_add_token_hash_to_collector_credential::Migration),
             Box::new(m20240214_215101_upload_metrics::Migration),
             Box::new(m20240411_195358_time_bucketed_fixed_size::Migration),
+            Box::new(m20240416_172920_task_deleted_at::Migration),
         ]
     }
 }

--- a/migration/src/m20240416_172920_task_deleted_at.rs
+++ b/migration/src/m20240416_172920_task_deleted_at.rs
@@ -1,0 +1,39 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Task::Table)
+                    .add_column(
+                        ColumnDef::new(Task::DeletedAt)
+                            .timestamp_with_time_zone()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                TableAlterStatement::new()
+                    .table(Task::Table)
+                    .drop_column(Task::DeletedAt)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Task {
+    Table,
+    DeletedAt,
+}

--- a/src/clients/aggregator_client/api_types.rs
+++ b/src/clients/aggregator_client/api_types.rs
@@ -289,6 +289,11 @@ impl TaskCreate {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct TaskPatch {
+    pub task_expiration: Option<JanusTime>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TaskResponse {
     pub task_id: TaskId,

--- a/src/entity/task.rs
+++ b/src/entity/task.rs
@@ -1,16 +1,11 @@
 use crate::{
-    clients::aggregator_client::api_types::{TaskResponse, TaskUploadMetrics},
+    clients::aggregator_client::api_types::TaskResponse,
     entity::{
-        account, membership, AccountColumn, Accounts, Aggregator, AggregatorColumn, Aggregators,
-        CollectorCredentialColumn, CollectorCredentials,
+        Aggregator, AggregatorColumn, Aggregators, CollectorCredentialColumn, CollectorCredentials,
     },
 };
-use sea_orm::{
-    ActiveModelBehavior, ActiveModelTrait, ActiveValue, ConnectionTrait, DbErr, DeriveEntityModel,
-    DerivePrimaryKey, DeriveRelation, EntityTrait, EnumIter, IntoActiveModel, PrimaryKeyTrait,
-    Related, RelationDef, RelationTrait,
-};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use std::fmt::Debug;
 use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 use validator::{Validate, ValidationError};
@@ -22,173 +17,27 @@ pub use new_task::NewTask;
 mod update_task;
 pub use update_task::UpdateTask;
 mod provisionable_task;
-pub use provisionable_task::{ProvisionableTask, TaskProvisioningError};
+pub use provisionable_task::ProvisionableTask;
+pub mod model;
+pub use model::*;
 
 pub const DEFAULT_EXPIRATION_DURATION: Duration = Duration::days(365);
 
-use super::json::Json;
-
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[sea_orm(table_name = "task")]
-pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub id: String,
-    pub account_id: Uuid,
-    pub name: String,
-    pub vdaf: Json<Vdaf>,
-    pub min_batch_size: i64,
-    pub max_batch_size: Option<i64>,
-    pub batch_time_window_size_seconds: Option<i64>,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
-    pub time_precision_seconds: i32,
-
-    /// Deprecated metrics field. Never populated, only reads zero.
-    #[sea_orm(ignore)]
-    #[serde(default)]
-    pub report_count: i32,
-    /// Deprecated metrics field. Never populated, only reads zero.
-    #[sea_orm(ignore)]
-    #[serde(default)]
-    pub aggregate_collection_count: i32,
-
-    #[serde(default, with = "time::serde::rfc3339::option")]
-    pub expiration: Option<OffsetDateTime>,
-    pub leader_aggregator_id: Uuid,
-    pub helper_aggregator_id: Uuid,
-    pub collector_credential_id: Uuid,
-
-    pub report_counter_interval_collected: i64,
-    pub report_counter_decode_failure: i64,
-    pub report_counter_decrypt_failure: i64,
-    pub report_counter_expired: i64,
-    pub report_counter_outdated_key: i64,
-    pub report_counter_success: i64,
-    pub report_counter_too_early: i64,
-    pub report_counter_task_expired: i64,
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum TaskProvisioningError {
+    #[error("discrepancy in {0}")]
+    Discrepancy(&'static str),
 }
 
-impl Model {
-    pub async fn update_task_upload_metrics(
-        self,
-        metrics: TaskUploadMetrics,
-        db: impl ConnectionTrait,
-    ) -> Result<Self, DbErr> {
-        let mut task = self.into_active_model();
-        task.report_counter_interval_collected =
-            ActiveValue::Set(metrics.interval_collected.try_into().unwrap_or(i64::MAX));
-        task.report_counter_decode_failure =
-            ActiveValue::Set(metrics.report_decode_failure.try_into().unwrap_or(i64::MAX));
-        task.report_counter_decrypt_failure = ActiveValue::Set(
-            metrics
-                .report_decrypt_failure
-                .try_into()
-                .unwrap_or(i64::MAX),
-        );
-        task.report_counter_expired =
-            ActiveValue::Set(metrics.report_expired.try_into().unwrap_or(i64::MAX));
-        task.report_counter_outdated_key =
-            ActiveValue::Set(metrics.report_outdated_key.try_into().unwrap_or(i64::MAX));
-        task.report_counter_success =
-            ActiveValue::Set(metrics.report_success.try_into().unwrap_or(i64::MAX));
-        task.report_counter_too_early =
-            ActiveValue::Set(metrics.report_too_early.try_into().unwrap_or(i64::MAX));
-        task.report_counter_task_expired =
-            ActiveValue::Set(metrics.task_expired.try_into().unwrap_or(i64::MAX));
-        task.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
-        task.update(&db).await
-    }
-
-    pub async fn leader_aggregator(
-        &self,
-        db: &impl ConnectionTrait,
-    ) -> Result<super::Aggregator, DbErr> {
-        super::Aggregators::find_by_id(self.leader_aggregator_id)
-            .one(db)
-            .await
-            .transpose()
-            .ok_or(DbErr::Custom("expected leader aggregator".into()))?
-    }
-
-    pub async fn helper_aggregator(&self, db: &impl ConnectionTrait) -> Result<Aggregator, DbErr> {
-        Aggregators::find_by_id(self.helper_aggregator_id)
-            .one(db)
-            .await
-            .transpose()
-            .ok_or(DbErr::Custom("expected helper aggregator".into()))?
-    }
-
-    pub async fn aggregators(&self, db: &impl ConnectionTrait) -> Result<[Aggregator; 2], DbErr> {
-        futures_lite::future::try_zip(self.leader_aggregator(db), self.helper_aggregator(db))
-            .await
-            .map(|(leader, helper)| [leader, helper])
-    }
-
-    pub async fn first_party_aggregator(
-        &self,
-        db: &impl ConnectionTrait,
-    ) -> Result<Option<Aggregator>, DbErr> {
-        Ok(self
-            .aggregators(db)
-            .await?
-            .into_iter()
-            .find(|agg| agg.is_first_party))
+pub(crate) fn assert_same<T: Eq + Debug>(
+    ours: T,
+    theirs: T,
+    property: &'static str,
+) -> Result<(), TaskProvisioningError> {
+    if ours == theirs {
+        Ok(())
+    } else {
+        log::error!("{property} discrepancy. ours: {ours:?}, theirs: {theirs:?}");
+        Err(TaskProvisioningError::Discrepancy(property))
     }
 }
-
-#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-pub enum Relation {
-    #[sea_orm(
-        belongs_to = "Accounts",
-        from = "Column::AccountId",
-        to = "AccountColumn::Id"
-    )]
-    Account,
-
-    #[sea_orm(
-        belongs_to = "Aggregators",
-        from = "Column::HelperAggregatorId",
-        to = "AggregatorColumn::Id"
-    )]
-    HelperAggregator,
-
-    #[sea_orm(
-        belongs_to = "Aggregators",
-        from = "Column::LeaderAggregatorId",
-        to = "AggregatorColumn::Id"
-    )]
-    LeaderAggregator,
-
-    #[sea_orm(
-        belongs_to = "CollectorCredentials",
-        from = "Column::CollectorCredentialId",
-        to = "CollectorCredentialColumn::Id"
-    )]
-    CollectorCredential,
-}
-
-impl Related<account::Entity> for Entity {
-    fn to() -> RelationDef {
-        Relation::Account.def()
-    }
-}
-
-impl Related<membership::Entity> for Entity {
-    fn to() -> RelationDef {
-        account::Relation::Memberships.def()
-    }
-
-    fn via() -> Option<RelationDef> {
-        Some(account::Relation::Tasks.def().rev())
-    }
-}
-
-impl Related<CollectorCredentials> for Entity {
-    fn to() -> RelationDef {
-        Relation::CollectorCredential.def()
-    }
-}
-
-impl ActiveModelBehavior for ActiveModel {}

--- a/src/entity/task/model.rs
+++ b/src/entity/task/model.rs
@@ -20,7 +20,7 @@ use super::vdaf::Vdaf;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
 #[sea_orm(table_name = "task")]
 pub struct Model {
-    /// The task's DAP ID.
+    /// The DAP task ID.
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: String,
     pub account_id: Uuid,

--- a/src/entity/task/model.rs
+++ b/src/entity/task/model.rs
@@ -1,0 +1,186 @@
+use crate::{
+    clients::aggregator_client::TaskUploadMetrics,
+    entity::{
+        account, json::Json, membership, AccountColumn, Accounts, Aggregator, AggregatorColumn,
+        Aggregators, CollectorCredentialColumn, CollectorCredentials,
+    },
+};
+use sea_orm::{
+    ActiveModelBehavior, ActiveModelTrait, ActiveValue, ConnectionTrait, DbErr, DeriveEntityModel,
+    DerivePrimaryKey, DeriveRelation, EntityTrait, EnumIter, IntoActiveModel, PrimaryKeyTrait,
+    Related, RelationDef, RelationTrait,
+};
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use super::vdaf::Vdaf;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
+#[sea_orm(table_name = "task")]
+pub struct Model {
+    /// The task's DAP ID.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub account_id: Uuid,
+    pub name: String,
+    pub vdaf: Json<Vdaf>,
+    pub min_batch_size: i64,
+    pub max_batch_size: Option<i64>,
+    pub batch_time_window_size_seconds: Option<i64>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub deleted_at: Option<OffsetDateTime>,
+    pub time_precision_seconds: i32,
+
+    /// Deprecated metrics field. Never populated, only reads zero.
+    #[sea_orm(ignore)]
+    #[serde(default)]
+    pub report_count: i32,
+    /// Deprecated metrics field. Never populated, only reads zero.
+    #[sea_orm(ignore)]
+    #[serde(default)]
+    pub aggregate_collection_count: i32,
+
+    #[serde(default, with = "time::serde::rfc3339::option")]
+    pub expiration: Option<OffsetDateTime>,
+    pub leader_aggregator_id: Uuid,
+    pub helper_aggregator_id: Uuid,
+    pub collector_credential_id: Uuid,
+
+    pub report_counter_interval_collected: i64,
+    pub report_counter_decode_failure: i64,
+    pub report_counter_decrypt_failure: i64,
+    pub report_counter_expired: i64,
+    pub report_counter_outdated_key: i64,
+    pub report_counter_success: i64,
+    pub report_counter_too_early: i64,
+    pub report_counter_task_expired: i64,
+}
+
+impl Model {
+    pub async fn update_task_upload_metrics(
+        self,
+        metrics: TaskUploadMetrics,
+        db: impl ConnectionTrait,
+    ) -> Result<Self, DbErr> {
+        let mut task = self.into_active_model();
+        task.report_counter_interval_collected =
+            ActiveValue::Set(metrics.interval_collected.try_into().unwrap_or(i64::MAX));
+        task.report_counter_decode_failure =
+            ActiveValue::Set(metrics.report_decode_failure.try_into().unwrap_or(i64::MAX));
+        task.report_counter_decrypt_failure = ActiveValue::Set(
+            metrics
+                .report_decrypt_failure
+                .try_into()
+                .unwrap_or(i64::MAX),
+        );
+        task.report_counter_expired =
+            ActiveValue::Set(metrics.report_expired.try_into().unwrap_or(i64::MAX));
+        task.report_counter_outdated_key =
+            ActiveValue::Set(metrics.report_outdated_key.try_into().unwrap_or(i64::MAX));
+        task.report_counter_success =
+            ActiveValue::Set(metrics.report_success.try_into().unwrap_or(i64::MAX));
+        task.report_counter_too_early =
+            ActiveValue::Set(metrics.report_too_early.try_into().unwrap_or(i64::MAX));
+        task.report_counter_task_expired =
+            ActiveValue::Set(metrics.task_expired.try_into().unwrap_or(i64::MAX));
+        task.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
+        task.update(&db).await
+    }
+
+    pub async fn leader_aggregator(
+        &self,
+        db: &impl ConnectionTrait,
+    ) -> Result<super::Aggregator, DbErr> {
+        super::Aggregators::find_by_id(self.leader_aggregator_id)
+            .one(db)
+            .await
+            .transpose()
+            .ok_or(DbErr::Custom("expected leader aggregator".into()))?
+    }
+
+    pub async fn helper_aggregator(&self, db: &impl ConnectionTrait) -> Result<Aggregator, DbErr> {
+        Aggregators::find_by_id(self.helper_aggregator_id)
+            .one(db)
+            .await
+            .transpose()
+            .ok_or(DbErr::Custom("expected helper aggregator".into()))?
+    }
+
+    pub async fn aggregators(&self, db: &impl ConnectionTrait) -> Result<[Aggregator; 2], DbErr> {
+        futures_lite::future::try_zip(self.leader_aggregator(db), self.helper_aggregator(db))
+            .await
+            .map(|(leader, helper)| [leader, helper])
+    }
+
+    pub async fn first_party_aggregator(
+        &self,
+        db: &impl ConnectionTrait,
+    ) -> Result<Option<Aggregator>, DbErr> {
+        Ok(self
+            .aggregators(db)
+            .await?
+            .into_iter()
+            .find(|agg| agg.is_first_party))
+    }
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "Accounts",
+        from = "Column::AccountId",
+        to = "AccountColumn::Id"
+    )]
+    Account,
+
+    #[sea_orm(
+        belongs_to = "Aggregators",
+        from = "Column::HelperAggregatorId",
+        to = "AggregatorColumn::Id"
+    )]
+    HelperAggregator,
+
+    #[sea_orm(
+        belongs_to = "Aggregators",
+        from = "Column::LeaderAggregatorId",
+        to = "AggregatorColumn::Id"
+    )]
+    LeaderAggregator,
+
+    #[sea_orm(
+        belongs_to = "CollectorCredentials",
+        from = "Column::CollectorCredentialId",
+        to = "CollectorCredentialColumn::Id"
+    )]
+    CollectorCredential,
+}
+
+impl Related<account::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Account.def()
+    }
+}
+
+impl Related<membership::Entity> for Entity {
+    fn to() -> RelationDef {
+        account::Relation::Memberships.def()
+    }
+
+    fn via() -> Option<RelationDef> {
+        Some(account::Relation::Tasks.def().rev())
+    }
+}
+
+impl Related<CollectorCredentials> for Entity {
+    fn to() -> RelationDef {
+        Relation::CollectorCredential.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/entity/task/new_task.rs
+++ b/src/entity/task/new_task.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use rand::Rng;
-use sea_orm::{ColumnTrait, QueryFilter};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 use sha2::{Digest, Sha256};
 use validator::{ValidationErrors, ValidationErrorsKind};
 

--- a/src/entity/task/provisionable_task.rs
+++ b/src/entity/task/provisionable_task.rs
@@ -5,16 +5,9 @@ use crate::{
     handler::Error,
     Crypter,
 };
+use sea_orm::IntoActiveModel;
 use std::fmt::Debug;
 use trillium_client::Client;
-
-#[derive(thiserror::Error, Debug, Clone, Copy)]
-pub enum TaskProvisioningError {
-    #[error("discrepancy in {0}")]
-    Discrepancy(&'static str),
-    #[error("missing task id from all sources")]
-    MissingTaskId,
-}
 
 #[derive(Clone, Debug)]
 pub struct ProvisionableTask {
@@ -34,19 +27,6 @@ pub struct ProvisionableTask {
     pub collector_credential: CollectorCredential,
     pub aggregator_auth_token: Option<String>,
     pub protocol: Protocol,
-}
-
-fn assert_same<T: Eq + Debug>(
-    ours: T,
-    theirs: T,
-    property: &'static str,
-) -> Result<(), TaskProvisioningError> {
-    if ours == theirs {
-        Ok(())
-    } else {
-        log::error!("{property} discrepancy. ours: {ours:?}, theirs: {theirs:?}");
-        Err(TaskProvisioningError::Discrepancy(property))
-    }
 }
 
 impl ProvisionableTask {
@@ -116,6 +96,7 @@ impl ProvisionableTask {
                 .transpose()?,
             created_at: OffsetDateTime::now_utc(),
             updated_at: OffsetDateTime::now_utc(),
+            deleted_at: None,
             time_precision_seconds: self.time_precision_seconds.try_into()?,
             report_count: 0,
             aggregate_collection_count: 0,

--- a/src/entity/task/update_task.rs
+++ b/src/entity/task/update_task.rs
@@ -29,7 +29,7 @@ fn validate_name(name: &str) -> Result<(), ValidationError> {
 }
 
 impl UpdateTask {
-    async fn update_aggregator_expiration(
+    pub async fn update_aggregator_expiration(
         &self,
         aggregator: Aggregator,
         task_id: &str,

--- a/src/entity/task/update_task.rs
+++ b/src/entity/task/update_task.rs
@@ -1,20 +1,93 @@
-use sea_orm::{ActiveValue, IntoActiveModel};
+use janus_messages::Time as JanusTime;
+use sea_orm::{ActiveModelTrait, ActiveValue, IntoActiveModel};
 use serde::Deserialize;
 use time::OffsetDateTime;
-use validator::Validate;
+use tokio::try_join;
+use trillium_client::Client;
+use validator::{Validate, ValidationError};
 
-#[derive(Deserialize, Validate, Debug)]
+use crate::{deserialize_some, entity::Aggregator, handler::Error, Crypter, Db};
+
+use super::assert_same;
+
+#[derive(Default, Deserialize, Validate, Debug)]
 pub struct UpdateTask {
-    #[validate(required, length(min = 1))]
-    pub name: Option<String>,
+    #[validate(custom(function = "validate_name"))]
+    name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_some")]
+    expiration: Option<Expiration>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+struct Expiration(#[serde(default, with = "time::serde::rfc3339::option")] Option<OffsetDateTime>);
+
+fn validate_name(name: &str) -> Result<(), ValidationError> {
+    if name.is_empty() {
+        return Err(ValidationError::new("name-too-short"));
+    }
+    Ok(())
 }
 
 impl UpdateTask {
-    pub fn build(self, model: super::Model) -> Result<super::ActiveModel, crate::handler::Error> {
+    async fn update_aggregator_expiration(
+        &self,
+        aggregator: Aggregator,
+        task_id: &str,
+        http_client: &Client,
+        crypter: &Crypter,
+    ) -> Result<(), Error> {
+        let expiration = self.expiration.as_ref().unwrap().0.map(|expiration| {
+            JanusTime::from_seconds_since_epoch(expiration.unix_timestamp().try_into().unwrap())
+        });
+        let response = aggregator
+            .client(http_client.clone(), crypter)?
+            .update_task_expiration(task_id, expiration)
+            .await?;
+        assert_same(expiration, response.task_expiration, "expiration")?;
+        Ok(())
+    }
+
+    /// Validates the request. Updates task definitions in the aggregators, if necessary. Returns
+    /// an [`ActiveModel`] for committing to the database.
+    pub async fn update(
+        self,
+        http_client: &Client,
+        db: &Db,
+        crypter: &Crypter,
+        model: super::Model,
+    ) -> Result<super::ActiveModel, Error> {
         self.validate()?;
-        let mut am = model.into_active_model();
-        am.name = ActiveValue::Set(self.name.unwrap());
-        am.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
+        let mut am = model.clone().into_active_model();
+        if let Some(ref name) = self.name {
+            am.name = ActiveValue::Set(name.clone());
+        }
+        if let Some(ref expiration) = self.expiration {
+            try_join!(
+                self.update_aggregator_expiration(
+                    model.leader_aggregator(db).await?,
+                    &model.id,
+                    http_client,
+                    crypter
+                ),
+                self.update_aggregator_expiration(
+                    model.helper_aggregator(db).await?,
+                    &model.id,
+                    http_client,
+                    crypter
+                )
+            )?;
+            am.expiration = ActiveValue::set(expiration.0);
+        }
+        if am.is_changed() {
+            am.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
+        }
         Ok(am)
+    }
+
+    pub fn expiration(expiration: Option<OffsetDateTime>) -> Self {
+        Self {
+            expiration: Some(Expiration(expiration)),
+            ..Default::default()
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,20 @@ pub use opentelemetry;
 pub use permissions::{Permissions, PermissionsActor};
 pub use queue::Queue;
 pub use routes::routes;
+use serde::{Deserialize, Deserializer};
 pub use user::{User, USER_SESSION_KEY};
 
 #[cfg(test)]
 pub mod test;
 
 pub mod api_mocks;
+
+/// Any value that is present is considered Some value, including null.
+/// See https://github.com/serde-rs/serde/issues/984#issuecomment-314143738
+fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).map(Some)
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -70,6 +70,7 @@ fn api_routes() -> impl Handler {
                 api(tasks::collector_auth_tokens::index),
             )
             .patch("/tasks/:task_id", api(tasks::update))
+            .delete("/tasks/:task_id", api(tasks::delete))
             .patch("/aggregators/:aggregator_id", api(aggregators::update))
             .get("/aggregators/:aggregator_id", api(aggregators::show))
             .delete("/aggregators/:aggregator_id", api(aggregators::delete))

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -1,10 +1,13 @@
 use crate::{
     clients::aggregator_client::TaskUploadMetrics,
     config::FeatureFlags,
-    entity::{Account, NewTask, Task, Tasks, UpdateTask},
+    entity::{Account, NewTask, Task, TaskColumn, Tasks, UpdateTask},
     Crypter, Db, Error, Permissions, PermissionsActor,
 };
-use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait, IntoActiveModel, ModelTrait};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, IntoActiveModel, ModelTrait,
+    QueryFilter,
+};
 use std::time::Duration;
 use time::OffsetDateTime;
 use tracing::warn;
@@ -17,6 +20,7 @@ use trillium_router::RouterConnExt;
 pub async fn index(_: &mut Conn, (account, db): (Account, Db)) -> Result<impl Handler, Error> {
     account
         .find_related(Tasks)
+        .filter(TaskColumn::DeletedAt.is_null())
         .all(&db)
         .await
         .map(Json)

--- a/test-support/src/fixtures.rs
+++ b/test-support/src/fixtures.rs
@@ -115,6 +115,7 @@ pub async fn task(app: &DivviupApi, account: &Account) -> Task {
         batch_time_window_size_seconds: None,
         created_at: OffsetDateTime::now_utc(),
         updated_at: OffsetDateTime::now_utc(),
+        deleted_at: None,
         time_precision_seconds: 60,
         report_count: 0,
         aggregate_collection_count: 0,

--- a/tests/integration/aggregator_client.rs
+++ b/tests/integration/aggregator_client.rs
@@ -72,34 +72,6 @@ async fn get_task_metrics(app: DivviupApi, client_logs: ClientLogs) -> TestResul
 }
 
 #[test(harness = with_client_logs)]
-async fn delete_task(app: DivviupApi, client_logs: ClientLogs) -> TestResult {
-    let aggregator = fixtures::aggregator(&app, None).await;
-    let client = aggregator.client(app.config().client.clone(), app.crypter())?;
-    assert!(client.delete_task("fake-task-id").await.is_ok());
-
-    let log = client_logs.last();
-    assert_eq!(
-        log.request_headers
-            .get_str(KnownHeaderName::Accept)
-            .unwrap(),
-        "application/vnd.janus.aggregator+json;version=0.1"
-    );
-    assert_eq!(
-        log.request_headers
-            .get_str(KnownHeaderName::Authorization)
-            .unwrap(),
-        &format!("Bearer {}", aggregator.bearer_token(app.crypter()).unwrap())
-    );
-
-    assert_eq!(
-        log.url.as_ref(),
-        &format!("{}tasks/fake-task-id", aggregator.api_url.as_ref())
-    );
-
-    Ok(())
-}
-
-#[test(harness = with_client_logs)]
 async fn get_config(app: DivviupApi, client_logs: ClientLogs) -> TestResult {
     AggregatorClient::get_config(
         app.config().client.clone(),
@@ -227,24 +199,6 @@ mod prefixes {
             client_logs.last().url.as_ref(),
             format!("{}/tasks/fake-task-id/metrics/uploads", aggregator.api_url)
         );
-        assert_eq!(client_logs.logs().len(), 1);
-        Ok(())
-    }
-
-    #[test(harness = with_random_prefix)]
-    async fn delete_task(
-        app: DivviupApi,
-        client_logs: ClientLogs,
-        aggregator: Aggregator,
-    ) -> TestResult {
-        let client = aggregator.client(app.config().client.clone(), app.crypter())?;
-        client.delete_task("fake-task-id").await?;
-        assert_eq!(client_logs.last().url.path_segments().unwrap().count(), 3);
-        assert_eq!(
-            client_logs.last().url.as_ref(),
-            format!("{}/tasks/fake-task-id", aggregator.api_url)
-        );
-        assert_eq!(client_logs.last().method, Method::Delete);
         assert_eq!(client_logs.logs().len(), 1);
         Ok(())
     }

--- a/tests/integration/tasks.rs
+++ b/tests/integration/tasks.rs
@@ -630,10 +630,12 @@ mod show {
 }
 
 mod update {
+    use time::format_description::well_known::Rfc3339;
+
     use super::{assert_eq, test, *};
 
     #[test(harness = set_up)]
-    async fn valid(app: DivviupApi) -> TestResult {
+    async fn valid_name_change(app: DivviupApi) -> TestResult {
         let (user, account, ..) = fixtures::member(&app).await;
         let task = fixtures::task(&app, &account).await;
 
@@ -647,13 +649,19 @@ mod update {
         assert_ok!(conn);
         let response_task: Task = conn.response_json().await;
         assert_eq!(response_task.name, new_name);
-        assert_eq!(task.reload(app.db()).await?.unwrap().name, new_name);
+
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert_eq!(task_reload.name, new_name);
+
+        // Ensure the other field(s) are unchanged.
+        assert_eq!(response_task.expiration, task.expiration);
+        assert_eq!(task_reload.expiration, task.expiration);
 
         Ok(())
     }
 
     #[test(harness = set_up)]
-    async fn invalid(app: DivviupApi) -> TestResult {
+    async fn name_too_short(app: DivviupApi) -> TestResult {
         let (user, account, ..) = fixtures::member(&app).await;
         let task = fixtures::task(&app, &account).await;
 
@@ -671,6 +679,76 @@ mod update {
             task.reload(app.db()).await?.unwrap().name,
             task.name // unchanged
         );
+
+        Ok(())
+    }
+
+    #[test(harness = set_up)]
+    async fn expiration(app: DivviupApi) -> TestResult {
+        let (user, account, ..) = fixtures::member(&app).await;
+        let task = fixtures::task(&app, &account).await;
+
+        // Set the expiration.
+        let now = OffsetDateTime::now_utc();
+        let mut conn = patch(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_request_json(json!({ "expiration": now.format(&Rfc3339).unwrap() }))
+            .with_state(user.clone())
+            .run_async(&app)
+            .await;
+        assert_ok!(conn);
+        let response_task: Task = conn.response_json().await;
+        assert_eq!(response_task.expiration, Some(now));
+
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert_eq!(task_reload.expiration, Some(now));
+
+        // Ensure the other field(s) are unchanged.
+        assert_eq!(response_task.name, task.name);
+        assert_eq!(
+            task.reload(app.db()).await?.unwrap().name,
+            task.name // unchanged
+        );
+
+        // Unset the expiration.
+        let mut conn = patch(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_request_json(json!({ "expiration": null }))
+            .with_state(user.clone())
+            .run_async(&app)
+            .await;
+        assert_ok!(conn);
+        let response_task: Task = conn.response_json().await;
+        assert_eq!(response_task.expiration, None);
+
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert_eq!(task_reload.expiration, None);
+
+        // Ensure the other field(s) are unchanged.
+        assert_eq!(response_task.name, task.name);
+        assert_eq!(
+            task.reload(app.db()).await?.unwrap().name,
+            task.name // unchanged
+        );
+
+        // Set both name and expiration.
+        let now = OffsetDateTime::now_utc();
+        let new_name = format!("new name {}", fixtures::random_name());
+        let mut conn = patch(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_request_json(
+                json!({ "expiration": now.format(&Rfc3339).unwrap(), "name": new_name}),
+            )
+            .with_state(user)
+            .run_async(&app)
+            .await;
+        assert_ok!(conn);
+        let response_task: Task = conn.response_json().await;
+        assert_eq!(response_task.expiration, Some(now));
+        assert_eq!(response_task.name, new_name);
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert_eq!(task_reload.expiration, Some(now));
+        assert_eq!(task_reload.name, new_name);
 
         Ok(())
     }
@@ -785,6 +863,221 @@ mod update {
             .await;
 
         assert_eq!(task.reload(app.db()).await?.unwrap().name, name_before);
+        assert_not_found!(conn);
+        Ok(())
+    }
+}
+
+mod delete {
+    use janus_messages::Time as JanusTime;
+
+    use super::{assert_eq, test, *};
+
+    fn check_client_logs(client_logs: &ClientLogs, task: &Task) {
+        let logs = dbg!(client_logs.logs());
+        let [leader, helper] = &logs[..] else {
+            panic!("expected exactly two requests");
+        };
+        let leader_task: TaskResponse =
+            serde_json::from_str(leader.response_body.as_ref().unwrap()).unwrap();
+        let helper_task: TaskResponse =
+            serde_json::from_str(helper.response_body.as_ref().unwrap()).unwrap();
+        let expected = JanusTime::from_seconds_since_epoch(
+            task.expiration
+                .unwrap()
+                .unix_timestamp()
+                .try_into()
+                .unwrap(),
+        );
+        assert!(leader_task.task_expiration.is_some());
+        assert!(leader_task.task_expiration.unwrap() <= expected);
+        assert!(helper_task.task_expiration.is_some());
+        assert!(helper_task.task_expiration.unwrap() <= expected);
+    }
+
+    #[test(harness = with_client_logs)]
+    async fn success(app: DivviupApi, client_logs: ClientLogs) -> TestResult {
+        let (user, account, ..) = fixtures::member(&app).await;
+        let task = fixtures::task(&app, &account).await;
+
+        let conn = delete(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_state(user.clone())
+            .run_async(&app)
+            .await;
+        assert_status!(conn, Status::NoContent);
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert!(task_reload.expiration.is_some());
+        assert!(task_reload.expiration <= Some(OffsetDateTime::now_utc()));
+        assert!(task_reload.deleted_at.is_some());
+        assert!(task_reload.deleted_at <= Some(OffsetDateTime::now_utc()));
+        check_client_logs(&client_logs, &task_reload);
+
+        // Ensure we don't do redundant work when deleting again.
+        let client_logs_len = client_logs.len();
+        let conn = delete(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_state(user)
+            .run_async(&app)
+            .await;
+        assert_status!(conn, Status::NoContent);
+        let task_reload_2 = task.reload(app.db()).await?.unwrap();
+        assert_eq!(task_reload.deleted_at, task_reload_2.deleted_at);
+        assert_eq!(client_logs_len, client_logs.len());
+        Ok(())
+    }
+
+    #[test(harness = with_client_logs)]
+    async fn success_if_no_expiry(app: DivviupApi, client_logs: ClientLogs) -> TestResult {
+        let (user, account, ..) = fixtures::member(&app).await;
+        let task = fixtures::task(&app, &account).await;
+        let mut am = task.into_active_model();
+        am.expiration = ActiveValue::Set(None);
+        let task = am.update(app.db()).await.unwrap();
+
+        let conn = delete(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_state(user.clone())
+            .run_async(&app)
+            .await;
+        assert_status!(conn, Status::NoContent);
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert!(task_reload.expiration.is_some());
+        assert!(task_reload.expiration <= Some(OffsetDateTime::now_utc()));
+        assert!(task_reload.deleted_at.is_some());
+        assert!(task_reload.deleted_at <= Some(OffsetDateTime::now_utc()));
+        check_client_logs(&client_logs, &task_reload);
+        Ok(())
+    }
+
+    #[test(harness = with_client_logs)]
+    async fn already_expired(app: DivviupApi, client_logs: ClientLogs) -> TestResult {
+        let (user, account, ..) = fixtures::member(&app).await;
+        let task = fixtures::task(&app, &account).await;
+        let mut am = task.into_active_model();
+        am.expiration = ActiveValue::Set(Some(OffsetDateTime::from_unix_timestamp(0).unwrap()));
+        let task = am.update(app.db()).await.unwrap();
+
+        let conn = delete(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_state(user)
+            .run_async(&app)
+            .await;
+        assert_status!(conn, Status::NoContent);
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        // Shouldn't re-expire an already expired task.
+        assert_eq!(task_reload.expiration, task.expiration);
+        assert!(task_reload.deleted_at.is_some());
+        assert!(task_reload.deleted_at <= Some(OffsetDateTime::now_utc()));
+        assert!(client_logs.is_empty());
+        Ok(())
+    }
+
+    #[test(harness = set_up)]
+    async fn not_member(app: DivviupApi) -> TestResult {
+        let user = fixtures::user();
+        let account = fixtures::account(&app).await;
+        let task = fixtures::task(&app, &account).await;
+
+        let mut conn = delete(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_state(user)
+            .run_async(&app)
+            .await;
+        assert_not_found!(conn);
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert_eq!(task_reload.expiration, task.expiration);
+        assert_eq!(task_reload.deleted_at, None);
+        Ok(())
+    }
+
+    #[test(harness = set_up)]
+    async fn admin_not_member(app: DivviupApi) -> TestResult {
+        let (admin, ..) = fixtures::admin(&app).await;
+        let account = fixtures::account(&app).await;
+        let task = fixtures::task(&app, &account).await;
+
+        let conn = delete(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_state(admin)
+            .run_async(&app)
+            .await;
+        assert_status!(conn, Status::NoContent);
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert!(task_reload.expiration.is_some());
+        assert!(task_reload.expiration <= Some(OffsetDateTime::now_utc()));
+        assert!(task_reload.deleted_at.is_some());
+        assert!(task_reload.deleted_at <= Some(OffsetDateTime::now_utc()));
+        Ok(())
+    }
+
+    #[test(harness = set_up)]
+    async fn nonexistant_task(app: DivviupApi) -> TestResult {
+        let user = fixtures::user();
+        let mut conn = delete("/api/tasks/not-a-task-id")
+            .with_api_headers()
+            .with_state(user)
+            .run_async(&app)
+            .await;
+        assert_not_found!(conn);
+        Ok(())
+    }
+
+    #[test(harness = set_up)]
+    async fn admin_token(app: DivviupApi) -> TestResult {
+        let token = fixtures::admin_token(&app).await;
+        let account = fixtures::account(&app).await;
+        let task = fixtures::task(&app, &account).await;
+
+        let conn = delete(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_auth_header(token)
+            .run_async(&app)
+            .await;
+        assert_status!(conn, Status::NoContent);
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert!(task_reload.expiration.is_some());
+        assert!(task_reload.expiration <= Some(OffsetDateTime::now_utc()));
+        assert!(task_reload.deleted_at.is_some());
+        assert!(task_reload.deleted_at <= Some(OffsetDateTime::now_utc()));
+        Ok(())
+    }
+
+    #[test(harness = set_up)]
+    async fn member_token(app: DivviupApi) -> TestResult {
+        let account = fixtures::account(&app).await;
+        let (_, token) = fixtures::api_token(&app, &account).await;
+        let task = fixtures::task(&app, &account).await;
+
+        let conn = delete(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_auth_header(token)
+            .run_async(&app)
+            .await;
+        assert_status!(conn, Status::NoContent);
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert!(task_reload.expiration.is_some());
+        assert!(task_reload.expiration <= Some(OffsetDateTime::now_utc()));
+        assert!(task_reload.deleted_at.is_some());
+        assert!(task_reload.deleted_at <= Some(OffsetDateTime::now_utc()));
+        Ok(())
+    }
+
+    #[test(harness = set_up)]
+    async fn nonmember_token(app: DivviupApi) -> TestResult {
+        let other_account = fixtures::account(&app).await;
+        let (_, token) = fixtures::api_token(&app, &other_account).await;
+        let account = fixtures::account(&app).await;
+        let task = fixtures::task(&app, &account).await;
+        let mut conn = delete(format!("/api/tasks/{}", task.id))
+            .with_api_headers()
+            .with_auth_header(token)
+            .run_async(&app)
+            .await;
+
+        let task_reload = task.reload(app.db()).await?.unwrap();
+        assert_eq!(task_reload.expiration, task.expiration);
+        assert_eq!(task_reload.deleted_at, None);
         assert_not_found!(conn);
         Ok(())
     }


### PR DESCRIPTION
Supports https://github.com/divviup/divviup-api/issues/862.

Two methods are provided.
- `PATCH {task_id}` with one field `expiration` that allows free manipulation of a task's expiration date. As alluded to in https://github.com/divviup/divviup-api/issues/980, there is no semantic validation of the new expiration--this can be set to whatever the user would like. Changes are propagated to the aggregators.
- `DELETE {task_id}` which sets the aggregators' expiration, if not already set and expired, and then tombstones the divviup-api view of the task by setting `deleted_at`. Currently, there is no effect of this flag--all other methods will ignore the deleted_at field.

Note that I'm assuming aggregators need to have support for the missing endpoints, otherwise we explicitly fail. I landed on this because we don't want to 'lie' to the user about deletion/expiration, since active aggregator-side tasks can still process data.

There is still more work to be done, but I'm keeping this PR from getting too long.
- Other existing task endpoints are not aware of the deleted_at field, e.g. listing tasks still presents deleted tasks.
- Need client/CLI support outside of basic definitions.
- Need UI support.