### PR TITLE
Copypaste error in route handler, use localized numbers for successful uploads.

### DIFF
--- a/app/src/tasks/TaskDetail/Metrics.tsx
+++ b/app/src/tasks/TaskDetail/Metrics.tsx
@@ -37,7 +37,8 @@ function UploadMetrics({ task }: { task: Promise<Task> }) {
             {(task: Task) => (
               <ListGroup variant="flush">
                 <ListGroup.Item>
-                  Successful Uploads: {task.report_counter_success}
+                  Successful Uploads:{" "}
+                  {numberFormat.format(task.report_counter_success)}
                 </ListGroup.Item>
                 <FailedMetric
                   name="Interval Collected Failure"

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -155,7 +155,7 @@ pub async fn delete(
         // load based on this task because we've ensured that the leader will stop.
         let _ = update
             .update_aggregator_expiration(
-                task.leader_aggregator(&db).await?,
+                task.helper_aggregator(&db).await?,
                 &task.id,
                 &client,
                 crypter,


### PR DESCRIPTION
A couple bugs I noticed:
- The DELETE handler had a copypaste error such that it was talking to the leader twice.
- `Successful Uploads` metric wasn't using localized numbers.