### PR TITLE
compose.yaml: autopair first-party leader

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,9 +46,11 @@ jobs:
       - name: Inspect dev containers
         if: ${{ failure() && steps.compose-dev.outcome != 'success' }}
         run: |
-          docker compose ps
-          for NAME in `docker compose ps --format json | jq -r '.Name'`; do
+          docker compose ps --all
+          for NAME in `docker compose ps --all --format json | jq -r '.Name'`; do
+            echo $NAME
             docker inspect $NAME
+            docker logs $NAME
           done
 
   # Test the non-dev compose, which we use for demo purposes. This pulls images from remote repos,
@@ -66,7 +68,9 @@ jobs:
       - name: Inspect containers
         if: ${{ failure() && steps.compose.outcome != 'success' }}
         run: |
-          docker compose ps
-          for NAME in `docker compose ps --format json | jq -r '.Name'`; do
+          docker compose ps --all
+          for NAME in `docker compose ps --all --format json | jq -r '.Name'`; do
+            echo $NAME
             docker inspect $NAME
+            docker logs $NAME
           done

--- a/compose.dev.override.yaml
+++ b/compose.dev.override.yaml
@@ -29,29 +29,8 @@ services:
           ignore:
             - README.md
 
-  # TODO(#1096): Move most of this service to compose.yaml once a `divviup_api_integration_test`
-  # built with feature `admin` is released.
   pair_aggregator:
     image: !reset null
-    entrypoint:
-      - /divviup
-      - --url=http://localhost:8080
-      - --token=""
-      - aggregator
-      - create
-      - --name=leader
-      - --api-url=http://janus_1_aggregator:8080/aggregator-api
-      - --bearer-token=0000
-      - --first-party
-      - --shared
-    network_mode: service:divviup_api
-    depends_on:
-      divviup_api:
-        condition: service_healthy
-      janus_1_aggregator:
-        condition: service_healthy
-      janus_2_aggregator:
-        condition: service_healthy
     <<: *build
     develop:
       watch:
@@ -59,16 +38,3 @@ services:
           action: rebuild
         - path: client/
           action: rebuild
-
-  # Hack: if the last service to be started exits with status 0, then `docker compose up --wait`
-  # treats that as a failure. So we force divviup_api_vite to start last. Another option would be to
-  # add a health check to pair_aggregator as in ([1]), but the timing is brittle (the main process
-  # has to last long enough for the health check to succeed at least once) so it's easier and more
-  # reliable to add this dependency.
-  #
-  # [1]: https://github.com/docker/compose/issues/11774
-  # https://github.com/docker/compose/issues/10596
-  divviup_api_vite:
-    depends_on:
-      pair_aggregator:
-        condition: service_completed_successfully

--- a/compose.yaml
+++ b/compose.yaml
@@ -45,7 +45,7 @@ services:
         target: /docker-entrypoint-initdb.d/postgres_init.sql
 
   divviup_api_migrate:
-    image: ${DIVVIUP_API_MIGRATOR_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api:0.3.12}
+    image: ${DIVVIUP_API_MIGRATOR_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api:0.3.16}
     entrypoint:
       - /migration
       - up
@@ -55,8 +55,30 @@ services:
       postgres:
         condition: service_started
 
+  pair_aggregator:
+    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api_integration_test:0.3.16}
+    entrypoint:
+      - /divviup
+      - --url=http://localhost:8080
+      - --token=""
+      - aggregator
+      - create
+      - --name=leader
+      - --api-url=http://janus_1_aggregator:8080/aggregator-api
+      - --bearer-token=0000
+      - --first-party
+      - --shared
+    network_mode: service:divviup_api
+    depends_on:
+      divviup_api:
+        condition: service_healthy
+      janus_1_aggregator:
+        condition: service_healthy
+      janus_2_aggregator:
+        condition: service_healthy
+
   divviup_api:
-    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api_integration_test:0.3.12}
+    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api_integration_test:0.3.16}
     ports:
       - "8080:8080"
     healthcheck:
@@ -101,6 +123,17 @@ services:
       watch:
         - path: ./app/package.json
           action: rebuild
+    # Hack: if the last service to be started exits with status 0, then `docker compose up --wait`
+    # treats that as a failure. So we force divviup_api_vite to start last. Another option would be
+    # to add a health check to pair_aggregator as in ([1]), but the timing is brittle (the main
+    # process has to last long enough for the health check to succeed at least once) so it's easier
+    # and more reliable to add this dependency.
+    #
+    # [1]: https://github.com/docker/compose/issues/11774
+    # https://github.com/docker/compose/issues/10596
+    depends_on:
+      pair_aggregator:
+        condition: service_completed_successfully
 
   janus_1_migrate:
     <<: *janus_migrate


### PR DESCRIPTION
To enable the demo workflow, users will need to pair two aggregators with the control plane. Further, one of them must be first-party, which can only be done using a CLI built with feature `admin`. But the one we distribute via GitHub releases isn't, and I argue it shouldn't be, which means that demo users can't appropriately pair aggregators.

We could provide a `curl` or `wget` command that'd do it, but as it turns out, we already bundle the `divviup` CLI in the `divviup_api` container, so let's just use that, since the API URL and token for the aggregators are static!

I'm thinking we should have the demo user pair the other aggregator themselves with `divviup` to simulate what they might have to do in a realistic use case, if they bring their own helper.

This commit:

- adds feature `admin` to builds of `divviup_api_integration_test` in `docker-release.yaml` so that the bundled CLI will have `--first-party` and `--shared`
- adds a service `pair_aggregator` to `compose.yaml` that uses the `/divviup` entrypoint to pair `janus_1_aggregator` as a first-party, shared aggregator
- adds a stanza for `pair_aggregator` to `compose.dev.override.yaml`
- makes `compose.dev.override.yaml` build all images with features `integration_test,admin`

Part of #1096