### PR TITLE
Add support for configuring tasks with DP strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-api"
-version = "0.3.22"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "async-lock 3.4.0",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-cli"
-version = "0.3.22"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-client"
-version = "0.3.22"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "divviup-api",
@@ -1493,6 +1493,8 @@ dependencies = [
  "futures-lite 2.3.0",
  "janus_messages",
  "log",
+ "num-bigint",
+ "num-rational",
  "pad-adapter",
  "prio",
  "serde",
@@ -2745,7 +2747,7 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "migration"
-version = "0.3.22"
+version = "0.4.0"
 dependencies = [
  "async-std",
  "clap",
@@ -4887,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.3.22"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "divviup-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,15 @@
 members = [".", "migration", "client", "test-support", "cli"]
 
 [workspace.package]
-version = "0.3.22"
+version = "0.4.0"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://divviup.org"
 repository = "https://github.com/divviup/divviup-api"
 
 [workspace.dependencies]
-divviup-client = { path = "./client", version = "0.3.22" }
-divviup-cli = { path = "./cli", version = "0.3.22" }
+divviup-client = { path = "./client", version = "0.4.0" }
+divviup-cli = { path = "./cli", version = "0.4.0" }
 divviup-api.path = "."
 test-support.path = "./test-support"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,6 +27,8 @@ time = { version = "0.3.36", features = ["serde", "serde-well-known"] }
 log = "0.4.22"
 pad-adapter = "0.1.1"
 janus_messages = "0.7.25"
+num-bigint = "0.4.6"
+num-rational = "0.4.2"
 
 [dev-dependencies]
 divviup-api.workspace = true

--- a/client/src/dp_strategy.rs
+++ b/client/src/dp_strategy.rs
@@ -1,0 +1,29 @@
+use num_bigint::BigUint;
+use num_rational::Ratio;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+#[serde(tag = "dp_strategy")]
+pub enum Prio3Histogram {
+    #[default]
+    NoDifferentialPrivacy,
+    PureDpDiscreteLaplace(PureDpDiscreteLaplace),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+#[serde(tag = "dp_strategy")]
+pub enum Prio3SumVec {
+    #[default]
+    NoDifferentialPrivacy,
+    PureDpDiscreteLaplace(PureDpDiscreteLaplace),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct PureDpDiscreteLaplace {
+    pub budget: PureDpBudget,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct PureDpBudget {
+    pub epsilon: Ratio<BigUint>,
+}

--- a/client/src/dp_strategy.rs
+++ b/client/src/dp_strategy.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
 #[serde(tag = "dp_strategy")]
+#[non_exhaustive]
 pub enum Prio3Histogram {
     #[default]
     NoDifferentialPrivacy,
@@ -12,6 +13,7 @@ pub enum Prio3Histogram {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
 #[serde(tag = "dp_strategy")]
+#[non_exhaustive]
 pub enum Prio3SumVec {
     #[default]
     NoDifferentialPrivacy,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -39,6 +39,8 @@ pub use janus_messages::{
     HpkeConfig, HpkePublicKey,
 };
 pub use membership::Membership;
+pub use num_bigint::BigUint;
+pub use num_rational::Ratio;
 pub use protocol::Protocol;
 pub use task::{Histogram, NewTask, SumVec, Task, Vdaf};
 pub use time::OffsetDateTime;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -13,6 +13,7 @@ mod account;
 mod aggregator;
 mod api_token;
 mod collector_credentials;
+pub mod dp_strategy;
 mod membership;
 mod protocol;
 mod task;

--- a/documentation/openapi.yml
+++ b/documentation/openapi.yml
@@ -13,7 +13,7 @@ info:
   license:
     name: MPL-2.0
     url: https://www.mozilla.org/en-US/MPL/2.0/
-  version: "0.1"
+  version: "0.4"
 externalDocs:
   description: The Divvi Up API repository
   url: https://github.com/divviup/divviup-api
@@ -805,6 +805,25 @@ components:
                 type: string
         chunk_length:
           type: number
+        dp_strategy:
+          type: object
+          properties:
+            dp_strategy:
+              type: string
+              enum: [NoDifferentialPrivacy, PureDpDiscreteLaplace]
+            budget:
+              type: object
+              properties:
+                epsilon:
+                  type: array
+                  minItems: 2
+                  maxItems: 2
+                  items:
+                    type: array
+                    items:
+                      type: number
+                      minimum: 0
+                      maximum: 4294967295
       required: [type]
     ApiToken:
       type: object

--- a/src/clients/aggregator_client/api_types/dp_strategies.rs
+++ b/src/clients/aggregator_client/api_types/dp_strategies.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "dp_strategy")]
+pub enum Prio3Histogram {
+    NoDifferentialPrivacy,
+    PureDpDiscreteLaplace(PureDpDiscreteLaplace),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "dp_strategy")]
+pub enum Prio3SumVec {
+    NoDifferentialPrivacy,
+    PureDpDiscreteLaplace(PureDpDiscreteLaplace),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PureDpDiscreteLaplace {
+    pub budget: PureDpBudget,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PureDpBudget {
+    pub epsilon: [Vec<u32>; 2],
+}

--- a/src/entity/aggregator/feature.rs
+++ b/src/entity/aggregator/feature.rs
@@ -6,6 +6,7 @@ pub enum Feature {
     TokenHash,
     UploadMetrics,
     TimeBucketedFixedSize,
+    PureDpDiscreteLaplace,
     #[serde(untagged)]
     Unknown(String),
 }

--- a/src/entity/task/vdaf/tests/serde.rs
+++ b/src/entity/task/vdaf/tests/serde.rs
@@ -1,5 +1,6 @@
 use crate::entity::task::vdaf::{
-    BucketLength, CategoricalBuckets, ContinuousBuckets, CountVec, Histogram, Sum, SumVec, Vdaf,
+    BucketLength, CategoricalBuckets, ContinuousBuckets, CountVec, DpBudget, DpStrategy,
+    DpStrategyKind, Histogram, Sum, SumVec, Vdaf,
 };
 
 #[test]
@@ -11,6 +12,7 @@ fn json_vdaf() {
             Vdaf::Histogram(Histogram::Categorical(CategoricalBuckets {
                 buckets: Some(Vec::from(["A".to_owned(), "B".to_owned()])),
                 chunk_length: None,
+                dp_strategy: DpStrategy::default(),
             })),
         ),
         (
@@ -18,6 +20,7 @@ fn json_vdaf() {
             Vdaf::Histogram(Histogram::Categorical(CategoricalBuckets {
                 buckets: Some(Vec::from(["A".to_owned(), "B".to_owned()])),
                 chunk_length: Some(2),
+                dp_strategy: DpStrategy::default(),
             })),
         ),
         (
@@ -25,6 +28,7 @@ fn json_vdaf() {
             Vdaf::Histogram(Histogram::Continuous(ContinuousBuckets {
                 buckets: Some(Vec::from([1, 10, 100])),
                 chunk_length: None,
+                dp_strategy: DpStrategy::default(),
             })),
         ),
         (
@@ -32,6 +36,7 @@ fn json_vdaf() {
             Vdaf::Histogram(Histogram::Continuous(ContinuousBuckets {
                 buckets: Some(Vec::from([1, 10, 100])),
                 chunk_length: Some(2),
+                dp_strategy: DpStrategy::default(),
             })),
         ),
         (
@@ -39,6 +44,7 @@ fn json_vdaf() {
             Vdaf::Histogram(Histogram::Opaque(BucketLength {
                 length: 5,
                 chunk_length: None,
+                dp_strategy: DpStrategy::default(),
             })),
         ),
         (
@@ -46,6 +52,7 @@ fn json_vdaf() {
             Vdaf::Histogram(Histogram::Opaque(BucketLength {
                 length: 5,
                 chunk_length: Some(2),
+                dp_strategy: DpStrategy::default(),
             })),
         ),
         (
@@ -72,6 +79,7 @@ fn json_vdaf() {
                 bits: Some(8),
                 length: Some(10),
                 chunk_length: None,
+                dp_strategy: DpStrategy::default(),
             }),
         ),
         (
@@ -80,9 +88,35 @@ fn json_vdaf() {
                 bits: Some(8),
                 length: Some(10),
                 chunk_length: Some(12),
+                dp_strategy: DpStrategy::default(),
             }),
         ),
         (r#"{"type":"wrong"}"#, Vdaf::Unrecognized),
+        (
+            r#"{"type":"histogram","length":4,"chunk_length":2,"dp_strategy":{"dp_strategy":"NoDifferentialPrivacy"}}"#,
+            Vdaf::Histogram(Histogram::Opaque(BucketLength {
+                length: 4,
+                chunk_length: Some(2),
+                dp_strategy: DpStrategy {
+                    dp_strategy: DpStrategyKind::NoDifferentialPrivacy,
+                    budget: DpBudget { epsilon: None },
+                },
+            })),
+        ),
+        (
+            r#"{"type":"sum_vec","bits":2,"length":8,"chunk_length":4,"dp_strategy":{"dp_strategy":"PureDpDiscreteLaplace","budget":{"epsilon":[[1],[1]]}}}"#,
+            Vdaf::SumVec(SumVec {
+                bits: Some(2),
+                length: Some(8),
+                chunk_length: Some(4),
+                dp_strategy: DpStrategy {
+                    dp_strategy: DpStrategyKind::PureDpDiscreteLaplace,
+                    budget: DpBudget {
+                        epsilon: Some(Vec::from([Vec::from([1]), Vec::from([1])])),
+                    },
+                },
+            }),
+        ),
     ] {
         assert_eq!(serde_json::from_str::<Vdaf>(serialized).unwrap(), vdaf);
     }

--- a/tests/integration/vdaf.rs
+++ b/tests/integration/vdaf.rs
@@ -1,4 +1,5 @@
 use divviup_api::entity::task::vdaf::{BucketLength, CategoricalBuckets, Histogram, Vdaf};
+use task::vdaf::DpStrategy;
 use test_support::{assert_eq, test, *};
 #[test]
 pub fn histogram_representations() {
@@ -6,17 +7,75 @@ pub fn histogram_representations() {
         (
             json!({"type": "histogram", "buckets": ["a", "b", "c"], "chunk_length": 1}),
             Protocol::Dap09,
-            Ok(json!({"Prio3Histogram": {"length": 3, "chunk_length": 1}})),
+            Ok(
+                json!({"Prio3Histogram": {"length": 3, "chunk_length": 1, "dp_strategy": {"dp_strategy": "NoDifferentialPrivacy"}}}),
+            ),
         ),
         (
             json!({"type": "histogram", "buckets": [1, 2, 3], "chunk_length": 2}),
             Protocol::Dap09,
-            Ok(json!({"Prio3Histogram": {"length": 4, "chunk_length": 2}})),
+            Ok(
+                json!({"Prio3Histogram": {"length": 4, "chunk_length": 2, "dp_strategy": {"dp_strategy": "NoDifferentialPrivacy"}}}),
+            ),
         ),
         (
             json!({"type": "histogram", "length": 3, "chunk_length": 1}),
             Protocol::Dap09,
-            Ok(json!({"Prio3Histogram": {"length": 3, "chunk_length": 1}})),
+            Ok(
+                json!({"Prio3Histogram": {"length": 3, "chunk_length": 1, "dp_strategy": {"dp_strategy": "NoDifferentialPrivacy"}}}),
+            ),
+        ),
+        (
+            json!({"type": "histogram", "length": 3, "chunk_length": 1, "dp_strategy": {"dp_strategy": "NoDifferentialPrivacy"}}),
+            Protocol::Dap09,
+            Ok(
+                json!({"Prio3Histogram": {"length": 3, "chunk_length": 1, "dp_strategy": {"dp_strategy": "NoDifferentialPrivacy"}}}),
+            ),
+        ),
+        (
+            json!({"type": "histogram", "length": 3, "chunk_length": 1, "dp_strategy": {"dp_strategy": "PureDpDiscreteLaplace", "budget": {"epsilon": [[1], [1]]}}}),
+            Protocol::Dap09,
+            Ok(
+                json!({"Prio3Histogram": {"length": 3, "chunk_length": 1, "dp_strategy": {"dp_strategy": "PureDpDiscreteLaplace", "budget": {"epsilon": [[1], [1]]}}}}),
+            ),
+        ),
+    ];
+
+    for (input, protocol, output) in scenarios {
+        let vdaf: Vdaf = serde_json::from_value(input.clone()).unwrap();
+        assert_eq!(
+            output,
+            vdaf.representation_for_protocol(&protocol)
+                .map(|o| serde_json::to_value(o).unwrap())
+                .map_err(|e| serde_json::to_value(e).unwrap()),
+            "{vdaf:?} {input} {protocol}"
+        );
+    }
+}
+
+#[test]
+fn sumvec_representations() {
+    let scenarios = [
+        (
+            json!({"type": "sum_vec", "length": 3, "bits": 1, "chunk_length": 1}),
+            Protocol::Dap09,
+            Ok(
+                json!({"Prio3SumVec": {"length": 3, "bits": 1, "chunk_length": 1, "dp_strategy": {"dp_strategy": "NoDifferentialPrivacy"}}}),
+            ),
+        ),
+        (
+            json!({"type": "sum_vec", "length": 3, "bits": 1, "chunk_length": 1, "dp_strategy": {"dp_strategy": "NoDifferentialPrivacy"}}),
+            Protocol::Dap09,
+            Ok(
+                json!({"Prio3SumVec": {"length": 3, "bits": 1, "chunk_length": 1, "dp_strategy": {"dp_strategy": "NoDifferentialPrivacy"}}}),
+            ),
+        ),
+        (
+            json!({"type": "sum_vec", "length": 3, "bits": 1, "chunk_length": 1, "dp_strategy": {"dp_strategy": "PureDpDiscreteLaplace", "budget": {"epsilon": [[1], [1]]}}}),
+            Protocol::Dap09,
+            Ok(
+                json!({"Prio3SumVec": {"length": 3, "bits": 1, "chunk_length": 1, "dp_strategy": {"dp_strategy": "PureDpDiscreteLaplace", "budget": {"epsilon": [[1], [1]]}}}}),
+            ),
         ),
     ];
 
@@ -38,6 +97,7 @@ fn histogram_representation_dap_09_no_chunk_length_1() {
     let _ = Vdaf::Histogram(Histogram::Categorical(CategoricalBuckets {
         buckets: Some(Vec::from(["a".to_owned(), "b".to_owned(), "c".to_owned()])),
         chunk_length: None,
+        dp_strategy: DpStrategy::default(),
     }))
     .representation_for_protocol(&Protocol::Dap09);
 }
@@ -48,6 +108,7 @@ fn histogram_representation_dap_09_no_chunk_length_2() {
     let _ = Vdaf::Histogram(Histogram::Opaque(BucketLength {
         length: 3,
         chunk_length: None,
+        dp_strategy: DpStrategy::default(),
     }))
     .representation_for_protocol(&Protocol::Dap09);
 }


### PR DESCRIPTION
This adds support for specifying a differential privacy strategy alongside Prio3Histogram and Prio3SumVec VDAFs. I also bumped the minor version number component, since this introduces breaking changes to divviup-client. Closes #1163.