### PR TITLE
Commas are illegal in GHA cache keys

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -25,8 +25,8 @@ jobs:
           echo "PUBLIC_TAG=us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
           echo "PRIVATE_TAG=us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
           # Join features with , for RUST_FEATURES, but - for cache keys, where commas are illegal
-          echo "CACHE_KEY=${{ join(matrix.rust-features, "-") }}" >> $GITHUB_OUTPUT
-          echo "RUST_FEATURES=${{ join(matrix.rust-features, ",") }}" >> $GITHUB_OUTPUT
+          echo "CACHE_KEY=${{ join(matrix.rust-features, '-') }}" >> $GITHUB_OUTPUT
+          echo "RUST_FEATURES=${{ join(matrix.rust-features, ',') }}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         image: [
-          { name: "divviup_api", rust_features: "default" },
-          { name: "divviup_api_integration_test", rust_features: "integration-testing,admin" },
+          { name: "divviup_api", rust_features: ["default"] },
+          { name: "divviup_api_integration_test", rust_features: ["integration-testing", "admin"] },
         ]
     permissions:
       id-token: write
@@ -24,6 +24,9 @@ jobs:
           IMAGE=${{ matrix.image.name }}:${GITHUB_REF/refs\/tags\//}
           echo "PUBLIC_TAG=us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
           echo "PRIVATE_TAG=us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
+          # Join features with , for RUST_FEATURES, but - for cache keys, where commas are illegal
+          echo "CACHE_KEY=${{ join(matrix.rust-features, "-") }}" >> $GITHUB_OUTPUT
+          echo "RUST_FEATURES=${{ join(matrix.rust-features, ",") }}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -41,9 +44,9 @@ jobs:
           tags: "${{ steps.resolve_variables.outputs.PUBLIC_TAG}},${{ steps.resolve_variables.outputs.PRIVATE_TAG }}"
           build-args: |
             GIT_REVISION=${{ steps.resolve_variables.outputs.GIT_REVISION }}
-            RUST_FEATURES=${{ matrix.image.rust_features }}
+            RUST_FEATURES=${{ steps.resolve_variables.outputs.RUST_FEATURES }}
           cache-from: |
-            type=gha,scope=main-${{ matrix.image.rust_features }}
+            type=gha,scope=main-${{ steps.resolve_variables.outputs.CACHE_KEY }}
       - id: gcp-auth-private
         name: Authenticate to GCP (private repository)
         uses: google-github-actions/auth@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,12 +10,16 @@ jobs:
   build_docker:
     strategy:
       matrix:
-        rust-features: ["default", "integration-testing"]
+        rust-features: [["default"], ["integration-testing"] , [admin"]]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - id: git
-        run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
+      - id: resolve_variables
+        run: |
+          echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
+          # Join features with , for RUST_FEATURES, but - for cache keys, where commas are illegal
+          echo "CACHE_KEY=${{ join(matrix.rust-features, "-") }}" >> $GITHUB_OUTPUT
+          echo "RUST_FEATURES=${{ join(matrix.rust-features, ",") }}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -28,12 +32,12 @@ jobs:
           push: false
           load: true
           cache-from: |
-            type=gha,scope=main-${{ matrix.rust-features }}
-            type=gha,scope=${{ github.ref_name }}-${{ matrix.rust-features }}
-          cache-to: type=gha,scope=${{ github.ref_name }}-${{ matrix.rust-features }},mode=max
+            type=gha,scope=main-${{ steps.resolve_variables.outputs.CACHE_KEY }}
+            type=gha,scope=${{ github.ref_name }}-${{ steps.resolve_variables.outputs.CACHE_KEY }}
+          cache-to: type=gha,scope=${{ github.ref_name }}-${{ steps.resolve_variables.outputs.CACHE_KEY }},mode=max
           build-args: |
-            GIT_REVISION=${{ steps.git.outputs.GIT_REVISION }}
-            RUST_FEATURES=${{ matrix.rust-features }}
+            GIT_REVISION=${{ steps.resolve_variables.outputs.GIT_REVISION }}
+            RUST_FEATURES=${{ steps.resolve_variables.outputs.RUST_FEATURES }}
       # Test the dev compose, which should use the images built earlier. Technically this is only
       # interesting when feature integration-testing is on, but we may as well exercise both.
       - name: Compose (dev)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
   build_docker:
     strategy:
       matrix:
-        rust-features: [["default"], ["integration-testing"] , [admin"]]
+        rust-features: [["default"], ["integration-testing" , admin"]]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,8 +18,8 @@ jobs:
         run: |
           echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
           # Join features with , for RUST_FEATURES, but - for cache keys, where commas are illegal
-          echo "CACHE_KEY=${{ join(matrix.rust-features, "-") }}" >> $GITHUB_OUTPUT
-          echo "RUST_FEATURES=${{ join(matrix.rust-features, ",") }}" >> $GITHUB_OUTPUT
+          echo "CACHE_KEY=${{ join(matrix.rust-features, '-') }}" >> $GITHUB_OUTPUT
+          echo "RUST_FEATURES=${{ join(matrix.rust-features, ',') }}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
In #1100, we started building `divviup_api_integration_test` with feature `admin`. This breaks `docker-release.yml`, because the Rust features are used to construct GH Actions cache keys, and commas are illegal there (at the very least, `docker buildx build --cache-from` doesn't like it). Construct the cache key by joining with `-` to work `around this.

Additionally, this _should_ have broken `docker.yml`, but I forgot to add the `admin` feature there, which this PR corrects.

Part of #1096