### PR TITLE
Ignore opentelemetry-rust 0.25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,18 @@ updates:
       interval: "weekly"
     target-branch: "main"
     open-pull-requests-limit: 20
+    ignore:
+      # opentelemetry-rust removed support for pull exporters, including
+      # opentelemetry-prometheus, and will add it back after the 1.0 release.
+      - dependency-name: opentelemetry
+        versions:
+          - "0.25"
+      - dependency-name: opentelemetry_sdk
+        versions:
+          - "0.25"
+      - dependency-name: opentelemetry-otlp
+        versions:
+          - "0.25"
     groups:
       opentelemetry:
         patterns:


### PR DESCRIPTION
This ignores the latest opentelemetry-rust release.