### PR TITLE
Try to fix trailing quote

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -25,8 +25,8 @@ jobs:
           echo "PUBLIC_TAG=us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
           echo "PRIVATE_TAG=us-west2-docker.pkg.dev/janus-artifacts/divviup-api/${IMAGE}" >> $GITHUB_OUTPUT
           # Join features with , for RUST_FEATURES, but - for cache keys, where commas are illegal
-          echo "CACHE_KEY=${{ join(matrix.rust-features, '-') }}" >> $GITHUB_OUTPUT
-          echo "RUST_FEATURES=${{ join(matrix.rust-features, ',') }}" >> $GITHUB_OUTPUT
+          echo "CACHE_KEY=${{ join(matrix.image.rust-features, '-') }}" >> $GITHUB_OUTPUT
+          echo "RUST_FEATURES=${{ join(matrix.image.rust-features, ',') }}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
   build_docker:
     strategy:
       matrix:
-        rust-features: [["default"], ["integration-testing" , admin"]]
+        rust-features: [["default"], ["integration-testing", admin"]]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,8 +18,8 @@ jobs:
         run: |
           echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
           # Join features with , for RUST_FEATURES, but - for cache keys, where commas are illegal
-          echo "CACHE_KEY=${{ join(matrix.rust-features, '-') }}" >> $GITHUB_OUTPUT
-          echo "RUST_FEATURES=${{ join(matrix.rust-features, ',') }}" >> $GITHUB_OUTPUT
+          echo CACHE_KEY=${{ join(matrix.rust-features, '-') }} >> $GITHUB_OUTPUT
+          echo RUST_FEATURES=${{ join(matrix.rust-features, ',') }} >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
   build_docker:
     strategy:
       matrix:
-        rust-features: [["default"], ["integration-testing", admin"]]
+        rust-features: [["default"], ["integration-testing", "admin"]]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,8 +18,8 @@ jobs:
         run: |
           echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_OUTPUT
           # Join features with , for RUST_FEATURES, but - for cache keys, where commas are illegal
-          echo CACHE_KEY=${{ join(matrix.rust-features, '-') }} >> $GITHUB_OUTPUT
-          echo RUST_FEATURES=${{ join(matrix.rust-features, ',') }} >> $GITHUB_OUTPUT
+          echo "CACHE_KEY=${{ join(matrix.rust-features, '-') }}" >> $GITHUB_OUTPUT
+          echo "RUST_FEATURES=${{ join(matrix.rust-features, ',') }}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
I'm not sure why, but in an action, with `rust-features = ["integration-testing", "admin"]`

`echo CACHE_KEY=${{ join(matrix.rust-features, '-') }} >> $GITHUB_OUTPUT`

expands to

`echo "CACHE_KEY=integration-testing-admin"" >> $GITHUB_OUTPUT`

Note the double double-quotes before `>>`.

https://github.com/divviup/divviup-api/actions/runs/9521847561/job/26250168597#step:3:4