### PR TITLE
Use LTS version of Node.js in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS assets
+FROM node:iron-alpine AS assets
 WORKDIR /src/app
 COPY app/package.json /src/app/package.json
 COPY app/package-lock.json /src/app/package-lock.json

--- a/Dockerfile.vite
+++ b/Dockerfile.vite
@@ -1,1 +1,1 @@
-FROM node:alpine
+FROM node:iron-alpine


### PR DESCRIPTION
Version 22.5.0 of Node.js has now made it to Docker Hub library images as of yesterday. This switches the version we use in Dockerfiles, for the asset pipeline, to the last LTS release. Workaround for #1176.