### PR TITLE
Fix extra renders from closures in components

### DIFF
--- a/app/src/accounts/NextSteps/index.tsx
+++ b/app/src/accounts/NextSteps/index.tsx
@@ -12,6 +12,7 @@ import AggregatorTypeSelection from "./AggregatorTypeSelection";
 import InlineCollectorCredentials from "./InlineCollectorCredentials";
 import { usePromise, usePromiseAll } from "../../util";
 import css from "./index.module.css";
+import { useCallback } from "react";
 
 const STEPS = [
   { label: "Create account" },
@@ -66,8 +67,11 @@ export default function NextSteps() {
   const loadedTasks = usePromise(tasks, []);
   const activeIndex = usePromiseAll(
     [account, collectorCredentials, aggregators],
-    ([account, collectorCredentials, aggregators]) =>
-      determineModel({ account, collectorCredentials, aggregators }),
+    useCallback(
+      ([account, collectorCredentials, aggregators]) =>
+        determineModel({ account, collectorCredentials, aggregators }),
+      [],
+    ),
     1,
   );
 

--- a/app/src/tasks/TaskDetail/ClientConfig.tsx
+++ b/app/src/tasks/TaskDetail/ClientConfig.tsx
@@ -7,6 +7,7 @@ import "@github/relative-time-element";
 import { Copy, OutLink, usePromiseAll } from "../../util";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { github as syntaxStyle } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { useCallback } from "react";
 
 export default function ClientConfig() {
   return (
@@ -45,13 +46,16 @@ function TsClientConfig() {
 
   const taskConfig = usePromiseAll(
     [task, leaderAggregator, helperAggregator],
-    ([task, leader, helper]) => ({
-      ...task.vdaf,
-      id: task.id,
-      leader: leader.dap_url,
-      helper: helper.dap_url,
-      timePrecisionSeconds: task.time_precision_seconds,
-    }),
+    useCallback(
+      ([task, leader, helper]) => ({
+        ...task.vdaf,
+        id: task.id,
+        leader: leader.dap_url,
+        helper: helper.dap_url,
+        timePrecisionSeconds: task.time_precision_seconds,
+      }),
+      [],
+    ),
     {
       type: null,
       id: null,

--- a/app/src/util.tsx
+++ b/app/src/util.tsx
@@ -140,6 +140,18 @@ function useArray<T extends unknown[]>(input: T): T {
   }
 }
 
+/**
+ * This custom hook allows using the results of multiple futures. At first, the
+ * initial value is returned. Once all futures are ready, their resolved values
+ * are passed to the `then` function, and the result is returned.
+ *
+ * Note that the `then function should be either defined outside of any render
+ * function or passed through `useCallback()`, to avoid spurious renders.
+ * @param promises Array of promises
+ * @param then Function
+ * @param initialState Value to be returned until futures are resolved
+ * @returns `initialState` or output of `then`
+ */
 export function usePromiseAll<U, T extends unknown[]>(
   promises: [...T],
   then: (arr: { [P in keyof T]: Awaited<T[P]> }) => U | PromiseLike<U>,


### PR DESCRIPTION
I loaded the task detail page with React Developer Tools enabled, and I noticed that the `TsClientConfig` component was re-rendering every frame. This was ultimately because we were constructing lambda functions within a render function, and passing it to the dependency list of useMemo (inside usePromiseAll). This PR fixes the issue by memoizing both `then` functions passed to usePromiseAll. I also added some documentation to usePromiseAll to explain the referential identity requirement on `then`.

This fixes the issue identified in #1000.