### PR TITLE
client/cli: `GET /aggregators/:aggregator_id`

### DIFF
--- a/cli/src/aggregators.rs
+++ b/cli/src/aggregators.rs
@@ -4,6 +4,9 @@ use divviup_client::{DivviupClient, NewAggregator, Url, Uuid};
 
 #[derive(Subcommand, Debug)]
 pub enum AggregatorAction {
+    /// Show an aggregator
+    Show { aggregator_id: Uuid },
+
     /// List all aggregators for the target account
     List {
         /// list only shared aggregators
@@ -67,17 +70,17 @@ impl AggregatorAction {
         output: Output,
     ) -> CliResult {
         match self {
-            AggregatorAction::List { shared: true } => {
-                output.display(client.shared_aggregators().await?)
-            }
+            Self::Show { aggregator_id } => output.display(client.aggregator(aggregator_id).await?),
 
-            AggregatorAction::List { shared: false } => {
+            Self::List { shared: true } => output.display(client.shared_aggregators().await?),
+
+            Self::List { shared: false } => {
                 let account_id = account_id.await?;
                 output.display(client.aggregators(account_id).await?)
             }
 
             #[cfg(feature = "admin")]
-            AggregatorAction::Create {
+            Self::Create {
                 name,
                 api_url,
                 bearer_token,
@@ -94,7 +97,7 @@ impl AggregatorAction {
                     .await?,
             ),
 
-            AggregatorAction::Create {
+            Self::Create {
                 name,
                 api_url,
                 bearer_token,
@@ -114,12 +117,12 @@ impl AggregatorAction {
                     .await?,
             ),
 
-            AggregatorAction::Rename {
+            Self::Rename {
                 aggregator_id,
                 name,
             } => output.display(client.rename_aggregator(aggregator_id, &name).await?),
 
-            AggregatorAction::RotateBearerToken {
+            Self::RotateBearerToken {
                 aggregator_id,
                 bearer_token,
             } => output.display(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -229,7 +229,7 @@ impl Resource {
             Resource::Account(action) => action.run(account_id, client, output).await,
             Resource::ApiToken(action) => action.run(account_id, client, output).await,
             Resource::Task(action) => action.run(account_id, client, output).await,
-            Resource::DapClient(action) => action.run(account_id, client).await,
+            Resource::DapClient(action) => action.run(client).await,
             Resource::Aggregator(action) => action.run(account_id, client, output).await,
             Resource::Membership(action) => action.run(account_id, client, output).await,
             Resource::CollectorCredential(action) => action.run(account_id, client, output).await,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -182,6 +182,10 @@ impl DivviupClient {
         .await
     }
 
+    pub async fn aggregator(&self, aggregator_id: Uuid) -> ClientResult<Aggregator> {
+        self.get(&format!("api/aggregators/{aggregator_id}")).await
+    }
+
     pub async fn aggregators(&self, account_id: Uuid) -> ClientResult<Vec<Aggregator>> {
         self.get(&format!("api/accounts/{account_id}/aggregators"))
             .await

--- a/client/tests/integration/aggregators.rs
+++ b/client/tests/integration/aggregators.rs
@@ -2,6 +2,25 @@ use crate::harness::{assert_eq, test, *};
 use divviup_client::NewAggregator;
 
 #[test(harness = with_configured_client)]
+async fn show_aggregator(
+    app: Arc<DivviupApi>,
+    account: Account,
+    client: DivviupClient,
+) -> TestResult {
+    let aggregators = [
+        fixtures::aggregator(&app, Some(&account)).await,
+        fixtures::aggregator(&app, Some(&account)).await,
+    ];
+
+    for aggregator in aggregators {
+        let response = client.aggregator(aggregator.id).await?;
+        assert_same_json_representation(&aggregator, &response);
+    }
+
+    Ok(())
+}
+
+#[test(harness = with_configured_client)]
 async fn aggregator_list(
     app: Arc<DivviupApi>,
     account: Account,


### PR DESCRIPTION
Adds support to the client library and the CLI for getting a single aggregator by its ID. This is used to simplify `dap_client.rs` somewhat.

Closes #1034