### PR TITLE
Add safety comments for unwrap calls in session_store.rs

### DIFF
--- a/src/handler/session_store.rs
+++ b/src/handler/session_store.rs
@@ -29,7 +29,7 @@ impl TryFrom<&Session> for session::Model {
         Ok(Self {
             id: session.id().to_string(),
             // unwrap safety: session object comes from the session handler, and its timestamp
-            // we made ourselves.            
+            // we made ourselves.
             expiry: session
                 .expiry()
                 .map(|e| OffsetDateTime::from_unix_timestamp(e.timestamp()).unwrap()),


### PR DESCRIPTION
Document why unwrap operations are safe in session store conversion methods:
- Session expiry timestamps are validated values from our own database.
- The JSON-dump of Session will have a "data" element when serialization succeeds.