### PR TITLE
Add `cli-release` workflow

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,21 @@
+name: cli-release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_rust:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    runs-on: matrix.os
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: build
+        run: cargo build --package divviup-cli --profile release


### PR DESCRIPTION
Adds a simple `cli-release.yml` GitHub Actions workflow that just builds `divviup-cli` on Ubuntu, Windows and macOS runners. The goal here is just to get a basic workflow checked in and acknowledged by GitHub Actions so that I can then debug and iterate on it in a later PR.

Part of #492