### PR TITLE
Fix tag determination in cli-release workflow

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -50,7 +50,7 @@ jobs:
         # Use tag input if available, otherwise parse it out of the git ref
         run: |
           TAG_INPUT=${{ inputs.tag }}
-          echo "tag=${TAG_INPUT:-GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG_INPUT:-${GITHUB_REF/refs\/tags\//}}" >> $GITHUB_OUTPUT
           TRIPLE=`printf '%s-%s' ${{ matrix.arch }} ${{ matrix.target.triple-suffix }}`
           echo "triple=$TRIPLE" >> $GITHUB_OUTPUT
           EXECUTABLE=`printf 'divviup-%s%s' $TRIPLE ${{ matrix.target.extension }}`


### PR DESCRIPTION
I incorrectly nested variables when resolving the `tag` input against `$GITHUB_REF`, causing the workflow to fail when triggered by a release event, as in [1].

[1]: https://github.com/divviup/divviup-api/actions/runs/9471088404/job/26093472049