### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,6 @@ updates:
       interval: "weekly"
     target-branch: "main"
     open-pull-requests-limit: 20
-    ignore:
-      # opentelemetry-rust removed support for pull exporters, including
-      # opentelemetry-prometheus, and will add it back after the 1.0 release.
-      - dependency-name: opentelemetry
-        versions:
-          - ">= 0.25, < 1.0"
-      - dependency-name: opentelemetry_sdk
-        versions:
-          - ">= 0.25, < 1.0"
-      - dependency-name: opentelemetry-otlp
-        versions:
-          - ">= 0.25, < 1.0"
     groups:
       opentelemetry:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,17 @@ updates:
       interval: "weekly"
     target-branch: "main"
     open-pull-requests-limit: 20
+    groups:
+      react:
+        patterns:
+          - 'react'
+          - '@types/react'
+          - 'react-dom'
+          - '@types/react-dom'
+      react-router:
+        patterns:
+          - 'react-router'
+          - 'react-router-dom'
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This updates the Dependabot configuration to group some related frontend packages together, and remove the opentelemetry-rust ignores now that they have added Prometheus exporters back.