### PR TITLE
Add check-cfg directive

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use rustc_version::version;
 
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(assets)");
     if let Ok(asset_dir) = std::env::var("ASSET_DIR") {
         println!("cargo:rustc-cfg=assets");
         println!("cargo:rerun-if-changed={asset_dir}");


### PR DESCRIPTION
This adds an additional output from the build script to prepare for new lints that will be introduced in Rust 1.80. See https://blog.rust-lang.org/2024/05/06/check-cfg.html. Without this, we may see the following warning.

```
$ ASSET_DIR=app/build cargo +nightly check
   Compiling divviup-api v0.3.1 (/home/david/Code/ppm/divviup-api)
warning: unexpected `cfg` condition name: `assets`
 --> src/handler.rs:2:7
  |
2 | #[cfg(assets)]
  |       ^^^^^^
  |
  = help: expected names are: ...
```