### PR TITLE
Add max-length validation on string input fields

### DIFF
--- a/src/entity/aggregator/new_aggregator.rs
+++ b/src/entity/aggregator/new_aggregator.rs
@@ -20,13 +20,15 @@ use validator::{Validate, ValidationError, ValidationErrors};
 
 #[derive(Deserialize, Serialize, Validate, Debug, Clone, Default)]
 pub struct NewAggregator {
-    #[validate(required, length(min = 1))]
+    #[validate(required, length(min = 1, max = 255))]
     pub name: Option<String>,
     #[cfg_attr(
         not(feature = "integration-testing"),
         validate(custom(function = "https"))
     )]
+    #[validate(length(max = 2048))]
     pub api_url: Option<String>,
+    #[validate(length(max = 4096))]
     pub bearer_token: Option<String>,
     pub is_first_party: Option<bool>,
 }

--- a/src/entity/aggregator/update_aggregator.rs
+++ b/src/entity/aggregator/update_aggregator.rs
@@ -12,8 +12,9 @@ use validator::{Validate, ValidationError, ValidationErrors};
 
 #[derive(Deserialize, Validate, Debug)]
 pub struct UpdateAggregator {
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 255))]
     pub name: Option<String>,
+    #[validate(length(max = 4096))]
     pub bearer_token: Option<String>,
 }
 

--- a/src/entity/task/new_task.rs
+++ b/src/entity/task/new_task.rs
@@ -17,7 +17,7 @@ use vdaf::{DpStrategy, DpStrategyKind, SumVec};
 
 #[derive(Deserialize, Validate, Debug, Clone, Default)]
 pub struct NewTask {
-    #[validate(required, length(min = 1))]
+    #[validate(required, length(min = 1, max = 255))]
     pub name: Option<String>,
 
     #[validate(required)]

--- a/src/entity/task/update_task.rs
+++ b/src/entity/task/update_task.rs
@@ -25,6 +25,9 @@ fn validate_name(name: &str) -> Result<(), ValidationError> {
     if name.is_empty() {
         return Err(ValidationError::new("name-too-short"));
     }
+    if name.len() > 255 {
+        return Err(ValidationError::new("name-too-long"));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Add upper bounds to name fields (max 255), API URLs (max 2048), and bearer tokens (max 4096) across aggregator and task creation and update endpoints. Previously only minimum length was enforced.