### PR TITLE
`docker.yml`: run demo script in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           export DIVVIUP_API_URL=http://localhost:8080
           export DIVVIUP_TOKEN=""
-          export DIVVIUP_ACCOUNT_ID=`./divviup account list | jq -r '.[0].id`
+          export DIVVIUP_ACCOUNT_ID=`./divviup account list | jq -r '.[0].id'`
           export LEADER_ID=`./divviup aggregator list | jq -r 'map_values(select(.name == "leader")).[0].id'`
           export HELPER_ID=`./divviup aggregator list | jq -r 'map_values(select(.name == "helper")).[0].id'`
           CRED_OUTPUT=`./divviup collector-credential generate --save`

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,7 +123,7 @@ jobs:
 
           echo "finished uploading measurements"
 
-          sleep 1200
+          sleep 120
 
           ./divviup dap-client collect \
             --task-id $TASK_ID \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,7 +91,8 @@ jobs:
           printf 'account ID %s\n' $DIVVIUP_ACCOUNT_ID
 
           AGGREGATOR_LIST=`./divviup aggregator list`
-          printf 'aggregator list %s\n' $AGGREGATOR_LIST
+          echo "aggregator list:"
+          echo $AGGREGATOR_LIST
 
           LEADER_ID=`echo $AGGREGATOR_LIST | jq -r '.[] |= select(.name == "leader") |.[0].id'`
           printf 'leader ID %s\n' $LEADER_ID
@@ -100,7 +101,8 @@ jobs:
           printf 'helper ID %s\n' $HELPER_ID
 
           CRED_OUTPUT=`./divviup collector-credential generate --save`
-          printf 'collector credential %s\n' $CRED_OUTPUT
+          echo "collector credential:"
+          echo $CRED_OUTPUT
 
           COLLECTOR_CREDENTIAL_PATH=${PWD}/`echo $CRED_OUTPUT | jq -r '.name' 2>/dev/null || echo ''`.json
           printf 'collector credential path %s\n' $COLLECTOR_CREDENTIAL_PATH
@@ -113,7 +115,8 @@ jobs:
             --collector-credential-id $COLLECTOR_CREDENTIAL_ID \
             --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
             --min-batch-size 100 --max-batch-size 200 --time-precision 60sec`
-          printf 'task %s\n' $TASK
+          echo "task:"
+          echo $TASK
           TASK_ID=`echo $TASK | jq -r '.id'`
 
           for i in {1..150}; do

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,7 +123,7 @@ jobs:
 
           echo "finished uploading measurements"
 
-          sleep 600
+          sleep 1200
 
           ./divviup dap-client collect \
             --task-id $TASK_ID \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,7 +123,7 @@ jobs:
 
           echo "finished uploading measurements"
 
-          sleep 120
+          sleep 360
 
           ./divviup dap-client collect \
             --task-id $TASK_ID \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,13 +76,6 @@ jobs:
           mkdir compose
           cp checkout/target/release/divviup compose/
           cp checkout/compose.yaml compose/
-      # ubuntu-latest is 22.04, which does not package jq newer than 1.6.1, so grab a binary from
-      # GitHub releases
-      - name: install jq 1.7
-        run: |
-          curl -Lso jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
-          chmod +x jq
-          ./jq --version
       - name: Compose
         id: compose
         run: docker compose up --wait --wait-timeout 120
@@ -94,25 +87,25 @@ jobs:
           export DIVVIUP_API_URL=http://localhost:8080
           export DIVVIUP_TOKEN=""
 
-          export DIVVIUP_ACCOUNT_ID=`./divviup account list | ../jq -r '.[0].id'`
+          export DIVVIUP_ACCOUNT_ID=`./divviup account list | jq -r '.[0].id'`
           printf 'account ID %s\n' $DIVVIUP_ACCOUNT_ID
 
           AGGREGATOR_LIST=`./divviup aggregator list`
           printf 'aggregator list %s\n' $AGGREGATOR_LIST
 
-          LEADER_ID=`echo $AGGREGATOR_LIST | ../jq -r 'map_values(select(.name == "leader")).[0].id'`
+          LEADER_ID=`echo $AGGREGATOR_LIST | jq -r '.[] |= select(.name == "leader") |.[0].id'`
           printf 'leader ID %s\n' $LEADER_ID
 
-          HELPER_ID=`echo $AGGREGATOR_LIST | ../jq -r 'map_values(select(.name == "helper")).[0].id'`
+          HELPER_ID=`echo $AGGREGATOR_LIST | jq -r '.[] |= select(.name == "helper") |.[0].id'`
           printf 'helper ID %s\n' $HELPER_ID
 
           CRED_OUTPUT=`./divviup collector-credential generate --save`
           printf 'collector credential %s\n' $CRED_OUTPUT
 
-          COLLECTOR_CREDENTIAL_PATH=${PWD}/`echo $CRED_OUTPUT | ../jq -r '.name' 2>/dev/null || echo ''`.json
+          COLLECTOR_CREDENTIAL_PATH=${PWD}/`echo $CRED_OUTPUT | jq -r '.name' 2>/dev/null || echo ''`.json
           printf 'collector credential path %s\n' $COLLECTOR_CREDENTIAL_PATH
 
-          COLLECTOR_CREDENTIAL_ID=`echo $CRED_OUTPUT | ../jq -r '.id' 2>/dev/null || echo ''`
+          COLLECTOR_CREDENTIAL_ID=`echo $CRED_OUTPUT | jq -r '.id' 2>/dev/null || echo ''`
           printf 'collector credential ID %s\n' $COLLECTOR_CREDENTIAL_ID
 
           TASK=`./divviup task create --name net-promoter-score \
@@ -121,16 +114,16 @@ jobs:
             --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
             --min-batch-size 100 --max-batch-size 200 --time-precision 60sec`
           printf 'task %s\n' $TASK
-          TASK_ID=`echo $TASK | ../jq -r '.id'`
+          TASK_ID=`echo $TASK | jq -r '.id'`
 
           for i in {1..150}; do
             measurement=$(( $RANDOM % 10 ))
             ./divviup dap-client upload --task-id $TASK_ID --measurement $measurement;
           done
 
-          sleep 120
+          sleep 60
 
-          divviup dap-client collect \
+          ./divviup dap-client collect \
             --task-id $TASK_ID \
             --collector-credential-file $COLLECTOR_CREDENTIAL_PATH \
             --current-batch

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,9 +73,9 @@ jobs:
       - run: cargo build --package divviup-cli --profile release
         working-directory: checkout
       - run: |
-        mkdir compose
-        cp checkout/target/release/divviup compose/
-        cp checkout/compose.yaml compose/
+          mkdir compose
+          cp checkout/target/release/divviup compose/
+          cp checkout/compose.yaml compose/
       - name: Compose
         id: compose
         run: docker compose up --wait --wait-timeout 120

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -121,7 +121,9 @@ jobs:
             ./divviup dap-client upload --task-id $TASK_ID --measurement $measurement;
           done
 
-          sleep 60
+          echo "finished uploading measurements"
+
+          sleep 120
 
           ./divviup dap-client collect \
             --task-id $TASK_ID \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,6 +76,13 @@ jobs:
           mkdir compose
           cp checkout/target/release/divviup compose/
           cp checkout/compose.yaml compose/
+      # ubuntu-latest is 22.04, which does not package jq newer than 1.6.1, so grab a binary from
+      # GitHub releases
+      - name: install jq 1.7
+        run: |
+          curl -Lso jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+          chmod +x jq
+          ./jq --version
       - name: Compose
         id: compose
         run: docker compose up --wait --wait-timeout 120
@@ -84,29 +91,28 @@ jobs:
         id: demo-script
         working-directory: compose
         run: |
-          jq --version
-          DIVVIUP_API_URL=http://localhost:8080
-          DIVVIUP_TOKEN=""
+          export DIVVIUP_API_URL=http://localhost:8080
+          export DIVVIUP_TOKEN=""
 
-          DIVVIUP_ACCOUNT_ID=`./divviup account list | jq -r '.[0].id'`
+          export DIVVIUP_ACCOUNT_ID=`./divviup account list | ../jq -r '.[0].id'`
           printf 'account ID %s\n' $DIVVIUP_ACCOUNT_ID
 
           AGGREGATOR_LIST=`./divviup aggregator list`
           printf 'aggregator list %s\n' $AGGREGATOR_LIST
 
-          LEADER_ID=`echo $AGGREGATOR_LIST | jq -r 'map_values(select(.name == "leader")).[0].id'`
+          LEADER_ID=`echo $AGGREGATOR_LIST | ../jq -r 'map_values(select(.name == "leader")).[0].id'`
           printf 'leader ID %s\n' $LEADER_ID
 
-          HELPER_ID=`echo $AGGREGATOR_LIST | jq -r 'map_values(select(.name == "helper")).[0].id'`
+          HELPER_ID=`echo $AGGREGATOR_LIST | ../jq -r 'map_values(select(.name == "helper")).[0].id'`
           printf 'helper ID %s\n' $HELPER_ID
 
           CRED_OUTPUT=`./divviup collector-credential generate --save`
           printf 'collector credential %s\n' $CRED_OUTPUT
 
-          COLLECTOR_CREDENTIAL_PATH=${PWD}/`echo $CRED_OUTPUT | jq -r '.name' 2>/dev/null || echo ''`.json
+          COLLECTOR_CREDENTIAL_PATH=${PWD}/`echo $CRED_OUTPUT | ../jq -r '.name' 2>/dev/null || echo ''`.json
           printf 'collector credential path %s\n' $COLLECTOR_CREDENTIAL_PATH
 
-          COLLECTOR_CREDENTIAL_ID=`echo $CRED_OUTPUT | jq -r '.id' 2>/dev/null || echo ''`
+          COLLECTOR_CREDENTIAL_ID=`echo $CRED_OUTPUT | ../jq -r '.id' 2>/dev/null || echo ''`
           printf 'collector credential ID %s\n' $COLLECTOR_CREDENTIAL_ID
 
           TASK=./divviup task create --name net-promoter-score \
@@ -115,7 +121,7 @@ jobs:
             --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
             --min-batch-size 100 --max-batch-size 200 --time-precision 60sec
           printf 'task %s\n' $TASK
-          TASK_ID=`echo $TASK | jq -r '.id'`
+          TASK_ID=`echo $TASK | ../jq -r '.id'`
 
           for i in {1..150}; do
             measurement=$(( $RANDOM % 10 ))

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,11 +115,11 @@ jobs:
           COLLECTOR_CREDENTIAL_ID=`echo $CRED_OUTPUT | ../jq -r '.id' 2>/dev/null || echo ''`
           printf 'collector credential ID %s\n' $COLLECTOR_CREDENTIAL_ID
 
-          TASK=./divviup task create --name net-promoter-score \
+          TASK=`./divviup task create --name net-promoter-score \
             --leader-aggregator-id $LEADER_ID --helper-aggregator-id $HELPER_ID \
             --collector-credential-id $COLLECTOR_CREDENTIAL_ID \
             --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
-            --min-batch-size 100 --max-batch-size 200 --time-precision 60sec
+            --min-batch-size 100 --max-batch-size 200 --time-precision 60sec`
           printf 'task %s\n' $TASK
           TASK_ID=`echo $TASK | ../jq -r '.id'`
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,11 +112,11 @@ jobs:
             --leader-aggregator-id $LEADER_ID --helper-aggregator-id $HELPER_ID \
             --collector-credential-id $COLLECTOR_CREDENTIAL_ID \
             --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
-            --min-batch-size 100 --max-batch-size 200 --time-precision 60sec`
+            --min-batch-size 10 --max-batch-size 200 --time-precision 60sec`
           printf 'task %s\n' $TASK
           TASK_ID=`echo $TASK | jq -r '.id'`
 
-          for i in {1..150}; do
+          for i in {1..15}; do
             measurement=$(( $RANDOM % 10 ))
             ./divviup dap-client upload --task-id $TASK_ID --measurement $measurement;
           done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,18 +112,18 @@ jobs:
             --leader-aggregator-id $LEADER_ID --helper-aggregator-id $HELPER_ID \
             --collector-credential-id $COLLECTOR_CREDENTIAL_ID \
             --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
-            --min-batch-size 10 --max-batch-size 200 --time-precision 60sec`
+            --min-batch-size 100 --max-batch-size 200 --time-precision 60sec`
           printf 'task %s\n' $TASK
           TASK_ID=`echo $TASK | jq -r '.id'`
 
-          for i in {1..15}; do
+          for i in {1..150}; do
             measurement=$(( $RANDOM % 10 ))
             ./divviup dap-client upload --task-id $TASK_ID --measurement $measurement;
           done
 
           echo "finished uploading measurements"
 
-          sleep 360
+          sleep 600
 
           ./divviup dap-client collect \
             --task-id $TASK_ID \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,19 +67,65 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        # This should work without any of the project sources except compose.yaml
         with:
-          sparse-checkout: |
-            compose.yaml
-          # Disable cone mode so we only grab a specific file
-          # https://github.com/actions/checkout?tab=readme-ov-file#fetch-only-a-single-file
-          # https://git-scm.com/docs/git-sparse-checkout
-          sparse-checkout-cone-mode: false
+          path: checkout
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --package divviup-cli --profile release
+        working-directory: checkout
+      - run: |
+        mkdir compose
+        cp checkout/target/release/divviup compose/
+        cp checkout/compose.yaml compose/
       - name: Compose
         id: compose
         run: docker compose up --wait --wait-timeout 120
+        working-directory: compose
+      - name: Demo script
+        id: demo-script
+        working-directory: compose
+        run: |
+          export DIVVIUP_API_URL=http://localhost:8080
+          export DIVVIUP_TOKEN=""
+          export DIVVIUP_ACCOUNT_ID=`./divviup account list | jq -r '.[0].id`
+          export LEADER_ID=`./divviup aggregator list | jq -r 'map_values(select(.name == "leader")).[0].id'`
+          export HELPER_ID=`./divviup aggregator list | jq -r 'map_values(select(.name == "helper")).[0].id'`
+          CRED_OUTPUT=`./divviup collector-credential generate --save`
+          export COLLECTOR_CREDENTIAL_PATH=${PWD}/`echo $CRED_OUTPUT | jq -r '.name' 2>/dev/null || echo ''`.json
+          export COLLECTOR_CREDENTIAL_ID=`echo $CRED_OUTPUT | jq -r '.id' 2>/dev/null || echo ''`
+
+          echo $DIVVIUP_API_URL
+          echo $DIVVIUP_TOKEN
+          echo $DIVVIUP_ACCOUNT_ID
+          echo $LEADER_ID
+          echo $HELPER_ID
+          echo COLLECTOR_CREDENTIAL_ID
+          echo COLLECTOR_CREDENTIAL_PATH
+
+          TASK=./divviup task create --name net-promoter-score \
+            --leader-aggregator-id $LEADER_ID --helper-aggregator-id $HELPER_ID \
+            --collector-credential-id $COLLECTOR_CREDENTIAL_ID \
+            --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
+            --min-batch-size 100 --max-batch-size 200 --time-precision 60sec
+          echo $TASK
+          export TASK_ID=`echo $TASK | jq -r '.id'`
+
+          echo $TASK_ID
+
+          for i in {1..150}; do
+            measurement=$(( $RANDOM % 10 ))
+            ./divviup dap-client upload --task-id $TASK_ID --measurement $measurement;
+          done
+
+          sleep 120
+
+          divviup dap-client collect \
+            --task-id $TASK_ID \
+            --collector-credential-file $COLLECTOR_CREDENTIAL_PATH \
+            --current-batch
+
       - name: Inspect containers
         if: ${{ failure() && steps.compose.outcome != 'success' }}
+        working-directory: compose
         run: |
           docker compose ps --all
           for NAME in `docker compose ps --all --format json | jq -r '.Name'`; do

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,32 +84,38 @@ jobs:
         id: demo-script
         working-directory: compose
         run: |
-          export DIVVIUP_API_URL=http://localhost:8080
-          export DIVVIUP_TOKEN=""
-          export DIVVIUP_ACCOUNT_ID=`./divviup account list | jq -r '.[0].id'`
-          export LEADER_ID=`./divviup aggregator list | jq -r 'map_values(select(.name == "leader")).[0].id'`
-          export HELPER_ID=`./divviup aggregator list | jq -r 'map_values(select(.name == "helper")).[0].id'`
-          CRED_OUTPUT=`./divviup collector-credential generate --save`
-          export COLLECTOR_CREDENTIAL_PATH=${PWD}/`echo $CRED_OUTPUT | jq -r '.name' 2>/dev/null || echo ''`.json
-          export COLLECTOR_CREDENTIAL_ID=`echo $CRED_OUTPUT | jq -r '.id' 2>/dev/null || echo ''`
+          jq --version
+          DIVVIUP_API_URL=http://localhost:8080
+          DIVVIUP_TOKEN=""
 
-          echo $DIVVIUP_API_URL
-          echo $DIVVIUP_TOKEN
-          echo $DIVVIUP_ACCOUNT_ID
-          echo $LEADER_ID
-          echo $HELPER_ID
-          echo COLLECTOR_CREDENTIAL_ID
-          echo COLLECTOR_CREDENTIAL_PATH
+          DIVVIUP_ACCOUNT_ID=`./divviup account list | jq -r '.[0].id'`
+          printf 'account ID %s\n' $DIVVIUP_ACCOUNT_ID
+
+          AGGREGATOR_LIST=`./divviup aggregator list`
+          printf 'aggregator list %s\n' $AGGREGATOR_LIST
+
+          LEADER_ID=`echo $AGGREGATOR_LIST | jq -r 'map_values(select(.name == "leader")).[0].id'`
+          printf 'leader ID %s\n' $LEADER_ID
+
+          HELPER_ID=`echo $AGGREGATOR_LIST | jq -r 'map_values(select(.name == "helper")).[0].id'`
+          printf 'helper ID %s\n' $HELPER_ID
+
+          CRED_OUTPUT=`./divviup collector-credential generate --save`
+          printf 'collector credential %s\n' $CRED_OUTPUT
+
+          COLLECTOR_CREDENTIAL_PATH=${PWD}/`echo $CRED_OUTPUT | jq -r '.name' 2>/dev/null || echo ''`.json
+          printf 'collector credential path %s\n' $COLLECTOR_CREDENTIAL_PATH
+
+          COLLECTOR_CREDENTIAL_ID=`echo $CRED_OUTPUT | jq -r '.id' 2>/dev/null || echo ''`
+          printf 'collector credential ID %s\n' $COLLECTOR_CREDENTIAL_ID
 
           TASK=./divviup task create --name net-promoter-score \
             --leader-aggregator-id $LEADER_ID --helper-aggregator-id $HELPER_ID \
             --collector-credential-id $COLLECTOR_CREDENTIAL_ID \
             --vdaf histogram --categorical-buckets 0,1,2,3,4,5,6,7,8,9,10 \
             --min-batch-size 100 --max-batch-size 200 --time-precision 60sec
-          echo $TASK
-          export TASK_ID=`echo $TASK | jq -r '.id'`
-
-          echo $TASK_ID
+          printf 'task %s\n' $TASK
+          TASK_ID=`echo $TASK | jq -r '.id'`
 
           for i in {1..150}; do
             measurement=$(( $RANDOM % 10 ))
@@ -124,7 +130,7 @@ jobs:
             --current-batch
 
       - name: Inspect containers
-        if: ${{ failure() && steps.compose.outcome != 'success' }}
+        if: ${{ failure() && (steps.compose.outcome != 'success' || steps.demo-script.outcome != 'success') }}
         working-directory: compose
         run: |
           docker compose ps --all

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,7 +27,7 @@ x-janus-migrate: &janus_migrate
       condition: service_healthy
 
 x-janus-environment: &janus_environment
-  RUST_LOG: info
+  #RUST_LOG: info
   PGPASSWORD: postgres
   DATASTORE_KEYS: 1B6szboUUtMfyrLsIVE20g
   AGGREGATOR_API_AUTH_TOKENS: "0000"
@@ -165,6 +165,7 @@ services:
       - "9001:8080"
     environment:
       CONFIG_FILE: /janus_1_aggregator.yaml
+      RUST_LOG: info
       <<: *janus_environment
 
   janus_1_aggregation_job_creator:
@@ -174,6 +175,7 @@ services:
       - janus_1_aggregation_job_creator.yaml
     environment:
       CONFIG_FILE: /janus_1_aggregation_job_creator.yaml
+      RUST_LOG: debug
       <<: *janus_environment
 
   janus_1_aggregation_job_driver:
@@ -183,6 +185,7 @@ services:
       - janus_1_aggregation_job_driver.yaml
     environment:
       CONFIG_FILE: /janus_1_aggregation_job_driver.yaml
+      RUST_LOG: debug
       <<: *janus_environment
 
   janus_1_collection_job_driver:
@@ -192,6 +195,7 @@ services:
       - janus_1_collection_job_driver.yaml
     environment:
       CONFIG_FILE: /janus_1_collection_job_driver.yaml
+      RUST_LOG: debug
       <<: *janus_environment
 
   janus_1_garbage_collector:
@@ -201,6 +205,7 @@ services:
       - janus_1_garbage_collector.yaml
     environment:
       CONFIG_FILE: /janus_1_garbage_collector.yaml
+      RUST_LOG: info
       <<: *janus_environment
 
   janus_2_migrate:
@@ -217,6 +222,7 @@ services:
       - "9002:8080"
     environment:
       CONFIG_FILE: /janus_2_aggregator.yaml
+      RUST_LOG: debug
       <<: *janus_environment
 
   janus_2_aggregation_job_creator:
@@ -226,6 +232,7 @@ services:
       - janus_2_aggregation_job_creator.yaml
     environment:
       CONFIG_FILE: /janus_2_aggregation_job_creator.yaml
+      RUST_LOG: info
       <<: *janus_environment
 
   janus_2_aggregation_job_driver:
@@ -235,6 +242,7 @@ services:
       - janus_2_aggregation_job_driver.yaml
     environment:
       CONFIG_FILE: /janus_2_aggregation_job_driver.yaml
+      RUST_LOG: info
       <<: *janus_environment
 
   janus_2_collection_job_driver:
@@ -244,6 +252,7 @@ services:
       - janus_2_collection_job_driver.yaml
     environment:
       CONFIG_FILE: /janus_2_collection_job_driver.yaml
+      RUST_LOG: info
       <<: *janus_environment
 
   janus_2_garbage_collector:
@@ -253,6 +262,7 @@ services:
       - janus_2_garbage_collector.yaml
     environment:
       CONFIG_FILE: /janus_2_garbage_collector.yaml
+      RUST_LOG: info
       <<: *janus_environment
 
 configs:

--- a/compose.yaml
+++ b/compose.yaml
@@ -291,7 +291,7 @@ configs:
         url: "postgres://postgres@postgres:5432/janus_1"
       health_check_listen_address: "0.0.0.0:8000"
       batch_aggregation_shard_count: 32
-      tasks_update_frequency_secs: 3600
+      tasks_update_frequency_secs: 10
       aggregation_job_creation_interval_secs: 10
       min_aggregation_job_size: 10
       max_aggregation_job_size: 100
@@ -350,7 +350,7 @@ configs:
         url: "postgres://postgres@postgres:5432/janus_2"
       health_check_listen_address: "0.0.0.0:8000"
       batch_aggregation_shard_count: 32
-      tasks_update_frequency_secs: 3600
+      tasks_update_frequency_secs: 10
       aggregation_job_creation_interval_secs: 10
       min_aggregation_job_size: 10
       max_aggregation_job_size: 100

--- a/compose.yaml
+++ b/compose.yaml
@@ -282,7 +282,7 @@ configs:
       health_check_listen_address: "0.0.0.0:8000"
       batch_aggregation_shard_count: 32
       tasks_update_frequency_secs: 3600
-      aggregation_job_creation_interval_secs: 60
+      aggregation_job_creation_interval_secs: 10
       min_aggregation_job_size: 10
       max_aggregation_job_size: 100
 
@@ -341,7 +341,7 @@ configs:
       health_check_listen_address: "0.0.0.0:8000"
       batch_aggregation_shard_count: 32
       tasks_update_frequency_secs: 3600
-      aggregation_job_creation_interval_secs: 60
+      aggregation_job_creation_interval_secs: 10
       min_aggregation_job_size: 10
       max_aggregation_job_size: 100
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,7 +27,7 @@ x-janus-migrate: &janus_migrate
       condition: service_healthy
 
 x-janus-environment: &janus_environment
-  #RUST_LOG: info
+  RUST_LOG: info
   PGPASSWORD: postgres
   DATASTORE_KEYS: 1B6szboUUtMfyrLsIVE20g
   AGGREGATOR_API_AUTH_TOKENS: "0000"
@@ -175,7 +175,6 @@ services:
       - "9001:8080"
     environment:
       CONFIG_FILE: /janus_1_aggregator.yaml
-      RUST_LOG: info
       <<: *janus_environment
 
   janus_1_aggregation_job_creator:
@@ -185,7 +184,6 @@ services:
       - janus_1_aggregation_job_creator.yaml
     environment:
       CONFIG_FILE: /janus_1_aggregation_job_creator.yaml
-      RUST_LOG: debug
       <<: *janus_environment
 
   janus_1_aggregation_job_driver:
@@ -200,7 +198,6 @@ services:
       - janus_1_aggregation_job_driver.yaml
     environment:
       CONFIG_FILE: /janus_1_aggregation_job_driver.yaml
-      RUST_LOG: debug
       <<: *janus_environment
 
   janus_1_collection_job_driver:
@@ -215,7 +212,6 @@ services:
       - janus_1_collection_job_driver.yaml
     environment:
       CONFIG_FILE: /janus_1_collection_job_driver.yaml
-      RUST_LOG: debug
       <<: *janus_environment
 
   janus_1_garbage_collector:
@@ -225,7 +221,6 @@ services:
       - janus_1_garbage_collector.yaml
     environment:
       CONFIG_FILE: /janus_1_garbage_collector.yaml
-      RUST_LOG: info
       <<: *janus_environment
 
   janus_2_migrate:
@@ -242,7 +237,6 @@ services:
       - "9002:8080"
     environment:
       CONFIG_FILE: /janus_2_aggregator.yaml
-      RUST_LOG: debug
       <<: *janus_environment
 
   janus_2_aggregation_job_creator:
@@ -252,7 +246,6 @@ services:
       - janus_2_aggregation_job_creator.yaml
     environment:
       CONFIG_FILE: /janus_2_aggregation_job_creator.yaml
-      RUST_LOG: info
       <<: *janus_environment
 
   janus_2_aggregation_job_driver:
@@ -262,7 +255,6 @@ services:
       - janus_2_aggregation_job_driver.yaml
     environment:
       CONFIG_FILE: /janus_2_aggregation_job_driver.yaml
-      RUST_LOG: info
       <<: *janus_environment
 
   janus_2_collection_job_driver:
@@ -272,7 +264,6 @@ services:
       - janus_2_collection_job_driver.yaml
     environment:
       CONFIG_FILE: /janus_2_collection_job_driver.yaml
-      RUST_LOG: info
       <<: *janus_environment
 
   janus_2_garbage_collector:
@@ -282,7 +273,6 @@ services:
       - janus_2_garbage_collector.yaml
     environment:
       CONFIG_FILE: /janus_2_garbage_collector.yaml
-      RUST_LOG: info
       <<: *janus_environment
 
 configs:

--- a/compose.yaml
+++ b/compose.yaml
@@ -158,7 +158,17 @@ services:
 
   janus_1_aggregator:
     <<: *janus_common
-    entrypoint: ["/janus_aggregator", "aggregator"]
+    entrypoint:
+      - /bin/sh
+      - -c
+      # Crimes: janus_2_aggregator's DAP API is localhost:9002 in the divviup-api aggregator object,
+      # but that address is only valid in the host network, outside of Docker Compose. But we need
+      # various parts of janus_1 to be able to reach janus_2_aggregator there. So we run nc(1)
+      # alongside the Janus processes so that it listens on localhost:9002 and forwards traffic to
+      # janus_2_aggregator:8080, which _does_ exist on the Docker Compose network.
+      - |
+        nc -p 9002 -lk -e nc janus_2_aggregator 8080 & \
+          /janus_aggregator aggregator
     configs:
       - janus_1_aggregator.yaml
     ports:
@@ -180,7 +190,12 @@ services:
 
   janus_1_aggregation_job_driver:
     <<: *janus_common
-    entrypoint: ["/janus_aggregator", "aggregation_job_driver"]
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        nc -p 9002 -lk -e nc janus_2_aggregator 8080 & \
+          /janus_aggregator aggregation_job_driver
     configs:
       - janus_1_aggregation_job_driver.yaml
     environment:
@@ -190,7 +205,12 @@ services:
 
   janus_1_collection_job_driver:
     <<: *janus_common
-    entrypoint: ["/janus_aggregator", "collection_job_driver"]
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        nc -p 9002 -lk -e nc janus_2_aggregator 8080 & \
+          /janus_aggregator collection_job_driver
     configs:
       - janus_1_collection_job_driver.yaml
     environment:


### PR DESCRIPTION
Add steps to the `compose` job in `docker.yml` that run the demo script from `cli/README.md` against a Docker Compose deployment to ensure that it works.

Perhaps unsurprisingly, adding a test for this revealed a couple of bugs, which are also addressed in this change:

- The task discovery interval and task creation intervals were poorly tuned
- The leader was trying to reach the helper at `localhost:9002`, which is not routable inside of the Docker Compose network. So we run `nc` alongside the leader's Janus processes so that connections to `localhost:9002` get redirected to `janus_2_aggregator:8080`, which is routable inside Docker Compose.