### PR TITLE
docker-release: also push images to public repo

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v4
       - id: resolve_variables
         run: |
-        echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
-        IMAGE=${{ matrix.image.name }}:${GITHUB_REF/refs\/tags\//}
-        echo "PUBLIC_TAG=us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
-        echo "PRIVATE_TAG=us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
+          echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
+          IMAGE=${{ matrix.image.name }}:${GITHUB_REF/refs\/tags\//}
+          echo "PUBLIC_TAG=us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
+          echo "PRIVATE_TAG=us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -18,37 +18,59 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - id: git
-        run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
-      - id: get_version
-        run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
+      - id: resolve_variables
+        run: |
+        echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
+        IMAGE=${{ matrix.image.name }}:${GITHUB_REF/refs\/tags\//}
+        echo "PUBLIC_TAG=us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
+        echo "PRIVATE_TAG=us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container
           use: true
-      - id: gcp-auth
-        name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ vars.GCP_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_ARTIFACT_PUBLISHER_LOAD_GEN_SERVICE_ACCOUNT }}
-          token_format: access_token
-          access_token_lifetime: "3600s"
-          access_token_scopes: https://www.googleapis.com/auth/cloud-platform
-      - uses: docker/login-action@v3
-        with:
-          registry: us-west2-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
-      - name: Build and Push
+      - name: Build
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          tags: "us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${{ matrix.image.name }}:${{ steps.get_version.outputs.VERSION }}"
+          push: false
+          tags: "${{ steps.resolve_variables.outputs.PUBLIC_TAG}},${{ steps.resolve_variables.outputs.PRIVATE_TAG }}"
           build-args: |
-            GIT_REVISION=${{ steps.git.outputs.GIT_REVISION }}
+            GIT_REVISION=${{ steps.resolve_variables.outputs.GIT_REVISION }}
             RUST_FEATURES=${{ matrix.image.rust_features }}
           cache-from: |
             type=gha,scope=main-${{ matrix.image.rust_features }}
+      - id: gcp-auth-private
+        name: Authenticate to GCP (private repository)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_ARTIFACTS_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_ARTIFACTS_PUBLISHER_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: "3600s"
+          access_token_scopes: https://www.googleapis.com/auth/cloud-platform
+      - name: Docker login (private repository)
+        uses: docker/login-action@v3
+        with:
+          registry: us-west2-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth-private.outputs.access_token }}
+      - name: Push (private repository)
+        run: docker push ${{ steps.resolve_variables.outputs.PRIVATE_TAG }}
+      - id: gcp-auth-private
+        name: Authenticate to GCP (public repository)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_GAR_PUBLIC_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_GAR_PUBLIC_PUBLISHER_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: "3600s"
+          access_token_scopes: https://www.googleapis.com/auth/cloud-platform
+      - name: Docker login (public repository)
+        uses: docker/login-action@v3
+        with:
+          registry: us-west2-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth-public.outputs.access_token }}
+      - name: Push (public repository)
+        run: docker push ${{ steps.resolve_variables.outputs.PUBLIC_TAG }}


### PR DESCRIPTION
We've already got everything set up to allow the `docker-release` workflow to impersonate a GCP SA that is allowed to push images to `divviup-public-artifacts`. We just need to tag the built image for the public repo as well as the private one, and then push to both. I also harmonized the names of the GitHub Actions Environment Variables (TM) for the workload identity providers and service accounts with the scheme used in Janus' Docker publishing action.