### PR TITLE
Fix pair_aggregator idempotency check

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,9 +40,14 @@ jobs:
             RUST_FEATURES=${{ steps.resolve_variables.outputs.RUST_FEATURES }}
       # Test the dev compose, which should use the images built earlier. Technically this is only
       # interesting when feature integration-testing is on, but we may as well exercise both.
+      #
+      # Bring the environment up, down and up again to ensure all services can restart
       - name: Compose (dev)
         id: compose-dev
-        run: docker compose -f compose.dev.yaml up --wait --wait-timeout 120
+        run: |
+          docker compose -f compose.dev.yaml up --wait --wait-timeout 120
+          docker compose down
+          docker compose -f compose.dev.yaml up --wait --wait-timeout 120
       - name: Inspect dev containers
         if: ${{ failure() && steps.compose-dev.outcome != 'success' }}
         run: |

--- a/compose.yaml
+++ b/compose.yaml
@@ -90,7 +90,7 @@ services:
       - -c
       - |
         test -f /tmp/done || \
-        /divviup --url=http://localhost:8080 --token="" \
+        (/divviup --url=http://localhost:8080 --token="" \
           aggregator create \
           --name=leader --api-url=http://janus_1_aggregator:8080/aggregator-api \
           --bearer-token=0000 \
@@ -101,7 +101,7 @@ services:
           aggregator create \
           --name=helper --api-url=http://janus_2_aggregator:8080/aggregator-api \
           --bearer-token=0000 && \
-        touch /tmp/done
+        touch /tmp/done)
     network_mode: service:divviup_api
     depends_on:
       divviup_api:


### PR DESCRIPTION
We need parentheses around the right hand side of the `||` so that everything get skipped if `/tmp/done` exists.

Part of #1096