### PR TITLE
Ship 6 `divviup-cli` binaries

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -2,6 +2,12 @@ name: cli-release
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: release/tag to upload artifacts to
+        required: true
+        type: string
+
   release:
     types: [published]
 
@@ -9,13 +15,59 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_rust:
+  build-cli:
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-    runs-on: matrix.os
+        arch: ["x86_64", "aarch64"]
+        target: [
+          {
+            os: "ubuntu-latest",
+            triple-suffix: "unknown-linux-gnu",
+            extension: "",
+            extra-build-flags: ""
+          },
+          {
+            os: "windows-latest",
+            triple-suffix: "pc-windows-msvc",
+            extension: ".exe",
+            # Build with ring on Windows so we don't have to set up aws-lc-rs' toolchain
+            extra-build-flags: "--no-default-features --features ring,common"
+          },
+          {
+            os: "macos-latest",
+            triple-suffix: "apple-darwin",
+            extension: "",
+            extra-build-flags: ""
+          }
+        ]
+    runs-on: ${{ matrix.target.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: build
-        run: cargo build --package divviup-cli --profile release
+      - name: Resolve inputs
+        id: resolve-inputs
+        # Use tag input if available, otherwise parse it out of the git ref
+        run: |
+          TAG_INPUT=${{ inputs.tag }}
+          echo "tag=${TAG_INPUT:-GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          TRIPLE=`printf '%s-%s' ${{ matrix.arch }} ${{ matrix.target.triple-suffix }}`
+          echo "triple=$TRIPLE" >> $GITHUB_OUTPUT
+          EXECUTABLE=`printf 'divviup-%s%s' $TRIPLE ${{ matrix.target.extension }}`
+          echo "executable=$EXECUTABLE" >> $GITHUB_OUTPUT
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          target: ${{ steps.resolve-inputs.outputs.triple }}
+          args: ${{ format('--locked --release --package divviup-cli {0}', matrix.target.extra-build-flags) }}
+          strip: true
+      - name: Publish
+        env:
+            GH_TOKEN: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
+        run: |
+          cp target/${{ steps.resolve-inputs.outputs.triple }}/release/divviup${{ matrix.target.extension }} \
+            ./${{ steps.resolve-inputs.outputs.executable }}
+          gh release upload \
+            ${{ steps.resolve-inputs.outputs.tag }} ${{ steps.resolve-inputs.outputs.executable }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,9 +42,7 @@ jobs:
         run: cargo fmt --all -- --check
       - name: check +api-mocks
         run: cargo check --features api-mocks
-      - name: check cli -default
-        run: cargo check -p divviup-cli --no-default-features
-      - name: check cli -default +admin
-        run: cargo check -p divviup-cli --no-default-features --features admin
+      - name: check cli -default +ring
+        run: cargo check -p divviup-cli --no-default-features --features ring,common
       - name: check cli +default +admin
         run: cargo check -p divviup-cli --features admin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3879,6 +3879,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
  "subtle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,7 +9,12 @@ version.workspace = true
 description = "Command line utility for divviup.org"
 
 [features]
-default = ["hpke"]
+default = ["common", "aws-lc-rs"]
+common = ["hpke", "trillium-rustls/client", "trillium-rustls/tls12"]
+# Building aws-lc-rs on Windows is challenging at best because of aws-lc's toolchain, so we allow
+# using ring instead
+aws-lc-rs = ["trillium-rustls/aws-lc-rs"]
+ring = ["trillium-rustls/ring"]
 hpke = ["dep:hpke-dispatch", "dep:rand"]
 admin = ["divviup-client/admin"]
 
@@ -22,7 +27,7 @@ anyhow = "1"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 thiserror = "1.0.61"
 divviup-client = { workspace = true }
-trillium-rustls = "0.8.0"
+trillium-rustls = { version = "0.8.0", default-features = false }
 trillium-tokio = "0.4.0"
 serde = "1.0.203"
 email_address = "0.2.4"

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,6 +2,16 @@
 
 `divviup` is a command line (CLI) tool for doing all basic operations on both the Divvi Up API and Distributed Aggregation Protocol (DAP) API endpoints. It's only likely to work if the leader aggregator is [Janus](https://github.com/divviup/janus). See `divviup --help` for details on all of the commands.
 
+To get the tool, either check out this project and build it yourself:
+
+```sh
+cargo run --package divviup-cli -- help
+```
+
+If you run into problems with the `aws-lc-rs` dependency, you can try building with `--no-default-features --features common,ring`.
+
+Or you can download a binary for your OS and host architecture from our [releases](https://github.com/divviup/divviup-api/releases).
+
 ### Command Line Tutorial
 
 First, set an environment variable for the Divvi Up account and an API token. You can create an API token by logging into the [Divvi Up console](https://app.divviup.org).

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -189,10 +189,13 @@ impl ClientBin {
 }
 
 pub fn main() -> ExitCode {
-    // Choose aws-lc-rs as the default rustls crypto provider. This is what's currently enabled by
-    // the default Cargo feature. Specifying a default provider here prevents runtime errors if
-    // another dependency also enables the ring feature.
+    // Install a default rustls crypto provider based on enabled features. Specifying a default
+    // provider here prevents runtime errors if another dependency enables a different crypto
+    // provider.
+    #[cfg(feature = "aws-lc-rs")]
     let _ = trillium_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
+    #[cfg(feature = "ring")]
+    let _ = trillium_rustls::rustls::crypto::ring::default_provider().install_default();
 
     env_logger::init();
     let args = ClientBin::parse();


### PR DESCRIPTION
Builds `divviup-cli` for Windows, macOS and Linux, across x86_64 and aarch64. The resulting executables are attached to the release, as in https://github.com/divviup/divviup-api/releases/tag/0.3.7.

Part of #492