### PR TITLE
Upgrade trillium-opentelemetry

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,3 +48,7 @@ jobs:
         run: cargo check -p divviup-cli --no-default-features --features ring,common
       - name: check cli +default +admin
         run: cargo check -p divviup-cli --features admin
+      - name: cargo deny
+        uses: EmbarkStudios/cargo-deny-action@v2.0.4
+        with:
+          command: check bans

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,7 +1405,7 @@ dependencies = [
  "janus_messages",
  "log",
  "oauth2",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "opentelemetry_sdk",
@@ -3137,20 +3137,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
@@ -3172,7 +3158,7 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 1.1.0",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
@@ -3189,7 +3175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b834e966ea5e2d03dfe5f2253f03d22cce21403ee940265070eeee96cee0bcc"
 dependencies = [
  "once_cell",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prometheus",
  "protobuf",
@@ -3202,7 +3188,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
@@ -3210,9 +3196,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.16.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -3225,7 +3211,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "glob",
- "opentelemetry 0.27.1",
+ "opentelemetry",
  "percent-encoding",
  "rand",
  "serde_json",
@@ -5612,10 +5598,9 @@ dependencies = [
 [[package]]
 name = "trillium-opentelemetry"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369989011133b91f356bc790cfda4eae9243ffd33929dfb067fb135a728f88af"
+source = "git+https://github.com/divviup/trillium-opentelemetry.git?rev=da2f578c4684e50a03ba177ceefd183e43a5367f#da2f578c4684e50a03ba177ceefd183e43a5367f"
 dependencies = [
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-semantic-conventions",
  "trillium",
  "trillium-macros 0.0.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,3 +126,7 @@ path = "src/bin.rs"
 
 [profile.release]
 lto = "fat"
+
+[patch.crates-io]
+# TODO(#1485): upgrade to the next release of trillium-opentelemetry once it is available
+trillium-opentelemetry = { git = "https://github.com/divviup/trillium-opentelemetry.git", rev = "da2f578c4684e50a03ba177ceefd183e43a5367f" }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,25 @@
+[graph]
+targets = [{ triple = "x86_64-unknown-linux-gnu" }, { triple = "x86_64-unknown-linux-musl" }]
+all-features = true
+
+[advisories]
+version = 2
+
+[bans]
+multiple-versions = "allow"
+deny = [{ name = "tracing", deny-multiple-versions = true }, { name = "opentelemetry", deny-multiple-versions = true }]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+required-git-spec = "rev"
+allow-org = { github = ["divviup"] }
+
+[licenses]
+version = 2
+allow = ["MPL-2.0", "MIT", "Apache-2.0", "BSL-1.0", "BSD-2-Clause", "BSD-3-Clause", "Unicode-DFS-2016", "Unicode-3.0", "ISC", "OpenSSL", "Unlicense", "CC0-1.0"]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]


### PR DESCRIPTION
This addresses #1485. I patched in an updated version of trillium-opentelemetry, pinning a commit from the PR I submitted (trillium-rs/trillium-opentelemetry#93), and added some basic `cargo deny` configuration and a CI step to check for duplicate crate versions going forward.