### PR TITLE
Allow force deleting a task

### DIFF
--- a/cli/src/tasks.rs
+++ b/cli/src/tasks.rs
@@ -59,7 +59,12 @@ pub enum TaskAction {
     Rename { task_id: String, name: String },
 
     /// delete a task
-    Delete { task_id: String },
+    Delete {
+        task_id: String,
+        /// delete the task even if the aggregators are unreachable
+        #[arg(long, action)]
+        force: bool,
+    },
 
     /// set the expiration date of a task
     SetExpiration {
@@ -171,7 +176,13 @@ impl TaskAction {
             TaskAction::CollectorAuthTokens { task_id } => {
                 output.display(client.task_collector_auth_tokens(&task_id).await?)
             }
-            TaskAction::Delete { task_id } => client.delete_task(&task_id).await?,
+            TaskAction::Delete { task_id, force } => {
+                if force {
+                    client.force_delete_task(&task_id).await?
+                } else {
+                    client.delete_task(&task_id).await?
+                }
+            }
             TaskAction::SetExpiration {
                 task_id,
                 expiration,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -292,6 +292,11 @@ impl DivviupClient {
         self.delete(&format!("api/tasks/{task_id}")).await
     }
 
+    pub async fn force_delete_task(&self, task_id: &str) -> ClientResult<()> {
+        self.delete(&format!("api/tasks/{task_id}?force=true"))
+            .await
+    }
+
     pub async fn api_tokens(&self, account_id: Uuid) -> ClientResult<Vec<ApiToken>> {
         self.get(&format!("api/accounts/{account_id}/api_tokens"))
             .await

--- a/client/tests/integration/tasks.rs
+++ b/client/tests/integration/tasks.rs
@@ -141,6 +141,24 @@ async fn delete_task(app: Arc<DivviupApi>, account: Account, client: DivviupClie
 }
 
 #[test(harness = with_configured_client)]
+async fn force_delete_task(
+    app: Arc<DivviupApi>,
+    account: Account,
+    client: DivviupClient,
+) -> TestResult {
+    let task = fixtures::task(&app, &account).await;
+
+    let response_tasks = client.tasks(account.id).await?;
+    assert!(!response_tasks.is_empty());
+
+    client.force_delete_task(&task.id).await?;
+
+    let response_tasks = client.tasks(account.id).await?;
+    assert!(response_tasks.is_empty());
+    Ok(())
+}
+
+#[test(harness = with_configured_client)]
 async fn collector_auth_tokens_no_token_hash(
     app: Arc<DivviupApi>,
     account: Account,

--- a/documentation/openapi.yml
+++ b/documentation/openapi.yml
@@ -213,6 +213,27 @@ paths:
                 $ref: "#/components/schemas/Task"
         "404":
           $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [tasks]
+      operationId: deleteTask
+      summary: delete a task by id
+      description: delete a task by id
+      parameters:
+        - in: query
+          name: force
+          schema:
+            type: boolean
+          required: false
+          description: >-
+            forces deletion of the task, even if task's aggregators are unreachable. this is a
+            dangerous operation!
+      responses:
+        "204":
+          description: Successful operation
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
 
   /tasks/{task_id}/collector_auth_tokens:
     get:

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -54,7 +54,7 @@ pub struct DivviupApi {
 }
 
 impl DivviupApi {
-    async fn init(&mut self, info: &mut Info) {
+    pub async fn init(&mut self, info: &mut Info) {
         *info.server_description_mut() = format!("divviup-api {}", env!("CARGO_PKG_VERSION"));
         *info.listener_description_mut() = format!(
             "api url: {}\n             app url: {}\n",

--- a/test-support/src/api_mocks.rs
+++ b/test-support/src/api_mocks.rs
@@ -7,11 +7,13 @@ pub struct ApiMocks {
     handler: (ClientLogs, divviup_api::api_mocks::ApiMocks),
     client_logs: ClientLogs,
 }
+
 impl Default for ApiMocks {
     fn default() -> Self {
         Self::new()
     }
 }
+
 impl ApiMocks {
     pub fn new() -> Self {
         let client_logs = ClientLogs::default();
@@ -24,6 +26,7 @@ impl ApiMocks {
             client_logs,
         }
     }
+
     pub fn client_logs(&self) -> ClientLogs {
         self.client_logs.clone()
     }

--- a/tests/integration/aggregator_client.rs
+++ b/tests/integration/aggregator_client.rs
@@ -3,7 +3,6 @@ use divviup_api::{
     clients::AggregatorClient,
 };
 use test_support::{assert_eq, test, *};
-use trillium::Handler;
 
 #[test(harness = with_client_logs)]
 async fn get_task_ids(app: DivviupApi, client_logs: ClientLogs) -> TestResult {


### PR DESCRIPTION
We can't assume that the leader aggregator is under our control, because we don't lock leader aggregator selection to a first party aggregator. Therefore, if the leader aggregator has lost knowledge of a task, the task is undeletable.

In similar vein, we have a DAP-04 environment where the leader-side task patching endpoint is not backported. So DAP-04 tasks are undeletable.

Instead of making assumptions about tasks we can/can't delete, let the user decide by exposing a `?force=true` parameter to task deletion, which will swallow any aggregator errors.

I've not plumbed this through the UI since I think we want this to be an uncommon, unhappy-path option.