### PR TITLE
Switch back to node@latest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/Iron
+          node-version: latest
           cache: "npm"
           cache-dependency-path: ./app/package-lock.json
       - run: npm ci && npm run build

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/Iron
+          node-version: latest
           cache: "npm"
           cache-dependency-path: ./app/package-lock.json
       - run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:iron-alpine AS assets
+FROM node:alpine AS assets
 WORKDIR /src/app
 COPY app/package.json /src/app/package.json
 COPY app/package-lock.json /src/app/package-lock.json

--- a/Dockerfile.vite
+++ b/Dockerfile.vite
@@ -1,1 +1,1 @@
-FROM node:iron-alpine
+FROM node:alpine


### PR DESCRIPTION
Node.js v22.5.1 has been released with a fix, so I think we're OK to switch back. Closes #1176.