### PR TITLE
Build divviup_api_integration_test with `admin`

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         image: [
           { name: "divviup_api", rust_features: "default" },
-          { name: "divviup_api_integration_test", rust_features: "integration-testing" },
+          { name: "divviup_api_integration_test", rust_features: "integration-testing,admin" },
         ]
     permissions:
       id-token: write

--- a/compose.dev.override.yaml
+++ b/compose.dev.override.yaml
@@ -1,14 +1,19 @@
 # Overrides for the local development docker compose setup. Meant only to be used by
 # compose.dev.yaml
 
+x-build: &build
+  build:
+    context: .
+    args:
+      RUST_PROFILE: dev
+      # We don't need both of these features in all three services, but it allows reusing one
+      # container image for both this and the divviup_api service.
+      RUST_FEATURES: integration-testing,admin
+
 services:
   divviup_api:
     image: !reset null
-    build:
-      context: .
-      args:
-        RUST_PROFILE: dev
-        RUST_FEATURES: integration-testing
+    <<: *build
     develop:
       watch:
         - path: src/
@@ -16,16 +21,54 @@ services:
 
   divviup_api_migrate:
     image: !reset null
-    build:
-      context: .
-      args:
-        RUST_PROFILE: dev
-        # This isn't strictly required for migrations, but it allows reusing one container image
-        # for both this and the divviup_api service.
-        RUST_FEATURES: integration-testing
+    <<: *build
     develop:
       watch:
         - path: migration
           action: rebuild
           ignore:
             - README.md
+
+  # TODO(#1096): Move most of this service to compose.yaml once a `divviup_api_integration_test`
+  # built with feature `admin` is released.
+  pair_aggregator:
+    image: !reset null
+    entrypoint:
+      - /divviup
+      - --url=http://localhost:8080
+      - --token=""
+      - aggregator
+      - create
+      - --name=leader
+      - --api-url=http://janus_1_aggregator:8080/aggregator-api
+      - --bearer-token=0000
+      - --first-party
+      - --shared
+    network_mode: service:divviup_api
+    depends_on:
+      divviup_api:
+        condition: service_healthy
+      janus_1_aggregator:
+        condition: service_healthy
+      janus_2_aggregator:
+        condition: service_healthy
+    <<: *build
+    develop:
+      watch:
+        - path: cli/
+          action: rebuild
+        - path: client/
+          action: rebuild
+
+  # Hack: if the last service to be started exits with status 0, then `docker compose up --wait`
+  # treats that as a failure. So we force divviup_api_vite to start last. Another option would be to
+  # add a health check to pair_aggregator as in ([1]), but the timing is brittle (the main process
+  # has to last long enough for the health check to succeed at least once) so it's easier and more
+  # reliable to add this dependency.
+  #
+  # [1]: https://github.com/docker/compose/issues/11774
+  # https://github.com/docker/compose/issues/10596
+  divviup_api_vite:
+    depends_on:
+      pair_aggregator:
+        condition: service_completed_successfully

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,8 @@ x-janus-common: &janus_common
   restart: always
   healthcheck:
     test: ["CMD", "/bin/sh", "-c", "wget http://0.0.0.0:8000/healthz -O - >/dev/null"]
+    interval: 1s
+    retries: 10
   depends_on:
     janus_1_migrate:
       condition: service_completed_successfully
@@ -59,6 +61,8 @@ services:
       - "8080:8080"
     healthcheck:
       test: ["CMD", "/bin/sh", "-c", "wget http://0.0.0.0:8080/health -O - >/dev/null"]
+      interval: 1s
+      retries: 10
     environment:
       RUST_LOG: info
       AUTH_URL: https://auth.example


### PR DESCRIPTION
We want the `divviup` CLI packaged into the
`divviup_api_integration_test` container to be built with feature `admin` for reasons discussed in #1099. In this commit:

- add feature `admin` to builds of `divviup_api_integration_test` in `docker-release.yaml` so that the bundled CLI will have `--first-party` and `--shared`
- adds a service `pair_aggregator` to `compose.dev.override.yaml` that uses the `/divviup` entrypoint to pair `janus_1_aggregator` as a first-party, shared aggregator
- factors the `build` stanza out of services in `compose.dev.override.yaml` to apply features to them uniformly
- tunes the health checks on `divviup-api` and the aggregators so they will succeed sooner and speed up startup

Part of #1096