### PR TITLE
Upgrade to new version of trillium-opentelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5597,8 +5597,9 @@ dependencies = [
 
 [[package]]
 name = "trillium-opentelemetry"
-version = "0.9.0"
-source = "git+https://github.com/divviup/trillium-opentelemetry.git?rev=da2f578c4684e50a03ba177ceefd183e43a5367f#da2f578c4684e50a03ba177ceefd183e43a5367f"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5e36d8e79ad6b8858715b9342b4d761d936dcd884f5680ecfb15c0076fa46a"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ typenum = "1.17.0"
 url = "2.5.2"
 uuid = { version = "1.12.0", features = ["v4", "fast-rng", "serde"] }
 validator = { version = "0.19.0", features = ["derive"] }
-trillium-opentelemetry = { version = "0.9.0", default-features = false, features = ["metrics"] }
+trillium-opentelemetry = { version = "0.10.0", default-features = false, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio", "logs", "metrics"] }
 opentelemetry-otlp = { version = "0.27.0", optional = true }
 
@@ -126,7 +126,3 @@ path = "src/bin.rs"
 
 [profile.release]
 lto = "fat"
-
-[patch.crates-io]
-# TODO(#1485): upgrade to the next release of trillium-opentelemetry once it is available
-trillium-opentelemetry = { git = "https://github.com/divviup/trillium-opentelemetry.git", rev = "da2f578c4684e50a03ba177ceefd183e43a5367f" }


### PR DESCRIPTION
This upgrades `trillium-opentelemetry` and clears out the patch. Follow-up to #1503.