### PR TITLE
Install LTS version of Node.js in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: lts
           cache: "npm"
           cache-dependency-path: ./app/package-lock.json
       - run: npm ci && npm run build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts
+          node-version: lts/Iron
           cache: "npm"
           cache-dependency-path: ./app/package-lock.json
       - run: npm ci && npm run build

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: lts
           cache: "npm"
           cache-dependency-path: ./app/package-lock.json
       - run: npm ci

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts
+          node-version: lts/Iron
           cache: "npm"
           cache-dependency-path: ./app/package-lock.json
       - run: npm ci


### PR DESCRIPTION
This switches which Node.js version we use, as a workaround for #1176.