### PR TITLE
Only use Vite in compose.dev.yaml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,6 +62,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        # This should work without any of the project sources except compose.yaml
+        with:
+          sparse-checkout: |
+            compose.yaml
+          # Disable cone mode so we only grab a specific file
+          # https://github.com/actions/checkout?tab=readme-ov-file#fetch-only-a-single-file
+          # https://git-scm.com/docs/git-sparse-checkout
+          sparse-checkout-cone-mode: false
       - name: Compose
         id: compose
         run: docker compose up --wait --wait-timeout 120

--- a/compose.dev.override.yaml
+++ b/compose.dev.override.yaml
@@ -38,3 +38,27 @@ services:
           action: rebuild
         - path: client/
           action: rebuild
+
+  # In the development context, we serve static assets using Vite and a bind mount, so that changes
+  # to the local assets will immediately be reflected.
+  static_assets:
+    image: !reset null
+    healthcheck: !reset null
+    build:
+      context: .
+      # `develop` cannot be used with an `image` directive, so we need to use a minimal dockerfile
+      # containing the image we need.
+      dockerfile: Dockerfile.vite
+    working_dir: /srv/app
+    volumes:
+     - type: bind
+       source: ./app
+       target: /srv/app
+    entrypoint:
+      - /bin/sh
+      - -c
+      - npm i && npx vite --host=0.0.0.0
+    develop:
+      watch:
+        - path: ./app/package.json
+          action: rebuild

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,23 @@ x-janus-environment: &janus_environment
   DATASTORE_KEYS: 1B6szboUUtMfyrLsIVE20g
   AGGREGATOR_API_AUTH_TOKENS: "0000"
 
+x-divviup-image: &divviup_image
+  image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api_integration_test:0.3.16}
+
+x-divviup-environment: &divviup_environment
+  RUST_LOG: info
+  AUTH_URL: https://auth.example
+  AUTH_CLIENT_ID: fake
+  AUTH_CLIENT_SECRET: fake
+  SESSION_SECRETS: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  DATABASE_ENCRYPTION_KEYS: heHIWC_qxHzdglI0VgLopQ
+  AUTH_AUDIENCE: https://app.example
+  APP_URL: http://localhost:8081
+  DATABASE_URL: postgres://postgres:postgres@postgres:5432/divviup
+  API_URL: http://localhost:8080
+  POSTMARK_TOKEN: fake
+  EMAIL_ADDRESS: the@from.address
+
 services:
   postgres:
     image: docker.io/library/postgres:16
@@ -56,7 +73,7 @@ services:
         condition: service_started
 
   pair_aggregator:
-    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api_integration_test:0.3.16}
+    <<: *divviup_image
     entrypoint:
       - /bin/sh
       - -c
@@ -82,51 +99,33 @@ services:
         condition: service_healthy
 
   divviup_api:
-    image: ${DIVVIUP_API_IMAGE:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-api/divviup_api_integration_test:0.3.16}
-    ports:
-      - "8080:8080"
+    <<: *divviup_image
     healthcheck:
       test: ["CMD", "/bin/sh", "-c", "wget http://0.0.0.0:8080/health -O - >/dev/null"]
       interval: 1s
       retries: 10
+    ports:
+      - "8080:8080"
     environment:
-      RUST_LOG: info
-      AUTH_URL: https://auth.example
-      AUTH_CLIENT_ID: fake
-      AUTH_CLIENT_SECRET: fake
-      SESSION_SECRETS: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-      DATABASE_ENCRYPTION_KEYS: heHIWC_qxHzdglI0VgLopQ
-      AUTH_AUDIENCE: https://app.example
-      APP_URL: http://localhost:8081
-      DATABASE_URL: postgres://postgres:postgres@postgres:5432/divviup
-      API_URL: http://localhost:8080
-      POSTMARK_TOKEN: fake
-      EMAIL_ADDRESS: the@from.address
+      <<: *divviup_environment
     depends_on:
       divviup_api_migrate:
         condition: service_completed_successfully
 
-  divviup_api_vite:
-    build:
-      context: .
-      # `develop` cannot be used with an `image` directive, so we need to use a minimal dockerfile
-      # containing the image we need.
-      dockerfile: Dockerfile.vite
+  # Run a second divviup_api just to serve static assets, so that users can browse to localhost:8081
+  # and play with the console. It'd be nice to do this from service divviup_api, but it only binds a
+  # single port and insists on serving assets and its API on distinct hostnames.
+  static_assets:
+    <<: *divviup_image
+    healthcheck:
+      test: ["CMD", "/bin/sh", "-c", "wget http://0.0.0.0:8081/health -O - >/dev/null"]
+      interval: 1s
+      retries: 10
     ports:
       - "8081:8081"
-    working_dir: /srv/app
-    volumes:
-     - type: bind
-       source: ./app
-       target: /srv/app
-    entrypoint:
-      - /bin/sh
-      - -c
-      - npm i && npx vite --host=0.0.0.0
-    develop:
-      watch:
-        - path: ./app/package.json
-          action: rebuild
+    environment:
+      PORT: 8081
+      <<: *divviup_environment
     # Hack: if the last service to be started exits with status 0, then `docker compose up --wait`
     # treats that as a failure. So we force divviup_api_vite to start last. Another option would be
     # to add a health check to pair_aggregator as in ([1]), but the timing is brittle (the main


### PR DESCRIPTION
We want demo users to be able to get started with nothing but a `divviup` binary, a working Docker Compose install and `compose.yaml`. `divviup_api_vite` relies on having a local checkout of the static assets to serve. We now use the `diviup_api_integration_test` image to serve static assets from service `static_assets`. The assets in question are already present in the image being run in service `divviup_api`, but I did it this way for the following reasons:

- `divviup-api` routes requests to the static asset handler based on hostname, making it difficult to serve alongside the API. I tried creating some aliases ([1]) in Docker Compose, but those names are only visible inside the compose network, meaning you have to set the `Host` header from outside the netns, which is a hassle I don't want to inflict on demo users.
- Having a distinct service for assets is convenient because we can make it depend on `pair_aggregators`. If that ran last, it could cause `docker compose up --wait` to fail (see comment in `compose.yaml`).

[1]: https://docs.docker.com/compose/compose-file/05-services/#aliases

Part of #1096