### PR TITLE
compose.yaml: specify user for postgres

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -52,6 +52,7 @@ x-divviup-environment: &divviup_environment
 services:
   postgres:
     image: docker.io/library/postgres:16
+    user: postgres
     ports:
       - "5432:5432"
     healthcheck:


### PR DESCRIPTION
This container was emitting `FATAL:  role "root" does not exist` which lead me to suspect an issue with some invocation of psql internally running as root. I didn't investigate further as setting the user to postgres seems to fix the issue.

Tested with podman compose on macOS.