### PR TITLE
Raise open PR limit for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    open-pull-requests-limit: 20
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot keeps hitting the default open PR limit of 5 when we run it for the NPM ecosystem. This raises it to 20, like we do with Cargo.