### PR TITLE
Import default exports under the same names

### DIFF
--- a/app/src/aggregators/index.tsx
+++ b/app/src/aggregators/index.tsx
@@ -1,5 +1,5 @@
 import Aggregators from "./AggregatorList";
-import AggregatorForm from "./AggregatorForm";
+import AggregatorFormPage from "./AggregatorForm";
 import AggregatorDetail from "./AggregatorDetail";
 import ApiClient from "../ApiClient";
 import { RouteObject, defer, redirect } from "react-router-dom";
@@ -48,7 +48,7 @@ export default function aggregators(apiClient: ApiClient): RouteObject {
 
       {
         path: "new",
-        element: <AggregatorForm />,
+        element: <AggregatorFormPage />,
       },
     ],
   };

--- a/app/src/api-tokens/index.tsx
+++ b/app/src/api-tokens/index.tsx
@@ -1,6 +1,6 @@
 import { RouteObject, defer } from "react-router-dom";
 import ApiClient from "../ApiClient";
-import ApiTokenList from "./ApiTokenList";
+import ApiTokens from "./ApiTokenList";
 
 export default function apiTokens(apiClient: ApiClient): RouteObject {
   return {
@@ -9,7 +9,7 @@ export default function apiTokens(apiClient: ApiClient): RouteObject {
       {
         path: "",
         index: true,
-        element: <ApiTokenList />,
+        element: <ApiTokens />,
         loader({ params }) {
           return defer({
             apiTokens: apiClient

--- a/app/src/collector-credentials/index.tsx
+++ b/app/src/collector-credentials/index.tsx
@@ -1,6 +1,6 @@
 import { RouteObject, defer } from "react-router-dom";
 import ApiClient from "../ApiClient";
-import CollectorCredentialList from "./CollectorCredentialList";
+import CollectorCredentials from "./CollectorCredentialList";
 export default function collectorCredentials(
   apiClient: ApiClient,
 ): RouteObject {
@@ -10,7 +10,7 @@ export default function collectorCredentials(
       {
         path: "",
         index: true,
-        element: <CollectorCredentialList />,
+        element: <CollectorCredentials />,
         loader({ params }) {
           return defer({
             collectorCredentials: apiClient.accountCollectorCredentials(

--- a/app/src/tasks/index.tsx
+++ b/app/src/tasks/index.tsx
@@ -1,4 +1,4 @@
-import TaskList from "./TaskList";
+import AccountDetailFull from "./TaskList";
 import TaskForm from "./TaskForm";
 import TaskDetail from "./TaskDetail";
 import ApiClient from "../ApiClient";
@@ -11,7 +11,7 @@ export default function tasks(apiClient: ApiClient): RouteObject {
       {
         path: "",
         index: true,
-        element: <TaskList />,
+        element: <AccountDetailFull />,
         loader({ params }) {
           return defer({
             tasks: apiClient.accountTasks(params.accountId as string),


### PR DESCRIPTION
I went through all the default exports, and made sure they were imported under the same name they had upon definition. There were four places that needed correcting.