### PR TITLE
`docker-release`: load built images for later push

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -33,7 +33,11 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          # Do not push in this step so we can push to the private and public repositories
+          # separately in later steps, but do load so that the images will be visible to `docker
+          # push`
           push: false
+          load: true
           tags: "${{ steps.resolve_variables.outputs.PUBLIC_TAG}},${{ steps.resolve_variables.outputs.PRIVATE_TAG }}"
           build-args: |
             GIT_REVISION=${{ steps.resolve_variables.outputs.GIT_REVISION }}


### PR DESCRIPTION
Otherwise the `docker push` steps can't see the images, as in [1]:

Build step:
```
WARNING: No output specified with docker-container driver. Build result
will only remain in the build cache. To push result image into registry
use --push or to load image into docker use --load
```
Push step:
```
The push refers to repository [us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api_integration_test]
An image does not exist locally with the tag: us-west2-docker.pkg.dev/janus-artifacts/divviup-api/divviup_api_integration_test
```

[1]: https://github.com/divviup/divviup-api/actions/runs/9490619255/job/26154435457