### PR TITLE
Add healthcheck for divviup-api to compose.yaml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,10 @@ jobs:
   # Test the non-dev compose, which we use for demo purposes. This pulls images from remote repos,
   # so no need to build anything. Additionally we want coverage across multiple operating systems.
   compose:
-    runs-on: [ubuntu-latest, windows-latest, macos-latest]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Compose

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,17 +48,12 @@ jobs:
           done
 
   # Test the non-dev compose, which we use for demo purposes. This pulls images from remote repos,
-  # so no need to build anything. Additionally we want coverage across multiple operating systems.
-  # Ideally we'd test on macOS, too, but those runners don't have Docker:
+  # so no need to build anything.
+  # Ideally we'd test on macOS and Windows, too, but those runners don't have Docker:
   # https://github.com/actions/runner-images/issues/2150
+  # https://github.com/actions/runner/issues/904
   compose:
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Compose

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
       # interesting when feature integration-testing is on, but we may as well exercise both.
       - name: Compose (dev)
         id: compose-dev
-        run: docker compose -f compose.dev.yaml --wait --wait-timeout 120
+        run: docker compose -f compose.dev.yaml up --wait --wait-timeout 120
       - name: Inspect dev containers
         if: ${{ failure() && steps.compose-dev.outcome != 'success' }}
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,11 +58,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker-container
-          use: true
       - name: Compose
         id: compose
         run: docker compose up --wait --wait-timeout 120

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,10 +49,12 @@ jobs:
 
   # Test the non-dev compose, which we use for demo purposes. This pulls images from remote repos,
   # so no need to build anything. Additionally we want coverage across multiple operating systems.
+  # Ideally we'd test on macOS, too, but those runners don't have Docker:
+  # https://github.com/actions/runner-images/issues/2150
   compose:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,6 +56,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          use: true
       - name: Compose
         id: compose
         run: docker compose up --wait --wait-timeout 120

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
             RUST_FEATURES=${{ matrix.rust-features }}
       - name: Compose
         id: compose
-        run: docker compose up --wait --waitfor 120
+        run: docker compose up --wait --wait-timeout 120
         # continue on error so we can inspect containers in the next step
         continue-on-error: true
       - name: Inspect containers

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,3 +33,16 @@ jobs:
           build-args: |
             GIT_REVISION=${{ steps.git.outputs.GIT_REVISION }}
             RUST_FEATURES=${{ matrix.rust-features }}
+      - name: Compose
+        id: compose
+        run: docker compose up --wait --waitfor 120
+        # continue on error so we can inspect containers in the next step
+        continue-on-error: true
+      - name: Inspect containers
+        if: steps.compose.outcome != 'success'
+        run: |
+          docker compose ps
+          for NAME in `docker compose ps --format json | jq -r '.Name'`; do
+            docker inspect $NAME
+          done
+          exit 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           cache-from: |
             type=gha,scope=main-${{ matrix.rust-features }}
             type=gha,scope=${{ github.ref_name }}-${{ matrix.rust-features }}
@@ -33,16 +34,32 @@ jobs:
           build-args: |
             GIT_REVISION=${{ steps.git.outputs.GIT_REVISION }}
             RUST_FEATURES=${{ matrix.rust-features }}
-      - name: Compose
-        id: compose
-        run: docker compose up --wait --wait-timeout 120
-        # continue on error so we can inspect containers in the next step
-        continue-on-error: true
-      - name: Inspect containers
-        if: steps.compose.outcome != 'success'
+      # Test the dev compose, which should use the images built earlier. Technically this is only
+      # interesting when feature integration-testing is on, but we may as well exercise both.
+      - name: Compose (dev)
+        id: compose-dev
+        run: docker compose -f compose.dev.yaml --wait --wait-timeout 120
+      - name: Inspect dev containers
+        if: ${{ failure() && steps.compose-dev.outcome != 'success' }}
         run: |
           docker compose ps
           for NAME in `docker compose ps --format json | jq -r '.Name'`; do
             docker inspect $NAME
           done
-          exit 1
+
+  # Test the non-dev compose, which we use for demo purposes. This pulls images from remote repos,
+  # so no need to build anything. Additionally we want coverage across multiple operating systems.
+  compose:
+    runs-on: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compose
+        id: compose
+        run: docker compose up --wait --wait-timeout 120
+      - name: Inspect containers
+        if: ${{ failure() && steps.compose.outcome != 'success' }}
+        run: |
+          docker compose ps
+          for NAME in `docker compose ps --format json | jq -r '.Name'`; do
+            docker inspect $NAME
+          done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,6 +52,9 @@ jobs:
   # Ideally we'd test on macOS, too, but those runners don't have Docker:
   # https://github.com/actions/runner-images/issues/2150
   compose:
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,6 +57,8 @@ services:
     image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api:0.3.12}
     ports:
       - "8080:8080"
+    healthcheck:
+      test: ["CMD", "/bin/sh", "-c", "wget http://0.0.0.0:8080/health -O - >/dev/null"]
     environment:
       RUST_LOG: info
       AUTH_URL: https://auth.example

--- a/compose.yaml
+++ b/compose.yaml
@@ -54,7 +54,7 @@ services:
         condition: service_started
 
   divviup_api:
-    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api:0.3.12}
+    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api_integration_test:0.3.12}
     ports:
       - "8080:8080"
     healthcheck:


### PR DESCRIPTION
Adds a simple healthcheck on the `divviup-api` service in `compose.yaml` that tickles the health endpoint. Also adds a check to the Docker CI job that runs Docker compose and waits 120 seconds for it to become healthy.

Part of #1096