### PR TITLE
Add image parameters to `compose.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ This will get you up and running quickly for development purposes.
 `docker compose` will automatically reload containers when you make changes. Data is persisted
 until you `docker compose rm --volumes`.
 
+If you want to use image versions besides the defaults, you can use environment variables
+`JANUS_AGGREGATOR_IMAGE`, `JANUS_MIGRATOR_IMAGE`, `DIVVIUP_API_IMAGE` and
+`DIVVIUP_API_MIGRATOR_IMAGE` when invoking `docker compose`. If the tag set for `DIVVIUP_API_IMAGE`
+or `DIVVIUP_API_MIGRATOR_IMAGE` cannot be found, it will be built from local context. For example:
+
+```bash
+DIVVIUP_API_IMAGE=divviup_api:localversion \
+  JANUS_IMAGE=us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:0.7.18 \
+  docker compose up
+```
+
+If `divviup_api:localversion` is present in the local Docker repository, it will be used, but it
+will be built otherwise, and then run.
+`us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:0.7.18` will be pulled and
+run.
+
 Two Janus aggregators will be created for you, but are not automatically paired to divviup-api.
 Their information is:
 1. Address: `http://janus_1_aggregator:8080/aggregator-api`, Token: `0000`
@@ -58,6 +74,7 @@ testing client, they are mapped to `localhost:9001` and `localhost:9002`, respec
 
 If using the divviup CLI, consider compiling with the `--features admin` option. Also, set these
 environment variables.
+
 ```bash
 # This token is intentionally blank, but you'll still need to set the variable.
 export DIVVIUP_TOKEN=

--- a/README.md
+++ b/README.md
@@ -42,16 +42,14 @@ This will get you up and running quickly for development purposes.
 
 1. Clone the repository and navigate to its root.
 1. Execute `echo "http://localhost:8080" >app/public/api_url`
-1. Execute `docker compose watch`.
+1. Execute `docker compose up`.
 1. Navigate in your browser to `http://localhost:8081/`.
 
-`docker compose` will automatically reload containers when you make changes. Data is persisted
-until you `docker compose rm --volumes`.
+Data is persisted until you `docker compose rm --volumes`.
 
 If you want to use image versions besides the defaults, you can use environment variables
 `JANUS_AGGREGATOR_IMAGE`, `JANUS_MIGRATOR_IMAGE`, `DIVVIUP_API_IMAGE` and
-`DIVVIUP_API_MIGRATOR_IMAGE` when invoking `docker compose`. If the tag set for `DIVVIUP_API_IMAGE`
-or `DIVVIUP_API_MIGRATOR_IMAGE` cannot be found, it will be built from local context. For example:
+`DIVVIUP_API_MIGRATOR_IMAGE` when invoking `docker compose`.  For example:
 
 ```bash
 DIVVIUP_API_IMAGE=divviup_api:localversion \
@@ -59,10 +57,18 @@ DIVVIUP_API_IMAGE=divviup_api:localversion \
   docker compose up
 ```
 
-If `divviup_api:localversion` is present in the local Docker repository, it will be used, but it
-will be built otherwise, and then run.
-`us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:0.7.18` will be pulled and
-run.
+`divviup_api:localversion` will be pulled from the local Docker repository and
+`us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:0.7.18` will be pulled from
+`us-west2-docker.pkg.dev`.
+
+We also provide `compose.dev.yaml`, which will build `divviup-api` from local sources. Try:
+
+```bash
+docker compose -f compose.dev.yaml watch
+```
+
+`docker compose` will automatically reload containers when you make changes. The `JANUS_IMAGE` and
+`JANUS_MIGRATOR_IMAGE` variables are honored by `compose.dev.yaml`.
 
 Two Janus aggregators will be created for you, but are not automatically paired to divviup-api.
 Their information is:

--- a/compose.dev.override.yaml
+++ b/compose.dev.override.yaml
@@ -1,0 +1,21 @@
+# Overrides for the local development docker compose setup. Meant only to be used by
+# compose.dev.yaml
+
+services:
+  divviup_api:
+    image: !reset null
+    build:
+      context: .
+      args:
+        RUST_PROFILE: dev
+        RUST_FEATURES: integration-testing
+
+  divviup_api_migrate:
+    image: !reset null
+    build:
+      context: .
+      args:
+        RUST_PROFILE: dev
+        # This isn't strictly required for migrations, but it allows reusing one container image
+        # for both this and the divviup_api service.
+        RUST_FEATURES: integration-testing

--- a/compose.dev.override.yaml
+++ b/compose.dev.override.yaml
@@ -9,6 +9,12 @@ services:
       args:
         RUST_PROFILE: dev
         RUST_FEATURES: integration-testing
+    develop:
+      watch:
+        - path: migration
+          action: rebuild
+          ignore:
+            - README.md
 
   divviup_api_migrate:
     image: !reset null
@@ -19,3 +25,7 @@ services:
         # This isn't strictly required for migrations, but it allows reusing one container image
         # for both this and the divviup_api service.
         RUST_FEATURES: integration-testing
+    develop:
+      watch:
+        - path: src/
+          action: rebuild

--- a/compose.dev.override.yaml
+++ b/compose.dev.override.yaml
@@ -11,10 +11,8 @@ services:
         RUST_FEATURES: integration-testing
     develop:
       watch:
-        - path: migration
+        - path: src/
           action: rebuild
-          ignore:
-            - README.md
 
   divviup_api_migrate:
     image: !reset null
@@ -27,5 +25,7 @@ services:
         RUST_FEATURES: integration-testing
     develop:
       watch:
-        - path: src/
+        - path: migration
           action: rebuild
+          ignore:
+            - README.md

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,8 @@
+# Local development-only compose file which builds divviup-api from source. This is not suitable for
+# production!
+
+include:
+  - path:
+    # These files are ordered deliberately so that they will be merged correctly
+    - compose.yaml
+    - compose.dev.override.yaml

--- a/compose.yaml
+++ b/compose.yaml
@@ -43,7 +43,7 @@ services:
         target: /docker-entrypoint-initdb.d/postgres_init.sql
 
   divviup_api_migrate:
-    image: ${DIVVIUP_API_MIGRATOR_IMAGE:-us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api:0.3.9}
+    image: ${DIVVIUP_API_MIGRATOR_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api:0.3.12}
     entrypoint:
       - /migration
       - up
@@ -54,7 +54,7 @@ services:
         condition: service_started
 
   divviup_api:
-    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api:0.3.9}
+    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api:0.3.12}
     ports:
       - "8080:8080"
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 # Local development-only compose file. This is not suitable for production!
 
 x-janus-common: &janus_common
-  image: us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:0.7.7
+  image: ${JANUS_AGGREGATOR_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:0.7.7}
   restart: always
   healthcheck:
     test: ["CMD", "/bin/sh", "-c", "wget http://0.0.0.0:8000/healthz -O - >/dev/null"]
@@ -12,7 +12,7 @@ x-janus-common: &janus_common
       condition: service_completed_successfully
 
 x-janus-migrate: &janus_migrate
-  image: us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_db_migrator:0.7.7
+  image: ${JANUS_MIGRATOR_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_db_migrator:0.7.7}
   command:
     - migrate
     - run
@@ -43,6 +43,7 @@ services:
         target: /docker-entrypoint-initdb.d/postgres_init.sql
 
   divviup_api_migrate:
+    image: ${DIVVIUP_API_MIGRATOR_IMAGE:-us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api:0.3.9}
     build:
       context: .
       args:
@@ -66,6 +67,7 @@ services:
             - README.md
 
   divviup_api:
+    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api:0.3.9}
     build:
       context: .
       args:

--- a/compose.yaml
+++ b/compose.yaml
@@ -52,12 +52,6 @@ services:
     depends_on:
       postgres:
         condition: service_started
-    develop:
-      watch:
-        - path: migration
-          action: rebuild
-          ignore:
-            - README.md
 
   divviup_api:
     image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api:0.3.9}
@@ -79,10 +73,6 @@ services:
     depends_on:
       divviup_api_migrate:
         condition: service_completed_successfully
-    develop:
-      watch:
-        - path: src/
-          action: rebuild
 
   divviup_api_vite:
     build:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-# Local development-only compose file. This is not suitable for production!
+# Compose file for bringing up a simple local Divvi Up environment. This is not suitable for production!
 
 x-janus-common: &janus_common
   image: ${JANUS_AGGREGATOR_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:0.7.7}
@@ -44,13 +44,6 @@ services:
 
   divviup_api_migrate:
     image: ${DIVVIUP_API_MIGRATOR_IMAGE:-us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api:0.3.9}
-    build:
-      context: .
-      args:
-        RUST_PROFILE: dev
-        # This isn't strictly required for migrations, but it allows reusing one container image
-        # for both this and the divviup_api service.
-        RUST_FEATURES: integration-testing
     entrypoint:
       - /migration
       - up
@@ -68,11 +61,6 @@ services:
 
   divviup_api:
     image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api:0.3.9}
-    build:
-      context: .
-      args:
-        RUST_PROFILE: dev
-        RUST_FEATURES: integration-testing
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
Compose files can be parameterized using Bash-style (*sigh*) syntax ([1]). We add variables `JANUS_AGGREGATOR_IMAGE`, `JANUS_MIGRATOR_IMAGE`, `DIVVIUP_API_IMAGE` and `DIVVIUP_API_MIGRATOR_IMAGE` to allow setting Docker image tags like so:

```sh
DIVVIUP_API_IMAGE=myrepository.dev/divviup_api:0.0.1 \
  JANUS_AGGREGATOR_IMAGE=myrepository.dev/janus_aggregator:0.7.8 \
  docker compose up
```

These variables are interpolated into the `image` field of the `service` elements ([2]). Because we also have a `build` element on the `divviup-api` services, the behavior is to pull the specified image and fall back to the `build` element if it can't be found ([3]). So if you want to build `divviup-api` from source and use that, do:

```sh
DIVVIUP_API_IMAGE=divviup_api:1 docker compose up
```

`divviup_api:1` will be built from the local context, unless it's already in the local Docker repository, and then launched.

We provide defaults for all these images that pull from Divvi Up owned public artifact repositories. It's somewhat unfortunate that we use a `divviup-api` version that is behind `main`, but on the other hand the objective is to enable a demo experience, so it makes sense to pin Janus and divviup-api versions where the demo is known to work end-to-end.

[1]: https://docs.docker.com/compose/compose-file/12-interpolation/
[2]: https://docs.docker.com/compose/compose-file/05-services/#image
[3]: https://docs.docker.com/compose/compose-file/build/#using-build-and-image