### PR TITLE
wire up aggregation job task counters

### DIFF
--- a/app/src/ApiClient.ts
+++ b/app/src/ApiClient.ts
@@ -82,6 +82,16 @@ export interface Task {
   report_counter_success: number;
   report_counter_too_early: number;
   report_counter_task_expired: number;
+  aggregation_job_counter_success: number;
+  aggregation_job_counter_helper_batch_collected : number;
+  aggregation_job_counter_helper_report_replayed : number;
+  aggregation_job_counter_helper_report_dropped : number;
+  aggregation_job_counter_helper_hpke_unknown_config_id : number;
+  aggregation_job_counter_helper_hpke_decrypt_failure: number,
+  aggregation_job_counter_helper_vdaf_prep_error : number;
+  aggregation_job_counter_helper_task_expired : number;
+  aggregation_job_counter_helper_invalid_message : number;
+  aggregation_job_counter_helper_report_too_early : number;
 }
 
 export interface CollectorAuthToken {

--- a/app/src/ApiClient.ts
+++ b/app/src/ApiClient.ts
@@ -83,15 +83,15 @@ export interface Task {
   report_counter_too_early: number;
   report_counter_task_expired: number;
   aggregation_job_counter_success: number;
-  aggregation_job_counter_helper_batch_collected : number;
-  aggregation_job_counter_helper_report_replayed : number;
-  aggregation_job_counter_helper_report_dropped : number;
-  aggregation_job_counter_helper_hpke_unknown_config_id : number;
-  aggregation_job_counter_helper_hpke_decrypt_failure: number,
-  aggregation_job_counter_helper_vdaf_prep_error : number;
-  aggregation_job_counter_helper_task_expired : number;
-  aggregation_job_counter_helper_invalid_message : number;
-  aggregation_job_counter_helper_report_too_early : number;
+  aggregation_job_counter_helper_batch_collected: number;
+  aggregation_job_counter_helper_report_replayed: number;
+  aggregation_job_counter_helper_report_dropped: number;
+  aggregation_job_counter_helper_hpke_unknown_config_id: number;
+  aggregation_job_counter_helper_hpke_decrypt_failure: number;
+  aggregation_job_counter_helper_vdaf_prep_error: number;
+  aggregation_job_counter_helper_task_expired: number;
+  aggregation_job_counter_helper_invalid_message: number;
+  aggregation_job_counter_helper_report_too_early: number;
 }
 
 export interface CollectorAuthToken {

--- a/app/src/tasks/TaskDetail/Metrics.tsx
+++ b/app/src/tasks/TaskDetail/Metrics.tsx
@@ -126,11 +126,15 @@ function AggregationJobMetrics({ task }: { task: Promise<Task> }) {
                 />
                 <FailedMetric
                   name="Unknown HPKE Config ID (Helper) Failure"
-                  counter={task.aggregation_job_counter_helper_hpke_unknown_config_id}
+                  counter={
+                    task.aggregation_job_counter_helper_hpke_unknown_config_id
+                  }
                 />
                 <FailedMetric
                   name="HPKE Decryption (Helper) Failure"
-                  counter={task.aggregation_job_counter_helper_hpke_decrypt_failure}
+                  counter={
+                    task.aggregation_job_counter_helper_hpke_decrypt_failure
+                  }
                 />
                 <FailedMetric
                   name="VDAF Preparation (Helper) Failure"
@@ -183,12 +187,14 @@ export default function Metrics() {
         {(leaderAggregator) => {
           return (
             <Row>
-              {leaderAggregator.features.includes("UploadMetrics") ?
-                <UploadMetrics task={task} /> : null}
-              {leaderAggregator.features.includes("AggregationJobMetrics") ?
-                <AggregationJobMetrics task={ task } /> : null}
+              {leaderAggregator.features.includes("UploadMetrics") ? (
+                <UploadMetrics task={task} />
+              ) : null}
+              {leaderAggregator.features.includes("AggregationJobMetrics") ? (
+                <AggregationJobMetrics task={task} />
+              ) : null}
             </Row>
-          )
+          );
         }}
       </Await>
     </Suspense>

--- a/app/src/tasks/TaskDetail/Metrics.tsx
+++ b/app/src/tasks/TaskDetail/Metrics.tsx
@@ -5,6 +5,7 @@ import { Aggregator, Task } from "../../ApiClient";
 import Card from "react-bootstrap/Card";
 import ListGroup from "react-bootstrap/ListGroup";
 import { DateTime } from "luxon";
+import Row from "react-bootstrap/Row";
 import Placeholder from "react-bootstrap/Placeholder";
 import { OutLink, numberFormat } from "../../util";
 
@@ -91,6 +92,85 @@ function UploadMetrics({ task }: { task: Promise<Task> }) {
   );
 }
 
+function AggregationJobMetrics({ task }: { task: Promise<Task> }) {
+  return (
+    <Col md="6">
+      <Card className="my-3">
+        <Card.Body>
+          <Card.Title>Aggregation Job Metrics</Card.Title>
+          <Card.Subtitle>
+            <OutLink href="https://docs.divviup.org/product-documentation/operational-metrics#aggregation-job-metrics">
+              View Documentation
+            </OutLink>
+          </Card.Subtitle>
+        </Card.Body>
+        <Suspense fallback={<Placeholder animation="glow" xs={2} />}>
+          <Await resolve={task}>
+            {(task: Task) => (
+              <ListGroup variant="flush">
+                <ListGroup.Item>
+                  Successful Report Preparations:{" "}
+                  {numberFormat.format(task.aggregation_job_counter_success)}
+                </ListGroup.Item>
+                <FailedMetric
+                  name="Batch Collected (Helper) Failure"
+                  counter={task.aggregation_job_counter_helper_batch_collected}
+                />
+                <FailedMetric
+                  name="Report Replayed (Helper) Failure"
+                  counter={task.aggregation_job_counter_helper_report_replayed}
+                />
+                <FailedMetric
+                  name="Report Dropped (Helper) Failure"
+                  counter={task.aggregation_job_counter_helper_report_dropped}
+                />
+                <FailedMetric
+                  name="Unknown HPKE Config ID (Helper) Failure"
+                  counter={task.aggregation_job_counter_helper_hpke_unknown_config_id}
+                />
+                <FailedMetric
+                  name="HPKE Decryption (Helper) Failure"
+                  counter={task.aggregation_job_counter_helper_hpke_decrypt_failure}
+                />
+                <FailedMetric
+                  name="VDAF Preparation (Helper) Failure"
+                  counter={task.aggregation_job_counter_helper_vdaf_prep_error}
+                />
+                <FailedMetric
+                  name="Task Expiration (Helper) Failure"
+                  counter={task.aggregation_job_counter_helper_task_expired}
+                />
+                <FailedMetric
+                  name="Invalid Message (Helper) Failure"
+                  counter={task.aggregation_job_counter_helper_invalid_message}
+                />
+                <FailedMetric
+                  name="Report Too Early (Helper) Failure"
+                  counter={task.aggregation_job_counter_helper_report_too_early}
+                />
+              </ListGroup>
+            )}
+          </Await>
+        </Suspense>
+        <Card.Footer className="text-muted">
+          Last updated{" "}
+          <Suspense fallback={<Placeholder animation="glow" xs={1} />}>
+            <Await resolve={task}>
+              {(task) => (
+                <relative-time datetime={task.updated_at} format="relative">
+                  {DateTime.fromISO(task.updated_at)
+                    .toLocal()
+                    .toLocaleString(DateTime.DATETIME_SHORT)}
+                </relative-time>
+              )}
+            </Await>
+          </Suspense>
+        </Card.Footer>
+      </Card>
+    </Col>
+  );
+}
+
 export default function Metrics() {
   const { task, leaderAggregator } = useLoaderData() as {
     task: Promise<Task>;
@@ -101,9 +181,14 @@ export default function Metrics() {
     <Suspense fallback={<Placeholder animation="glow" xs={2} />}>
       <Await resolve={leaderAggregator}>
         {(leaderAggregator) => {
-          if (leaderAggregator.features.includes("UploadMetrics")) {
-            return <UploadMetrics task={task} />;
-          }
+          return (
+            <Row>
+              {leaderAggregator.features.includes("UploadMetrics") ?
+                <UploadMetrics task={task} /> : null}
+              {leaderAggregator.features.includes("AggregationJobMetrics") ?
+                <AggregationJobMetrics task={ task } /> : null}
+            </Row>
+          )
         }}
       </Await>
     </Suspense>

--- a/client/src/task.rs
+++ b/client/src/task.rs
@@ -38,6 +38,17 @@ pub struct Task {
     pub report_counter_success: i64,
     pub report_counter_too_early: i64,
     pub report_counter_task_expired: i64,
+
+    pub aggregation_job_counter_success: i64,
+    pub aggregation_job_counter_helper_batch_collected: i64,
+    pub aggregation_job_counter_helper_report_replayed: i64,
+    pub aggregation_job_counter_helper_report_dropped: i64,
+    pub aggregation_job_counter_helper_hpke_unknown_config_id: i64,
+    pub aggregation_job_counter_helper_hpke_decrypt_failure: i64,
+    pub aggregation_job_counter_helper_vdaf_prep_error: i64,
+    pub aggregation_job_counter_helper_task_expired: i64,
+    pub aggregation_job_counter_helper_invalid_message: i64,
+    pub aggregation_job_counter_helper_report_too_early: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]

--- a/client/src/task.rs
+++ b/client/src/task.rs
@@ -39,15 +39,25 @@ pub struct Task {
     pub report_counter_too_early: i64,
     pub report_counter_task_expired: i64,
 
+    #[serde(default)]
     pub aggregation_job_counter_success: i64,
+    #[serde(default)]
     pub aggregation_job_counter_helper_batch_collected: i64,
+    #[serde(default)]
     pub aggregation_job_counter_helper_report_replayed: i64,
+    #[serde(default)]
     pub aggregation_job_counter_helper_report_dropped: i64,
+    #[serde(default)]
     pub aggregation_job_counter_helper_hpke_unknown_config_id: i64,
+    #[serde(default)]
     pub aggregation_job_counter_helper_hpke_decrypt_failure: i64,
+    #[serde(default)]
     pub aggregation_job_counter_helper_vdaf_prep_error: i64,
+    #[serde(default)]
     pub aggregation_job_counter_helper_task_expired: i64,
+    #[serde(default)]
     pub aggregation_job_counter_helper_invalid_message: i64,
+    #[serde(default)]
     pub aggregation_job_counter_helper_report_too_early: i64,
 }
 

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -25,6 +25,7 @@ mod m20231012_233117_add_token_hash_to_collector_credential;
 mod m20240214_215101_upload_metrics;
 mod m20240411_195358_time_bucketed_fixed_size;
 mod m20240416_172920_task_deleted_at;
+mod m20250801_164739_aggregation_job_metrics;
 
 pub struct Migrator;
 
@@ -57,6 +58,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240214_215101_upload_metrics::Migration),
             Box::new(m20240411_195358_time_bucketed_fixed_size::Migration),
             Box::new(m20240416_172920_task_deleted_at::Migration),
+            Box::new(m20250801_164739_aggregation_job_metrics::Migration),
         ]
     }
 }

--- a/migration/src/m20250801_164739_aggregation_job_metrics.rs
+++ b/migration/src/m20250801_164739_aggregation_job_metrics.rs
@@ -1,0 +1,103 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Task::Table)
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterSuccess)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterHelperBatchCollected)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterHelperReportReplayed)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterHelperReportDropped)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterHelperHpkeUnknownConfigId)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterHelperHpkeDecryptFailure)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterHelperVdafPrepError)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterHelperTaskExpired)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterHelperInvalidMessage)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .add_column(
+                        ColumnDef::new(Task::AggregationJobCounterHelperReportTooEarly)
+                            .big_integer()
+                            .default(0),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Task::Table)
+                    .drop_column(Task::AggregationJobCounterSuccess)
+                    .drop_column(Task::AggregationJobCounterHelperBatchCollected)
+                    .drop_column(Task::AggregationJobCounterHelperReportReplayed)
+                    .drop_column(Task::AggregationJobCounterHelperReportDropped)
+                    .drop_column(Task::AggregationJobCounterHelperHpkeUnknownConfigId)
+                    .drop_column(Task::AggregationJobCounterHelperHpkeDecryptFailure)
+                    .drop_column(Task::AggregationJobCounterHelperVdafPrepError)
+                    .drop_column(Task::AggregationJobCounterHelperTaskExpired)
+                    .drop_column(Task::AggregationJobCounterHelperInvalidMessage)
+                    .drop_column(Task::AggregationJobCounterHelperReportTooEarly)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum Task {
+    Table,
+
+    AggregationJobCounterSuccess,
+    AggregationJobCounterHelperBatchCollected,
+    AggregationJobCounterHelperReportReplayed,
+    AggregationJobCounterHelperReportDropped,
+    AggregationJobCounterHelperHpkeUnknownConfigId,
+    AggregationJobCounterHelperHpkeDecryptFailure,
+    AggregationJobCounterHelperVdafPrepError,
+    AggregationJobCounterHelperTaskExpired,
+    AggregationJobCounterHelperInvalidMessage,
+    AggregationJobCounterHelperReportTooEarly,
+}

--- a/src/clients/aggregator_client.rs
+++ b/src/clients/aggregator_client.rs
@@ -3,6 +3,7 @@ use crate::{
     entity::{task::ProvisionableTask, Aggregator},
     handler::Error,
 };
+use api_types::TaskAggregationJobMetrics;
 use janus_messages::Time as JanusTime;
 use serde::{de::DeserializeOwned, Serialize};
 use trillium_client::{Client, KnownHeaderName};
@@ -84,6 +85,14 @@ impl AggregatorClient {
         task_id: &str,
     ) -> Result<TaskUploadMetrics, ClientError> {
         self.get(&format!("tasks/{task_id}/metrics/uploads")).await
+    }
+
+    pub async fn get_task_aggregation_job_metrics(
+        &self,
+        task_id: &str,
+    ) -> Result<TaskAggregationJobMetrics, ClientError> {
+        self.get(&format!("tasks/{task_id}/metrics/aggregation_jobs"))
+            .await
     }
 
     pub async fn create_task(&self, task: &ProvisionableTask) -> Result<TaskResponse, Error> {

--- a/src/clients/aggregator_client/api_types.rs
+++ b/src/clients/aggregator_client/api_types.rs
@@ -362,6 +362,54 @@ impl PartialEq<Task> for TaskUploadMetrics {
     }
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TaskAggregationJobMetrics {
+    /// Reports that were successfully aggregated.
+    pub success: u64,
+
+    /// Reports rejected by the helper due to the batch being collected.
+    pub helper_batch_collected: u64,
+    /// Reports rejected by the helper due to the report replay.
+    pub helper_report_replayed: u64,
+    /// Reports rejected by the helper due to the leader dropping the report.
+    pub helper_report_dropped: u64,
+    /// Reports rejected by the helper due to unknown HPKE config ID.
+    pub helper_hpke_unknown_config_id: u64,
+    /// Reports rejected by the helper due to HPKE decryption failure.
+    pub helper_hpke_decrypt_failure: u64,
+    /// Reports rejected by the helper due to VDAF preparation error.
+    pub helper_vdaf_prep_error: u64,
+    /// Reports rejected by the helper due to task expiration.
+    pub helper_task_expired: u64,
+    /// Reports rejected by the helper due to an invalid message.
+    pub helper_invalid_message: u64,
+    /// Reports rejected by the helper due to a report arriving too early.
+    pub helper_report_too_early: u64,
+}
+
+impl PartialEq<Task> for TaskAggregationJobMetrics {
+    fn eq(&self, other: &Task) -> bool {
+        other.aggregation_job_counter_success == self.success as i64
+            && other.aggregation_job_counter_helper_batch_collected
+                == self.helper_batch_collected as i64
+            && other.aggregation_job_counter_helper_report_replayed
+                == self.helper_report_replayed as i64
+            && other.aggregation_job_counter_helper_report_dropped
+                == self.helper_report_dropped as i64
+            && other.aggregation_job_counter_helper_hpke_unknown_config_id
+                == self.helper_hpke_unknown_config_id as i64
+            && other.aggregation_job_counter_helper_hpke_decrypt_failure
+                == self.helper_hpke_decrypt_failure as i64
+            && other.aggregation_job_counter_helper_vdaf_prep_error
+                == self.helper_vdaf_prep_error as i64
+            && other.aggregation_job_counter_helper_task_expired == self.helper_task_expired as i64
+            && other.aggregation_job_counter_helper_invalid_message
+                == self.helper_invalid_message as i64
+            && other.aggregation_job_counter_helper_report_too_early
+                == self.helper_report_too_early as i64
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct AggregatorApiConfig {
     pub dap_url: Url,

--- a/src/entity/aggregator/feature.rs
+++ b/src/entity/aggregator/feature.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 pub enum Feature {
     TokenHash,
     UploadMetrics,
+    AggregationJobMetrics,
     TimeBucketedFixedSize,
     PureDpDiscreteLaplace,
     #[serde(untagged)]
@@ -21,6 +22,10 @@ impl Features {
 
     pub fn upload_metrics_enabled(&self) -> bool {
         self.0.contains(&Feature::UploadMetrics)
+    }
+
+    pub fn aggregation_job_metrics_enabled(&self) -> bool {
+        self.0.contains(&Feature::AggregationJobMetrics)
     }
 
     pub fn len(&self) -> usize {

--- a/src/entity/task/model.rs
+++ b/src/entity/task/model.rs
@@ -160,6 +160,7 @@ impl Model {
                 .try_into()
                 .unwrap_or(i64::MAX),
         );
+        task.updated_at = ActiveValue::Set(OffsetDateTime::now_utc());
         task.update(&db).await
     }
 

--- a/src/entity/task/provisionable_task.rs
+++ b/src/entity/task/provisionable_task.rs
@@ -112,6 +112,16 @@ impl ProvisionableTask {
             report_counter_success: 0,
             report_counter_too_early: 0,
             report_counter_task_expired: 0,
+            aggregation_job_counter_success: 0,
+            aggregation_job_counter_helper_hpke_decrypt_failure: 0,
+            aggregation_job_counter_helper_batch_collected: 0,
+            aggregation_job_counter_helper_report_replayed: 0,
+            aggregation_job_counter_helper_report_dropped: 0,
+            aggregation_job_counter_helper_hpke_unknown_config_id: 0,
+            aggregation_job_counter_helper_vdaf_prep_error: 0,
+            aggregation_job_counter_helper_task_expired: 0,
+            aggregation_job_counter_helper_invalid_message: 0,
+            aggregation_job_counter_helper_report_too_early: 0,
         }
         .into_active_model())
     }

--- a/test-support/src/fixtures.rs
+++ b/test-support/src/fixtures.rs
@@ -133,6 +133,16 @@ pub async fn task(app: &DivviupApi, account: &Account) -> Task {
         report_counter_success: 0,
         report_counter_too_early: 0,
         report_counter_task_expired: 0,
+        aggregation_job_counter_success: 0,
+        aggregation_job_counter_helper_hpke_decrypt_failure: 0,
+        aggregation_job_counter_helper_batch_collected: 0,
+        aggregation_job_counter_helper_report_replayed: 0,
+        aggregation_job_counter_helper_report_dropped: 0,
+        aggregation_job_counter_helper_hpke_unknown_config_id: 0,
+        aggregation_job_counter_helper_vdaf_prep_error: 0,
+        aggregation_job_counter_helper_task_expired: 0,
+        aggregation_job_counter_helper_invalid_message: 0,
+        aggregation_job_counter_helper_report_too_early: 0,
     }
     .into_active_model()
     .insert(app.db())


### PR DESCRIPTION
- aggregator API client: fetch TaskAggregatorCounter
- add columns for aggregation job task metrics to DB
- display aggregation job metrics in task detail view

All gated on the new aggregator feature for aggregation job task metrics.

This will need more changes as we add more aggregation job metrics counters.

Part of https://github.com/divviup/janus/issues/3798

The task detail view with these changes:

<img width="2872" height="2140" alt="image" src="https://github.com/user-attachments/assets/0123c691-8222-472a-96ba-e345cbdf845c" />
