### PR TITLE
Add Dependabot group for Janus dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
         patterns:
           - "trillium"
           - "trillium-*"
+      janus:
+        patterns:
+          - "janus_*"
   - package-ecosystem: "npm"
     directory: "app"
     schedule:


### PR DESCRIPTION
This adds another Dependabot group, now that we have added dependencies on `janus_client` and `janus_collector`.