### PR TITLE
use correct request path for agg job metrics

### DIFF
--- a/src/clients/aggregator_client.rs
+++ b/src/clients/aggregator_client.rs
@@ -91,7 +91,7 @@ impl AggregatorClient {
         &self,
         task_id: &str,
     ) -> Result<TaskAggregationJobMetrics, ClientError> {
-        self.get(&format!("tasks/{task_id}/metrics/aggregation_jobs"))
+        self.get(&format!("tasks/{task_id}/metrics/aggregations"))
             .await
     }
 


### PR DESCRIPTION
Now it matches the path served by Janus ([1])

[1]: https://github.com/divviup/janus/blob/1fc4ac83066774aed6d6ef409a41c48d7ee8d06c/aggregator_api/src/lib.rs#L103