### PR TITLE
cli: add README and dap-client command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,9 +2478,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "janus_client"
-version = "0.7.7"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c8a13740bd57acdc3a8845ec19c8bf78af287b6f0a01545ab7a129699595a6"
+checksum = "30392863ebd2497392a8812d3a38b6459c085faa1f7c4b7d3b412283325f2cae"
 dependencies = [
  "backoff",
  "derivative",
@@ -2499,13 +2499,13 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.7.7"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1ccc1f0f1b79b4ee9732a0be2c75044c8c036a7ce65d8e540e7c0a4862465e"
+checksum = "2cbf2542b225bed780bac2ba3a1bfa58f48aefade41cad257b01426e74287e31"
 dependencies = [
  "anyhow",
  "backoff",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",
@@ -2532,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.7.7"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c6c35fffd82f3c0d43560d2e635ed5e34353c2713d33dee3948e195c5e2fb3"
+checksum = "882ee3aca1e6af36824aba8044315ef563734387d63a2b1d80dc5fbe450fb05a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3624,7 +3624,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,7 @@ dependencies = [
 name = "divviup-cli"
 version = "0.3.7"
 dependencies = [
+ "anyhow",
  "base64 0.22.1",
  "clap",
  "colored",
@@ -1464,6 +1465,7 @@ dependencies = [
  "hpke-dispatch",
  "humantime",
  "janus_client",
+ "janus_collector",
  "janus_messages",
  "prio",
  "rand",
@@ -1491,6 +1493,7 @@ dependencies = [
  "janus_messages",
  "log",
  "pad-adapter",
+ "prio",
  "serde",
  "serde_json",
  "test-support",
@@ -2491,6 +2494,30 @@ dependencies = [
  "prio",
  "rand",
  "reqwest",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "janus_collector"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0cec6e61077ad921a4f772aaed5579e38dd3b04c42aa870449437f2c8504960"
+dependencies = [
+ "backoff",
+ "chrono",
+ "derivative",
+ "hpke-dispatch",
+ "janus_core",
+ "janus_messages",
+ "prio",
+ "rand",
+ "reqwest",
+ "retry-after",
+ "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -3657,6 +3684,17 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.26.1",
  "winreg",
+]
+
+[[package]]
+name = "retry-after"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a2a3fe45c9b89f416bc92174669d954594e152d158df845e6df173a9b7aed4"
+dependencies = [
+ "chrono",
+ "http 1.1.0",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,9 +532,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -558,8 +558,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -571,6 +571,20 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
@@ -896,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.32"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41daef31d7a747c5c847246f36de49ced6f7403b4cdabc807a97b5cc184cda7a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1449,14 +1463,19 @@ dependencies = [
  "env_logger",
  "hpke-dispatch",
  "humantime",
+ "janus_client",
+ "janus_messages",
+ "prio",
  "rand",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
  "time",
+ "tokio",
  "trillium-rustls",
  "trillium-tokio",
+ "url",
 ]
 
 [[package]]
@@ -1760,6 +1779,7 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1989,7 +2009,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.1",
  "slab",
  "tokio",
@@ -2162,13 +2182,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-api-problem"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bfa6ba9e2d8cf5299faf4721520ff7997989431d2c8fdf702eb8b1a4313b625"
+dependencies = [
+ "http 1.1.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2201,8 +2266,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2215,15 +2280,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2326,6 +2447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,10 +2477,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "janus_messages"
-version = "0.7.16"
+name = "janus_client"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ee3aca1e6af36824aba8044315ef563734387d63a2b1d80dc5fbe450fb05a"
+checksum = "18c8a13740bd57acdc3a8845ec19c8bf78af287b6f0a01545ab7a129699595a6"
+dependencies = [
+ "backoff",
+ "derivative",
+ "http 1.1.0",
+ "itertools 0.12.0",
+ "janus_core",
+ "janus_messages",
+ "prio",
+ "rand",
+ "reqwest",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "janus_core"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a1ccc1f0f1b79b4ee9732a0be2c75044c8c036a7ce65d8e540e7c0a4862465e"
+dependencies = [
+ "anyhow",
+ "backoff",
+ "base64 0.22.0",
+ "bytes",
+ "chrono",
+ "clap",
+ "derivative",
+ "futures",
+ "hex",
+ "hpke-dispatch",
+ "http 1.1.0",
+ "http-api-problem",
+ "janus_messages",
+ "prio",
+ "rand",
+ "regex",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trillium",
+ "url",
+]
+
+[[package]]
+name = "janus_messages"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c6c35fffd82f3c0d43560d2e635ed5e34353c2713d33dee3948e195c5e2fb3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2754,7 +2935,7 @@ dependencies = [
  "base64 0.13.1",
  "chrono",
  "getrandom",
- "http",
+ "http 0.2.12",
  "rand",
  "serde",
  "serde_json",
@@ -2813,7 +2994,7 @@ checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -3438,6 +3619,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.22.4",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.1",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3594,6 +3816,20 @@ dependencies = [
  "ring",
  "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3990,6 +4226,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -4707,6 +4955,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4760,9 +5019,9 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4787,9 +5046,9 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5048,7 +5307,7 @@ dependencies = [
  "encoding_rs",
  "futures-lite 2.3.0",
  "hashbrown 0.14.3",
- "http",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "log",
@@ -5760,6 +6019,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ name = "divviup"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 thiserror = "1.0.61"
 divviup-client = { workspace = true }
@@ -40,6 +41,7 @@ const_format = "0.2.32"
 hpke-dispatch = { version = "0.5.1", features = ["serde"], optional = true }
 rand = { version = "0.8.5", optional = true }
 janus_client = "0.7.11"
+janus_collector = "0.7.11"
 url = "2.5.0"
 janus_messages = "0.7.11"
 prio = "0.16.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,4 +39,8 @@ colored = "2.1.0"
 const_format = "0.2.32"
 hpke-dispatch = { version = "0.5.1", features = ["serde"], optional = true }
 rand = { version = "0.8.5", optional = true }
+janus_client = "0.7.7"
+url = "2.5.0"
+janus_messages = "0.7.7"
+prio = "0.16.3"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,8 +39,8 @@ colored = "2.1.0"
 const_format = "0.2.32"
 hpke-dispatch = { version = "0.5.1", features = ["serde"], optional = true }
 rand = { version = "0.8.5", optional = true }
-janus_client = "0.7.7"
+janus_client = "0.7.11"
 url = "2.5.0"
-janus_messages = "0.7.7"
+janus_messages = "0.7.11"
 prio = "0.16.3"
-
+tokio = { version = "1.37.0" }

--- a/cli/README.md
+++ b/cli/README.md
@@ -122,7 +122,7 @@ export COLLECTOR_CREDENTIAL_PATH=/your/current/directory/collector-credential-<s
 export COLLECTOR_ID=0a0f8ea8-b603-4416-b138-b7f217153bb7
 ```
 
-Create the the histogram task. In this case the task is a set of values from 0 to 10 for use in collecting an net-promoter score for a survey.
+Create the the histogram task. In this case the task is a set of values from 0 to 10 for use in collecting a net-promoter score for a survey.
 
 ```sh
  divviup task create --name net-promoter-score \

--- a/cli/README.md
+++ b/cli/README.md
@@ -7,19 +7,19 @@
 First, set an environment variable for the Divvi Up account and an API token. The initial token will be created when an account is created.
 
 ```
-export TOKEN=YOUR_TOKEN_HERE
+export DIVVIUP_TOKEN=YOUR_TOKEN_HERE
 ```
 
 Test the token by listing all accounts.
 
 ```
-divviup --token $TOKEN account list
+divviup account list
 ```
 
 List the aggregators and identify the ID of both a leader and a helper.
 
 ```
-divviup --token $TOKEN aggregator list
+divviup aggregator list
 ```
 
 ```
@@ -87,7 +87,7 @@ export HELPERID=96301951-c848-4a57-b4f5-32812e4db1be
 Next, generate a collector-credential for the task. The collector credential will be used by the collector to export the aggregated statistics.
 
 ```
-divviup --token $TOKEN collector-credential generate
+divviup collector-credential generate --save
 ```
 
 ```
@@ -129,7 +129,7 @@ export COLLECTORID=0a0f8ea8-b603-4416-b138-b7f217153bb7
 Create the the histogram task. In this case the task is a set of values from 0 to 10 for use in collecting an net-promoter score for a survey.
 
 ```
- divviup --token $TOKEN task create --name net-promoter-score \
+ divviup task create --name net-promoter-score \
  --leader-aggregator-id $LEADERID --helper-aggregator-id $HELPERID \
  --collector-credential-id $COLLECTORID \
  --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
@@ -191,7 +191,7 @@ Upload a random set of 150 metrics.
 ```
 for i in {1..150}; do
   value=$(( $RANDOM % 10 ))
-  divviup dap-client --task-id $TASKID --vdaf histogram --value 7
+  divviup dap-client upload --task-id $TASKID  --value $value;
 done
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 ## divviup - the Divvi Up command line tool
 
-`divviup` is a command line (CLI) tool for doing all basic operations on both the Divvi Up API and Distributed Aggregation Protocol (DAP) API endpoints. See `divviup --help` for details on all of the commands.
+`divviup` is a command line (CLI) tool for doing all basic operations on both the Divvi Up API and Distributed Aggregation Protocol (DAP) API endpoints. It's only likely to work if the leader aggregator is [Janus](https://github.com/divviup/janus). See `divviup --help` for details on all of the commands.
 
 ### Command Line Tutorial
 
@@ -194,6 +194,8 @@ for i in {1..150}; do
   divviup dap-client upload --task-id $TASKID  --value $value;
 done
 ```
+
+TODO(timg) fill in guide for collecting aggregate result
 
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,25 +4,27 @@
 
 ### Command Line Tutorial
 
-First, set an environment variable for the Divvi Up account and an API token. The initial token will be created when an account is created.
+First, set an environment variable for the Divvi Up account and an API token. You can create an API token by logging into the [Divvi Up console](https://app.divviup.org).
 
-```
+```sh
 export DIVVIUP_TOKEN=YOUR_TOKEN_HERE
 ```
 
-Test the token by listing all accounts.
+Test the token by listing all accounts. Your account ID is inferred from the token.
 
-```
+```sh
 divviup account list
 ```
 
 List the aggregators and identify the ID of both a leader and a helper.
 
-```
+```sh
 divviup aggregator list
 ```
 
-```
+The output will contain JSON objects like:
+
+```json
   {
     "id": "3650870b-56e6-4eac-8944-b7ca36569b33",
     "role": "Either",
@@ -79,18 +81,20 @@ divviup aggregator list
 
 Set the two IDs into environment variables. NOTE: These IDs will vary based on your configuration.
 
-```
-export LEADERID=3650870b-56e6-4eac-8944-b7ca36569b33
-export HELPERID=96301951-c848-4a57-b4f5-32812e4db1be
+```sh
+export LEADER_ID=3650870b-56e6-4eac-8944-b7ca36569b33
+export HELPER_ID=96301951-c848-4a57-b4f5-32812e4db1be
 ```
 
 Next, generate a collector-credential for the task. The collector credential will be used by the collector to export the aggregated statistics.
 
-```
+```sh
 divviup collector-credential generate --save
 ```
 
-```
+The output will be like:
+
+```sh
 {
   "id": "0a0f8ea8-b603-4416-b138-b7f217153bb7",
   "hpke_config": {
@@ -108,35 +112,29 @@ divviup collector-credential generate --save
   "token": "A6JDAYPiYDXmNyh-OpYXGw"
 }
 
-New collector credential generated. Copy and paste the following text into a file or your password manager:
-{
-  "aead": "AesGcm128",
-  "id": 144,
-  "kdf": "Sha256",
-  "kem": "X25519HkdfSha256",
-  "private_key": "SECRETS",
-  "public_key": "V9IpdJxS91MHPiNTjwDk9DFS-5M_neVrPxlmvolmTTo",
-  "token": "A6JDAYPiYDXmNyh-OpYXGw"
-}
+Saved new collector credential to /your/current/directory/collector-credential-<some-number>.json. Keep this file safe!
 ```
 
-Save the collector credential ID to an environment variable.
+Make a note of the path where the credential was saved, and save the collector credential ID to an environment variable.
 
-```
-export COLLECTORID=0a0f8ea8-b603-4416-b138-b7f217153bb7
+```sh
+export COLLECTOR_CREDENTIAL_PATH=/your/current/directory/collector-credential-<some-number>.json
+export COLLECTOR_ID=0a0f8ea8-b603-4416-b138-b7f217153bb7
 ```
 
 Create the the histogram task. In this case the task is a set of values from 0 to 10 for use in collecting an net-promoter score for a survey.
 
-```
+```sh
  divviup task create --name net-promoter-score \
- --leader-aggregator-id $LEADERID --helper-aggregator-id $HELPERID \
- --collector-credential-id $COLLECTORID \
- --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
- --min-batch-size 100 --max-batch-size 200 --time-precision 60sec
+    --leader-aggregator-id $LEADER_ID --helper-aggregator-id $HELPER_ID \
+    --collector-credential-id $COLLECTOR_ID \
+    --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
+    --min-batch-size 100 --max-batch-size 200 --time-precision 60sec
 ```
 
-```
+The output will contain a JSON object:
+
+```json
 {
   "id": "Siwa4QTEnQXMfRPyhir8AzS4EBqfTebmEzKfvajDgYk",
   "account_id": "a9c571ba-5f3d-4814-8d8b-c5bb0f5030b7",
@@ -182,27 +180,37 @@ Create the the histogram task. In this case the task is a set of values from 0 t
 
 Save the ID of the task into an environment variable.
 
-```
-export TASKID=Siwa4QTEnQXMfRPyhir8AzS4EBqfTebmEzKfvajDgYk
+```sh
+export TASK_ID=Siwa4QTEnQXMfRPyhir8AzS4EBqfTebmEzKfvajDgYk
 ```
 
 Upload a random set of 150 metrics.
 
-```
+```sh
 for i in {1..150}; do
-  value=$(( $RANDOM % 10 ))
-  divviup dap-client upload --task-id $TASKID  --value $value;
+  measurement=$(( $RANDOM % 10 ))
+  divviup dap-client upload --task-id $TASK_ID  --measurement $measurement;
 done
 ```
 
-TODO(timg) fill in guide for collecting aggregate result
+Wait a little while to let the aggregators run the aggregation jobs. Then, get collection results:
 
+```sh
+divviup dap-client collect \
+    --task-id $TASK_ID \
+    --collector-credential-file $COLLECTOR_CREDENTIAL_PATH \
+    --current-batch
 ```
 
+You will get a result like:
+
+```sh
+Number of reports: 113
+Interval start: 2024-06-05 21:31:00 UTC
+Interval end: 2024-06-05 21:34:00 UTC
+Interval length: 180s
+Aggregation result: [14, 10, 10, 13, 13, 8, 16, 13, 9, 7, 0]
+collection: Collection { partial_batch_selector: PartialBatchSelector { batch_identifier: BatchId(wPLBlC6iHWp_YBBAYP_ig5nal0FOz1QlLSaC42U7sm0) }, report_count: 113, interval: (2024-06-05T21:31:00Z, TimeDelta { secs: 180, nanos: 0 }), aggregate_result: [14, 10, 10, 13, 13, 8, 16, 13, 9, 7, 0] }
 ```
 
-
-```
-./target/debug/collect  --task-id rc0jgm1MHH6Q7fcI4ZdNUxas9DAYLcJFK5CL7xUl-gU --leader https://staging-dap-09-2.api.divviup.org/ --length 12  --vdaf histogram  --collector-credential-file ~/collector.json  --current-batch
-```
-
+If you get fewer reports in the collection than you uploaded, that's because you sent the collection request too soon and not all the reports were prepared yet. Those reports will be available in a later collection, after enough additional reports are uploaded to meet the minimum batch size.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,206 @@
+## divviup - the Divvi Up command line tool
+
+`divviup` is a command line (CLI) tool for doing all basic operations on both the Divvi Up API and Distributed Aggregation Protocol (DAP) API endpoints. See `divviup --help` for details on all of the commands.
+
+### Command Line Tutorial
+
+First, set an environment variable for the Divvi Up account and an API token. The initial token will be created when an account is created.
+
+```
+export TOKEN=YOUR_TOKEN_HERE
+```
+
+Test the token by listing all accounts.
+
+```
+divviup --token $TOKEN account list
+```
+
+List the aggregators and identify the ID of both a leader and a helper.
+
+```
+divviup --token $TOKEN aggregator list
+```
+
+```
+  {
+    "id": "3650870b-56e6-4eac-8944-b7ca36569b33",
+    "role": "Either",
+    "name": "Divvi Up staging-dap-09-1",
+    "dap_url": "https://staging-dap-09-1.api.example.com/",
+    "api_url": "https://staging-dap-09-1.api.example.com/aggregator-api",
+    "is_first_party": true,
+    "vdafs": [
+      "Prio3Count",
+      "Prio3Sum",
+      "Prio3Histogram",
+      "Prio3SumVec"
+    ],
+    "query_types": [
+      "TimeInterval",
+      "FixedSize"
+    ],
+    "protocol": "DAP-09",
+    "features": [
+      "TokenHash",
+      "TimeBucketedFixedSize",
+      "UploadMetrics"
+    ]
+  },
+  {
+    "id": "96301951-c848-4a57-b4f5-32812e4db1be",
+    "account_id": null,
+    "created_at": "2024-03-21T22:47:15.467139Z",
+    "updated_at": "2024-04-18T17:33:30.439465Z",
+    "deleted_at": null,
+    "role": "Either",
+    "name": "Divvi Up staging-dap-09-2",
+    "dap_url": "https://staging-dap-09-2.api.example.com/",
+    "api_url": "https://staging-dap-09-2.api.example.com/aggregator-api",
+    "is_first_party": false,
+    "vdafs": [
+      "Prio3Count",
+      "Prio3Sum",
+      "Prio3Histogram",
+      "Prio3SumVec"
+    ],
+    "query_types": [
+      "TimeInterval",
+      "FixedSize"
+    ],
+    "protocol": "DAP-09",
+    "features": [
+      "TokenHash",
+      "UploadMetrics",
+      "TimeBucketedFixedSize"
+    ]
+  }
+```
+
+Set the two IDs into environment variables. NOTE: These IDs will vary based on your configuration.
+
+```
+export LEADERID=3650870b-56e6-4eac-8944-b7ca36569b33
+export HELPERID=96301951-c848-4a57-b4f5-32812e4db1be
+```
+
+Next, generate a collector-credential for the task. The collector credential will be used by the collector to export the aggregated statistics.
+
+```
+divviup --token $TOKEN collector-credential generate
+```
+
+```
+{
+  "id": "0a0f8ea8-b603-4416-b138-b7f217153bb7",
+  "hpke_config": {
+    "id": 144,
+    "kem_id": "X25519HkdfSha256",
+    "kdf_id": "HkdfSha256",
+    "aead_id": "Aes128Gcm",
+    "public_key": "V9IpdJxS91MHPiNTjwDk9DFS-5M_neVrPxlmvolmTTo"
+  },
+  "created_at": "2024-05-03T15:23:56.624726Z",
+  "deleted_at": null,
+  "updated_at": "2024-05-03T15:23:56.624727Z",
+  "name": "collector-credential-144",
+  "token_hash": "VItYJdAyWYIvooe8GzkGnVTvaMkvWc9G-eiwxudfWww",
+  "token": "A6JDAYPiYDXmNyh-OpYXGw"
+}
+
+New collector credential generated. Copy and paste the following text into a file or your password manager:
+{
+  "aead": "AesGcm128",
+  "id": 144,
+  "kdf": "Sha256",
+  "kem": "X25519HkdfSha256",
+  "private_key": "SECRETS",
+  "public_key": "V9IpdJxS91MHPiNTjwDk9DFS-5M_neVrPxlmvolmTTo",
+  "token": "A6JDAYPiYDXmNyh-OpYXGw"
+}
+```
+
+Save the collector credential ID to an environment variable.
+
+```
+export COLLECTORID=0a0f8ea8-b603-4416-b138-b7f217153bb7
+```
+
+Create the the histogram task. In this case the task is a set of values from 0 to 10 for use in collecting an net-promoter score for a survey.
+
+```
+ divviup --token $TOKEN task create --name net-promoter-score \
+ --leader-aggregator-id $LEADERID --helper-aggregator-id $HELPERID \
+ --collector-credential-id $COLLECTORID \
+ --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
+ --min-batch-size 100 --max-batch-size 200 --time-precision 60sec
+```
+
+```
+{
+  "id": "Siwa4QTEnQXMfRPyhir8AzS4EBqfTebmEzKfvajDgYk",
+  "account_id": "a9c571ba-5f3d-4814-8d8b-c5bb0f5030b7",
+  "name": "net-promoter-score",
+  "vdaf": {
+    "type": "histogram",
+    "buckets": [
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10"
+    ],
+    "chunk_length": 4
+  },
+  "min_batch_size": 100,
+  "max_batch_size": null,
+  "created_at": "2024-05-03T15:27:56.229891Z",
+  "updated_at": "2024-05-03T15:27:56.229891Z",
+  "time_precision_seconds": 60,
+  "report_count": 0,
+  "aggregate_collection_count": 0,
+  "expiration": "2025-05-03T15:27:55.88511Z",
+  "leader_aggregator_id": "3650870b-56e6-4eac-8944-b7ca36569b33",
+  "helper_aggregator_id": "96301951-c848-4a57-b4f5-32812e4db1be",
+  "collector_credential_id": "0a0f8ea8-b603-4416-b138-b7f217153bb7",
+  "report_counter_interval_collected": 0,
+  "report_counter_decode_failure": 0,
+  "report_counter_decrypt_failure": 0,
+  "report_counter_expired": 0,
+  "report_counter_outdated_key": 0,
+  "report_counter_success": 0,
+  "report_counter_too_early": 0,
+  "report_counter_task_expired": 0
+}
+```
+
+Save the ID of the task into an environment variable.
+
+```
+export TASKID=Siwa4QTEnQXMfRPyhir8AzS4EBqfTebmEzKfvajDgYk
+```
+
+Upload a random set of 150 metrics.
+
+```
+for i in {1..150}; do
+  value=$(( $RANDOM % 10 ))
+  divviup dap-client --task-id $TASKID --vdaf histogram --value 7
+done
+```
+
+```
+
+```
+
+
+```
+./target/debug/collect  --task-id rc0jgm1MHH6Q7fcI4ZdNUxas9DAYLcJFK5CL7xUl-gU --leader https://staging-dap-09-2.api.divviup.org/ --length 12  --vdaf histogram  --collector-credential-file ~/collector.json  --current-batch
+```
+

--- a/cli/src/dap_client.rs
+++ b/cli/src/dap_client.rs
@@ -1,0 +1,88 @@
+use std::str::FromStr;
+use url::Url;
+
+use janus_client;
+
+use janus_messages::{Duration, TaskId};
+use prio::vdaf::prio3::Prio3Histogram;
+
+use crate::{CliResult, DetermineAccountId, Error, Output};
+use clap::Subcommand;
+use divviup_client::{self, Histogram};
+
+#[derive(Subcommand, Debug)]
+pub enum DapClientAction {
+    /// create a new task for the target account
+    Upload {
+        #[arg(long)]
+        task_id: String,
+        #[arg(long)]
+        value: usize,
+    },
+}
+
+impl DapClientAction {
+    pub(crate) async fn run(
+        self,
+        account_id: DetermineAccountId,
+        client: divviup_client::DivviupClient,
+        _output: Output,
+    ) -> CliResult {
+        let account_id = account_id.await?;
+
+        match self {
+            DapClientAction::Upload { task_id, value } => {
+                let task = client.task(&task_id).await?;
+
+                let aggregators = client.aggregators(account_id).await?;
+
+                let mut leader_url: Option<Url> = None;
+                let mut helper_url: Option<Url> = None;
+
+                for a in &aggregators {
+                    if a.id == task.leader_aggregator_id {
+                        leader_url = Some(a.dap_url.clone());
+                    }
+                    if a.id == task.helper_aggregator_id {
+                        helper_url = Some(a.dap_url.clone());
+                    }
+                }
+                if leader_url.is_none() {
+                    return Err(Error::Other("leader URL unset".into()));
+                }
+                if helper_url.is_none() {
+                    return Err(Error::Other("leader URL unset".into()));
+                }
+
+                match task.vdaf {
+                    divviup_client::Vdaf::Histogram(Histogram::Categorical {
+                        buckets,
+                        chunk_length,
+                    }) => {
+                        let client = janus_client::Client::new(
+                            TaskId::from_str(&task_id).unwrap(),
+                            leader_url.unwrap(),
+                            helper_url.unwrap(),
+                            Duration::from_seconds(task.time_precision_seconds as u64),
+                            Prio3Histogram::new_histogram(
+                                2,
+                                buckets.len(),
+                                chunk_length.unwrap() as usize,
+                            )
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                        client.upload(&value).await.unwrap();
+                        println!("uploaded measurement: {}", &value);
+                    }
+                    _ => {
+                        return Err(Error::Other("No matching VDAF".into()));
+                    }
+                };
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/dap_client.rs
+++ b/cli/src/dap_client.rs
@@ -1,9 +1,126 @@
 use crate::{CliResult, DetermineAccountId, Error};
-use clap::Subcommand;
-use divviup_client::{self, Histogram, Protocol};
-use janus_messages::Duration;
+use anyhow::Context;
+use clap::{ArgAction, Args, Subcommand};
+use divviup_client::{self, Protocol};
+use janus_collector::{Collector, PrivateCollectorCredential};
+use janus_messages::{BatchId, Duration, FixedSizeQuery, Interval, Query, Time};
 use prio::vdaf::prio3::{Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVec};
+use std::{fs::File, io::BufReader, path::PathBuf};
 use tokio::try_join;
+
+macro_rules! query_dispatch {
+    ($query:expr, ($janus_query:ident) => $body:tt) => {
+        match (
+            &$query.batch_interval_start,
+            &$query.batch_interval_duration,
+            &$query.batch_id,
+            $query.current_batch,
+        ) {
+            (Some(batch_interval_start), Some(batch_interval_duration), None, false) => {
+                let $janus_query = Query::new_time_interval(
+                    Interval::new(
+                        Time::from_seconds_since_epoch(*batch_interval_start),
+                        Duration::from_seconds(*batch_interval_duration),
+                    )
+                    .context("illegal time interval")?,
+                );
+                $body
+            }
+            (None, None, Some(batch_id), false) => {
+                let $janus_query = Query::new_fixed_size(FixedSizeQuery::ByBatchId {
+                    batch_id: *batch_id,
+                });
+                $body
+            }
+            (None, None, None, true) => {
+                let $janus_query = Query::new_fixed_size(FixedSizeQuery::CurrentBatch);
+                $body
+            }
+            _ => unreachable!("clap argument parsing shouldn't allow this to be possible"),
+        }
+    };
+}
+
+macro_rules! vdaf_dispatch {
+    ($divviup_vdaf:expr, ($janus_vdaf:ident) => $body:tt) => {
+        match $divviup_vdaf {
+            divviup_client::Vdaf::Count => {
+                let $janus_vdaf = Prio3Count::new_count(2).context("failed to instantiate VDAF")?;
+                $body
+            }
+            divviup_client::Vdaf::Sum { bits } => {
+                let $janus_vdaf =
+                    Prio3Sum::new_sum(2, bits as usize).context("failed to instantiate VDAF")?;
+                $body
+            }
+            divviup_client::Vdaf::SumVec(sum_vec) => {
+                let $janus_vdaf = Prio3SumVec::new_sum_vec(
+                    2,
+                    sum_vec.bits as usize,
+                    sum_vec.length as usize,
+                    sum_vec.chunk_length(),
+                )
+                .context("failed to instantiate VDAF")?;
+                $body
+            }
+            divviup_client::Vdaf::Histogram(histogram) => {
+                let $janus_vdaf =
+                    Prio3Histogram::new_histogram(2, histogram.length(), histogram.chunk_length())
+                        .context("failed to instantiate VDAF")?;
+                $body
+            }
+            v => {
+                return Err(Error::Other(format!("No matching VDAF {v:?}")));
+            }
+        }
+    };
+}
+
+macro_rules! collect_dispatch {
+    ($vdaf:expr, $divviup_query:expr, ($janus_query:ident, $janus_vdaf:ident) => $body:tt) => {
+        query_dispatch!($divviup_query, ($janus_query) => {
+            vdaf_dispatch!($vdaf, ($janus_vdaf) => {
+                let body = $body;
+                body
+            })
+        })
+    }
+}
+
+#[derive(Debug, Args, PartialEq, Eq)]
+#[group(required = true)]
+pub struct QueryOptions {
+    /// Start of the collection batch interval, as the number of seconds since the Unix epoch
+    #[clap(
+        long,
+        requires = "batch_interval_duration",
+        help_heading = "Collect Request Parameters (Time Interval)"
+    )]
+    batch_interval_start: Option<u64>,
+    /// Duration of the collection batch interval, in seconds
+    #[clap(
+        long,
+        requires = "batch_interval_start",
+        help_heading = "Collect Request Parameters (Time Interval)"
+    )]
+    batch_interval_duration: Option<u64>,
+
+    /// Batch identifier, encoded with base64url
+    #[clap(
+        long,
+        conflicts_with_all = ["batch_interval_start", "batch_interval_duration", "current_batch"],
+        help_heading = "Collect Request Parameters (Fixed Size)",
+    )]
+    batch_id: Option<BatchId>,
+    /// Have the aggregator select a batch that has not yet been collected
+    #[clap(
+        long,
+        action = ArgAction::SetTrue,
+        conflicts_with_all = ["batch_interval_start", "batch_interval_duration", "batch_id"],
+        help_heading = "Collect Request Parameters (Fixed Size)",
+    )]
+    current_batch: bool,
+}
 
 #[derive(Subcommand, Debug)]
 pub enum DapClientAction {
@@ -16,6 +133,21 @@ pub enum DapClientAction {
         #[arg(long)]
         measurement: String,
     },
+    /// collect an aggregate result
+    Collect {
+        /// DAP task to collect from, as an unpadded Base64, URL-safe encoded string.
+        #[arg(long)]
+        task_id: String,
+
+        /// Path to a file containing private collector credentials.
+        ///
+        /// This can be obtained with the command `divviup collector-credential generate`.
+        #[clap(long, default_value = "./collector-credential.json")]
+        collector_credential_file: PathBuf,
+
+        #[clap(flatten)]
+        query: QueryOptions,
+    },
 }
 
 impl DapClientAction {
@@ -26,145 +158,130 @@ impl DapClientAction {
     ) -> CliResult {
         let account_id = account_id.await?;
 
-        match self {
-            DapClientAction::Upload {
-                task_id,
-                measurement,
-            } => {
-                let (task, aggregators) =
-                    try_join!(client.task(&task_id), client.aggregators(account_id))?;
+        let task_id = match self {
+            DapClientAction::Upload { ref task_id, .. } => task_id,
+            DapClientAction::Collect { ref task_id, .. } => task_id,
+        };
 
-                if !aggregators.iter().all(|a| a.protocol == Protocol::Dap09) {
-                    return Err(Error::Other("unable to handle protocol version".into()));
-                }
+        let (task, aggregators) = try_join!(client.task(task_id), client.aggregators(account_id))?;
+        let task_id = task_id.parse().context("failed to parse task ID")?;
+        let time_precision = Duration::from_seconds(task.time_precision_seconds as u64);
 
-                let leader_url = aggregators
-                    .iter()
-                    .find(|a| a.id == task.leader_aggregator_id)
-                    .map(|a| a.dap_url.clone())
-                    .ok_or_else(|| Error::Other("leader URL unset".into()))?;
+        let (leader_url, leader_protocol) = aggregators
+            .iter()
+            .find(|a| a.id == task.leader_aggregator_id)
+            .map(|a| (a.dap_url.clone(), a.protocol))
+            .ok_or_else(|| Error::Other("leader URL unset".into()))?;
 
-                let helper_url = aggregators
-                    .iter()
-                    .find(|a| a.id == task.helper_aggregator_id)
-                    .map(|a| a.dap_url.clone())
-                    .ok_or_else(|| Error::Other("helper URL unset".into()))?;
+        let (helper_url, helper_protocol) = aggregators
+            .iter()
+            .find(|a| a.id == task.helper_aggregator_id)
+            .map(|a| (a.dap_url.clone(), a.protocol))
+            .ok_or_else(|| Error::Other("helper URL unset".into()))?;
 
-                match task.vdaf {
-                    divviup_client::Vdaf::Count => {
-                        let client = janus_client::Client::new(
-                            task_id.parse()?,
-                            leader_url,
-                            helper_url,
-                            Duration::from_seconds(task.time_precision_seconds as u64),
-                            Prio3Count::new_count(2)?,
-                        )
-                        .await?;
-                        let v = measurement.parse().map_err(|e| {
-                            Error::Other(format!("cannot parse measurement as boolean: {e:?}"))
-                        })?;
-                        client.upload(&v).await?;
-                    }
-                    divviup_client::Vdaf::Sum { bits } => {
-                        let client = janus_client::Client::new(
-                            task_id.parse()?,
-                            leader_url,
-                            helper_url,
-                            Duration::from_seconds(task.time_precision_seconds as u64),
-                            Prio3Sum::new_sum(2, bits as usize)?,
-                        )
-                        .await?;
-                        let v = measurement.parse().map_err(|e| {
-                            Error::Other(format!("cannot parse measurement as number: {e:?}"))
-                        })?;
-                        client.upload(&v).await?;
-                    }
-                    divviup_client::Vdaf::SumVec {
-                        bits,
-                        length,
-                        chunk_length,
-                    } => {
-                        // Chunk length should always be set for DAP-09 tasks
-                        let chunk_length = chunk_length.ok_or_else(|| {
-                            Error::Other(
-                                "task's VDAF configuration does not provide a chunk length".into(),
-                            )
-                        })?;
-                        let client = janus_client::Client::new(
-                            task_id.parse()?,
-                            leader_url,
-                            helper_url,
-                            Duration::from_seconds(task.time_precision_seconds as u64),
-                            Prio3SumVec::new_sum_vec(
-                                2,
-                                bits as usize,
-                                length as usize,
-                                chunk_length as usize,
-                            )?,
-                        )
-                        .await?;
-                        let v = measurement
-                            .split(',')
-                            .map(|s| s.trim().parse())
-                            .collect::<Result<_, _>>()
-                            .map_err(|e| {
-                                Error::Other(format!("cannot parse measurement as number: {e:?}"))
-                            })?;
-                        client.upload(&v).await?;
-                    }
-                    divviup_client::Vdaf::Histogram(Histogram::Categorical {
-                        buckets,
-                        chunk_length,
-                    }) => {
-                        // Chunk length should always be set for DAP-09 tasks
-                        let chunk_length = chunk_length.ok_or_else(|| {
-                            Error::Other(
-                                "task's VDAF configuration does not provide a chunk length".into(),
-                            )
-                        })?;
-                        let client = janus_client::Client::new(
-                            task_id.parse()?,
-                            leader_url,
-                            helper_url,
-                            Duration::from_seconds(task.time_precision_seconds as u64),
-                            Prio3Histogram::new_histogram(2, buckets.len(), chunk_length as usize)?,
-                        )
-                        .await?;
-                        let v = measurement.parse().map_err(|e| {
-                            Error::Other(format!("cannot parse measurement as number: {e:?}"))
-                        })?;
-                        client.upload(&v).await?;
-                    }
-                    divviup_client::Vdaf::Histogram(Histogram::Continuous {
-                        buckets,
-                        chunk_length,
-                    }) => {
-                        // Chunk length should always be set for DAP-09 tasks
-                        let chunk_length = chunk_length.ok_or_else(|| {
-                            Error::Other(
-                                "task's VDAF configuration does not provide a chunk length".into(),
-                            )
-                        })?;
-                        let client = janus_client::Client::new(
-                            task_id.parse()?,
-                            leader_url,
-                            helper_url,
-                            Duration::from_seconds(task.time_precision_seconds as u64),
-                            Prio3Histogram::new_histogram(2, buckets.len(), chunk_length as usize)?,
-                        )
-                        .await?;
-                        let v = measurement.parse().map_err(|e| {
-                            Error::Other(format!("cannot parse measurement as number: {e:?}"))
-                        })?;
-                        client.upload(&v).await?;
-                    }
-                    _ => {
-                        return Err(Error::Other("No matching VDAF".into()));
-                    }
-                };
-            }
+        if ![leader_protocol, helper_protocol]
+            .iter()
+            .all(|p| p == &Protocol::Dap09)
+        {
+            return Err(Error::Other("unable to handle protocol version".into()));
         }
 
-        Ok(())
+        match self {
+            DapClientAction::Upload { measurement, .. } => {
+                vdaf_dispatch!(task.vdaf, (janus_vdaf) => {
+                    let v = janus_vdaf.parse_measurement(measurement).context("failed to parse measurement")?;
+                    let client = janus_client::Client::new(
+                        task_id,
+                        leader_url,
+                        helper_url,
+                        time_precision,
+                        janus_vdaf,
+                    )
+                    .await
+                    .context("failed to instantiate client")?;
+                    Ok(client.upload(&v).await.context("failed to upload")?)
+                })
+            }
+            DapClientAction::Collect {
+                collector_credential_file,
+                query,
+                ..
+            } => {
+                let credential: PrivateCollectorCredential =
+                    serde_json::from_reader(BufReader::new(File::open(collector_credential_file)?))
+                        .context("failed to load collector credential")?;
+                collect_dispatch!(task.vdaf, query, (janus_query, janus_vdaf) => {
+                    let collector = Collector::new(
+                        task_id,
+                        leader_url,
+                        credential.authentication_token(),
+                        credential.hpke_keypair(),
+                        janus_vdaf
+                    ).context("failed to instantiate collector")?;
+                    let collection = collector.collect(
+                        janus_query,
+                        // For now, we only support Prio VDAFs and thus always use () as the
+                        // aggregation parameter
+                        &()
+                    ).await.context("failed to run collection job")?;
+
+                    let (start, duration) = collection.interval();
+                    println!("Number of reports: {}", collection.report_count());
+                    println!("Interval start: {}", start);
+                    println!("Interval end: {}", *start + *duration);
+                    println!(
+                        "Interval length: {:?}",
+                        // `std::time::Duration` has the most human-readable debug print for a Duration.
+                        duration.to_std().map_err(|err| Error::Anyhow(err.into()))?
+                    );
+                    println!("Aggregation result: {:?}", collection.aggregate_result());
+                    println!("collection: {collection:?}");
+
+                    Ok(())
+                })
+            }
+        }
+    }
+}
+
+trait ParseMeasurement: prio::vdaf::Vdaf {
+    fn parse_measurement<I: AsRef<str>>(&self, measurement: I) -> CliResult<Self::Measurement>;
+}
+
+impl ParseMeasurement for Prio3Count {
+    fn parse_measurement<I: AsRef<str>>(&self, measurement: I) -> CliResult<Self::Measurement> {
+        Ok(measurement
+            .as_ref()
+            .parse()
+            .context("failed to parse measurement")?)
+    }
+}
+
+impl ParseMeasurement for Prio3Sum {
+    fn parse_measurement<I: AsRef<str>>(&self, measurement: I) -> CliResult<Self::Measurement> {
+        Ok(measurement
+            .as_ref()
+            .parse()
+            .context("failed to parse measurement")?)
+    }
+}
+
+impl ParseMeasurement for Prio3SumVec {
+    fn parse_measurement<I: AsRef<str>>(&self, measurement: I) -> CliResult<Self::Measurement> {
+        Ok(measurement
+            .as_ref()
+            .split(',')
+            .map(|s| s.trim().parse())
+            .collect::<Result<_, _>>()
+            .context("failed to parse measurement")?)
+    }
+}
+
+impl ParseMeasurement for Prio3Histogram {
+    fn parse_measurement<I: AsRef<str>>(&self, measurement: I) -> CliResult<Self::Measurement> {
+        Ok(measurement
+            .as_ref()
+            .parse()
+            .context("failed to parse measurement")?)
     }
 }

--- a/cli/src/dap_client.rs
+++ b/cli/src/dap_client.rs
@@ -235,7 +235,7 @@ impl DapClientAction {
                         duration.to_std().map_err(|err| Error::Anyhow(err.into()))?
                     );
                     println!("Aggregation result: {:?}", collection.aggregate_result());
-                    println!("collection: {collection:?}");
+                    println!("Collection: {collection:?}");
 
                     Ok(())
                 })

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -155,14 +155,8 @@ pub enum Error {
     #[error(transparent)]
     CodecError(#[from] CodecError),
 
-    #[error("message encoding error: {0}")]
-    JanusMessages(#[from] janus_messages::Error),
-
-    #[error("Janus client error: {0}")]
-    JanusClient(#[from] janus_client::Error),
-
-    #[error("VDAF error: {0}")]
-    Vdaf(#[from] prio::vdaf::VdafError),
+    #[error("{0:?}")]
+    Anyhow(#[from] anyhow::Error),
 }
 
 pub type CliResult<T = ()> = Result<T, Error>;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -154,6 +154,15 @@ pub enum Error {
 
     #[error(transparent)]
     CodecError(#[from] CodecError),
+
+    #[error("message encoding error: {0}")]
+    JanusMessages(#[from] janus_messages::Error),
+
+    #[error("Janus client error: {0}")]
+    JanusClient(#[from] janus_client::Error),
+
+    #[error("VDAF error: {0}")]
+    Vdaf(#[from] prio::vdaf::VdafError),
 }
 
 pub type CliResult<T = ()> = Result<T, Error>;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,6 +13,7 @@ mod accounts;
 mod aggregators;
 mod api_tokens;
 mod collector_credentials;
+mod dap_client;
 mod memberships;
 mod tasks;
 
@@ -23,6 +24,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use collector_credentials::CollectorCredentialAction;
 use colored::Colorize;
 use const_format::concatcp;
+use dap_client::DapClientAction;
 use divviup_client::{Client, CodecError, DivviupClient, HeaderValue, KnownHeaderName, Url, Uuid};
 use memberships::MembershipAction;
 use serde::Serialize;
@@ -115,6 +117,10 @@ enum Resource {
     /// privacy-preserving metrics in the divviup system
     #[command(subcommand)]
     Task(TaskAction),
+
+    /// DAP client to upload metrics
+    #[command(subcommand)]
+    DapClient(DapClientAction),
 
     /// dap servers that have been paired to divviup for your account
     #[command(subcommand)]
@@ -220,6 +226,7 @@ impl Resource {
             Resource::Account(action) => action.run(account_id, client, output).await,
             Resource::ApiToken(action) => action.run(account_id, client, output).await,
             Resource::Task(action) => action.run(account_id, client, output).await,
+            Resource::DapClient(action) => action.run(account_id, client, output).await,
             Resource::Aggregator(action) => action.run(account_id, client, output).await,
             Resource::Membership(action) => action.run(account_id, client, output).await,
             Resource::CollectorCredential(action) => action.run(account_id, client, output).await,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -226,7 +226,7 @@ impl Resource {
             Resource::Account(action) => action.run(account_id, client, output).await,
             Resource::ApiToken(action) => action.run(account_id, client, output).await,
             Resource::Task(action) => action.run(account_id, client, output).await,
-            Resource::DapClient(action) => action.run(account_id, client, output).await,
+            Resource::DapClient(action) => action.run(account_id, client).await,
             Resource::Aggregator(action) => action.run(account_id, client, output).await,
             Resource::Membership(action) => action.run(account_id, client, output).await,
             Resource::CollectorCredential(action) => action.run(account_id, client, output).await,

--- a/cli/src/tasks.rs
+++ b/cli/src/tasks.rs
@@ -1,9 +1,8 @@
-use std::time::SystemTime;
-
 use crate::{CliResult, DetermineAccountId, Error, Output};
 use clap::Subcommand;
-use divviup_client::{DivviupClient, Histogram, NewTask, Uuid, Vdaf};
+use divviup_client::{DivviupClient, Histogram, NewTask, SumVec, Uuid, Vdaf};
 use humantime::{Duration, Timestamp};
+use std::time::SystemTime;
 use time::OffsetDateTime;
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -143,11 +142,9 @@ impl TaskAction {
                         length: length.unwrap(),
                         chunk_length,
                     },
-                    VdafName::SumVec => Vdaf::SumVec {
-                        bits: bits.unwrap(),
-                        length: length.unwrap(),
-                        chunk_length,
-                    },
+                    VdafName::SumVec => {
+                        Vdaf::SumVec(SumVec::new(bits.unwrap(), length.unwrap(), chunk_length))
+                    }
                 };
 
                 let time_precision_seconds = time_precision.as_secs();

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,6 +15,7 @@ admin = []
 [dependencies]
 base64 = "0.22.1"
 email_address = "0.2.4"
+prio = "0.16"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 thiserror = "1.0.61"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -39,7 +39,7 @@ pub use janus_messages::{
 };
 pub use membership::Membership;
 pub use protocol::Protocol;
-pub use task::{Histogram, NewTask, Task, Vdaf};
+pub use task::{Histogram, NewTask, SumVec, Task, Vdaf};
 pub use time::OffsetDateTime;
 pub use trillium_client;
 pub use trillium_client::Client;


### PR DESCRIPTION
This is a work in progress to add a dap-client subcommand and an end to end command line only driven README for using Divvi Up.

This is the most Rust I have ever written so please dish out your most fine-toothed review possible.

TODO

- [x] Have someone give feedback on my Rust mess
- [x] Should dap-client output some sort of made up JSON- the other commands output JSON
- [x] Have someone give feedback on basic README outline
- [x] Finish dap-client subcommand with all vdafs
- [x] Write the collect subcommand
- [ ] Merge