### PR TITLE
Fix extant clippy diagnostics

### DIFF
--- a/cli/src/collector_credentials.rs
+++ b/cli/src/collector_credentials.rs
@@ -145,13 +145,13 @@ impl CollectorCredentialAction {
                     public_key,
                 } = kem.gen_keypair();
 
-                let config_id = id.unwrap_or_else(|| rand::random());
+                let config_id = id.unwrap_or_else(rand::random);
 
                 let hpke_config = HpkeConfig::new(
                     config_id.into(),
-                    (kem as u16).try_into().unwrap(),
-                    (kdf as u16).try_into().unwrap(),
-                    (aead as u16).try_into().unwrap(),
+                    (kem as u16).into(),
+                    (kdf as u16).into(),
+                    (aead as u16).into(),
                     public_key.clone().into(),
                 );
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,8 @@
     nonstandard_style
 )]
 #![warn(clippy::perf, clippy::cargo)]
+#![allow(clippy::cargo_common_metadata)]
+#![allow(clippy::multiple_crate_versions)]
 
 mod accounts;
 mod aggregators;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -6,6 +6,8 @@
     nonstandard_style
 )]
 #![warn(clippy::perf, clippy::cargo)]
+#![allow(clippy::cargo_common_metadata)]
+#![allow(clippy::multiple_crate_versions)]
 
 mod account;
 mod aggregator;
@@ -373,8 +375,7 @@ impl DivviupClient {
         &self,
         aggregator: NewSharedAggregator,
     ) -> ClientResult<Aggregator> {
-        self.post(&format!("api/aggregators"), Some(&aggregator))
-            .await
+        self.post("api/aggregators", Some(&aggregator)).await
     }
 }
 

--- a/migration/src/bin/migrate_to.rs
+++ b/migration/src/bin/migrate_to.rs
@@ -109,7 +109,7 @@ async fn migrate_up<M: MigratorTrait>(
                 ),
             }
         }
-        Err(err) if matches!(err, Error::DbNotInitialized) => (
+        Err(Error::DbNotInitialized) => (
             0usize..=target_index,
             // The migration API takes "number of migrations to apply". If we have an
             // uninitialized database, and we want to apply the first migration (index 0),
@@ -215,7 +215,7 @@ enum Error {
     #[error("migration version {0} is newer than the latest applied migration")]
     VersionTooNew(String),
     #[error("error calculating number of migrations, too many migrations?: {0}")]
-    OverflowError(#[from] std::num::TryFromIntError),
+    Overflow(#[from] std::num::TryFromIntError),
     #[error("applied migrations do not match migrations present in this tool")]
     DbNotCompatible,
 }

--- a/src/handler/account_bearer_token.rs
+++ b/src/handler/account_bearer_token.rs
@@ -27,7 +27,7 @@ impl FromConn for AccountBearerToken {
         let (api_token, account) = ApiTokens::load_and_check(token, db).await?;
         let api_token = api_token.mark_last_used().update(db).await.ok()?;
         let account_bearer_token = Self { account, api_token };
-        conn.set_state(account_bearer_token.clone());
+        conn.insert_state(account_bearer_token.clone());
         Some(account_bearer_token)
     }
 }

--- a/src/handler/error.rs
+++ b/src/handler/error.rs
@@ -15,7 +15,7 @@ impl Handler for ErrorHandler {
 
     async fn before_send(&self, mut conn: Conn) -> Conn {
         if let Some(error) = conn.take_state::<ApiError>() {
-            conn.set_state(Error::from(error));
+            conn.insert_state(Error::from(error));
         };
 
         let Some(error) = conn.state().cloned() else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@
     nonstandard_style
 )]
 #![warn(clippy::perf, clippy::cargo)]
-#![allow(clippy::needless_pass_by_ref_mut)]
+#![allow(clippy::cargo_common_metadata)]
+#![allow(clippy::multiple_crate_versions)]
 
 pub mod clients;
 mod config;

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -69,7 +69,7 @@ impl FromConn for PermissionsActor {
         };
 
         if let Some(actor) = &actor {
-            conn.set_state(actor.clone());
+            conn.insert_state(actor.clone());
         }
 
         actor

--- a/src/routes/accounts.rs
+++ b/src/routes/accounts.rs
@@ -26,7 +26,7 @@ impl FromConn for Account {
             Ok(Some(account)) => actor.if_allowed(conn.method(), account),
             Ok(None) => None,
             Err(error) => {
-                conn.set_state(Error::from(error));
+                conn.insert_state(Error::from(error));
                 None
             }
         }

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -30,7 +30,7 @@ impl FromConn for queue::Model {
         match Entity::find_by_id(id).one(&db).await {
             Ok(job) => job,
             Err(error) => {
-                conn.set_state(Error::from(error));
+                conn.insert_state(Error::from(error));
                 None
             }
         }

--- a/src/routes/aggregators.rs
+++ b/src/routes/aggregators.rs
@@ -23,7 +23,7 @@ impl FromConn for Aggregator {
             Ok(Some(aggregator)) => actor.if_allowed(conn.method(), aggregator),
             Ok(None) => None,
             Err(error) => {
-                conn.set_state(Error::from(error));
+                conn.insert_state(Error::from(error));
                 None
             }
         }

--- a/src/routes/api_tokens.rs
+++ b/src/routes/api_tokens.rs
@@ -29,7 +29,7 @@ impl FromConn for ApiToken {
             Ok(Some(api_token)) => actor.if_allowed(conn.method(), api_token),
             Ok(None) => None,
             Err(error) => {
-                conn.set_state(Error::from(error));
+                conn.insert_state(Error::from(error));
                 None
             }
         }

--- a/src/routes/collector_credentials.rs
+++ b/src/routes/collector_credentials.rs
@@ -35,7 +35,7 @@ impl FromConn for CollectorCredential {
             Ok(Some(collector_credential)) => actor.if_allowed(conn.method(), collector_credential),
             Ok(None) => None,
             Err(error) => {
-                conn.set_state(Error::from(error));
+                conn.insert_state(Error::from(error));
                 None
             }
         }

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -46,7 +46,7 @@ impl FromConn for Task {
             Ok(Some(task)) => actor.if_allowed(conn.method(), task),
             Ok(None) => None,
             Err(error) => {
-                conn.set_state(Error::from(error));
+                conn.insert_state(Error::from(error));
                 None
             }
         }

--- a/src/user.rs
+++ b/src/user.rs
@@ -77,7 +77,7 @@ impl FromConn for User {
             .or_else(|| conn.session().get(USER_SESSION_KEY))?;
         let db: &Db = conn.state()?;
         user.populate_admin(db).await;
-        conn.set_state(user.clone());
+        conn.insert_state(user.clone());
         Some(user)
     }
 }

--- a/test-support/src/lib.rs
+++ b/test-support/src/lib.rs
@@ -6,6 +6,8 @@
     nonstandard_style
 )]
 #![warn(clippy::perf, clippy::cargo)]
+#![allow(clippy::cargo_common_metadata)]
+#![allow(clippy::multiple_crate_versions)]
 
 use divviup_api::{clients::aggregator_client::api_types, Config, Crypter, Db};
 use serde::{de::DeserializeOwned, Serialize};


### PR DESCRIPTION
Besides applying a variety of `clippy` suggestions, this neuters `clippy::cargo_common_metadata` ([1]) and
`clippy::multiple_crate_versions` ([2]) in several targets. Neither warning is very useful: the former nags us to set keywords and such on every package (which we don't do for Janus crates and have never lost sleep over) and while the dep duplication flagged by the latter is unfortunate, it's inevitable for any nontrivial Rust dependency tree. We also no longer need to allow `clippy::needless_pass_by_ref_mut` ([3]).

[1]: https://rust-lang.github.io/rust-clippy/master/index.html#/cargo_common_metadata
[2]: https://rust-lang.github.io/rust-clippy/master/index.html#/multiple_crate_versions
[3]: https://rust-lang.github.io/rust-clippy/master/index.html#/needless_pass_by_ref_mut