### PR TITLE
Move sqlx query logging to debug level

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,5 @@
-use sea_orm::{ConnectionTrait, Database, DbConn};
+use log::LevelFilter;
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DbConn};
 use std::ops::{Deref, DerefMut};
 use trillium::{async_trait, Conn, Handler};
 use trillium_api::FromConn;
@@ -8,7 +9,9 @@ pub struct Db(DbConn);
 
 impl Db {
     pub async fn connect(url: &str) -> Self {
-        Database::connect(url).await.map(Self).unwrap()
+        let mut connect_options = ConnectOptions::new(url);
+        connect_options.sqlx_logging_level(LevelFilter::Debug);
+        Database::connect(connect_options).await.map(Self).unwrap()
     }
 }
 


### PR DESCRIPTION
By default, `sea_orm::ConnectOptions` will log queries at info ([1]). As a result, `divviup-api` logs are filled with unhelpful lines like:

```json
{
    "timestamp": "2024-06-18T21:31:41.294043Z",
    "level": "INFO",
    "fields": {
        "summary": "select 1",
        "db.statement": "",
        "rows_affected": 1,
        "rows_returned": 1,
        "elapsed": "171.873\u00b5s"
    },
    "target": "sqlx::query",
    "filename": "/usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/sqlx-core-0.7.3/src/logger.rs",
    "line_number": 135,
    "threadId": "ThreadId(4)"
}
```

...which is just the healthcheck succeeding. This commit moves that logging to debug level, so that we can still opt into it but generate less noise in normal operation.

[1]: https://docs.rs/sea-orm/0.12.15/sea_orm/struct.ConnectOptions.html#method.sqlx_logging_level