### PR TITLE
Rename public GCP auth step

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -57,7 +57,7 @@ jobs:
           password: ${{ steps.gcp-auth-private.outputs.access_token }}
       - name: Push (private repository)
         run: docker push ${{ steps.resolve_variables.outputs.PRIVATE_TAG }}
-      - id: gcp-auth-private
+      - id: gcp-auth-public
         name: Authenticate to GCP (public repository)
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
Two steps had the same `id` due to a copy-paste error, causing the workflow to fail ([1]).

[1]: https://github.com/divviup/divviup-api/actions/runs/9490520600