### PR TITLE
Template API URL into divviup CLI command line

### DIFF
--- a/app/src/ApiClient.ts
+++ b/app/src/ApiClient.ts
@@ -218,6 +218,10 @@ export class ApiClient {
     });
   }
 
+  async apiUrl(): Promise<string> {
+    return (await this.#client).getUri({ url: "/" });
+  }
+
   async loginUrl(): Promise<string> {
     return (await this.#client).getUri({ url: "/login" });
   }

--- a/app/src/accounts/NextSteps/InlineCollectorCredentials.tsx
+++ b/app/src/accounts/NextSteps/InlineCollectorCredentials.tsx
@@ -11,7 +11,10 @@ import {
   Icon3CircleFill,
   Clipboard,
 } from "react-bootstrap-icons";
-import { Copy, OutLink } from "../../util";
+import { Copy, OutLink, usePromise } from "../../util";
+
+/** This matches the default value of DIVVIUP_API_URL in the divviup CLI tool. */
+const DEFAULT_API_URL = "https://api.divviup.org/";
 
 function SaveApiToken({ onToken }: { onToken: (token: string) => void }) {
   const fetcher = useFetcher<ApiToken & { token: string }>();
@@ -83,6 +86,7 @@ export default function InlineCollectorCredentials() {
 
   const [token, setToken] = React.useState<string>("«TOKEN»");
   const { revalidate, state } = useRevalidator();
+  const apiUrl = usePromise(apiClient.apiUrl(), DEFAULT_API_URL);
 
   if (anyCollectorCredentials) {
     return (
@@ -94,7 +98,10 @@ export default function InlineCollectorCredentials() {
       </>
     );
   } else {
-    const command = `divviup -t ${token} collector-credential generate`;
+    const command =
+      apiUrl == DEFAULT_API_URL
+        ? `divviup -t ${token} collector-credential generate`
+        : `divviup -u ${apiUrl} -t ${token} collector-credential generate`;
     return (
       <>
         <ol className="list-unstyled">


### PR DESCRIPTION
This adjusts the command line provided during new account setup to work on non-production instances by including the correct API URL.