### PR TITLE
Client and CLI support for task expiry and deletion

### DIFF
--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -1,10 +1,13 @@
 use crate::{
     clients::aggregator_client::TaskUploadMetrics,
     config::FeatureFlags,
-    entity::{Account, NewTask, Task, Tasks, UpdateTask},
+    entity::{Account, NewTask, Task, TaskColumn, Tasks, UpdateTask},
     Crypter, Db, Error, Permissions, PermissionsActor,
 };
-use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait, IntoActiveModel, ModelTrait};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, IntoActiveModel, ModelTrait,
+    QueryFilter,
+};
 use std::time::Duration;
 use time::OffsetDateTime;
 use trillium::{Conn, Handler, Status};
@@ -16,6 +19,7 @@ use trillium_router::RouterConnExt;
 pub async fn index(_: &mut Conn, (account, db): (Account, Db)) -> Result<impl Handler, Error> {
     account
         .find_related(Tasks)
+        .filter(TaskColumn::DeletedAt.is_null())
         .all(&db)
         .await
         .map(Json)


### PR DESCRIPTION
Stacked on https://github.com/divviup/divviup-api/pull/982.

Supports https://github.com/divviup/divviup-api/issues/862.

Straightforward plumbing of expiration and deletion through to the client and CLI.