### PR TITLE
Migrate from Trillium [part 1]: divviup-client and CLI to reqwest

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -50,8 +50,7 @@ jobs:
             os: "windows-latest",
             triple-suffix: "pc-windows-msvc",
             extension: ".exe",
-            # Build with ring on Windows so we don't have to set up aws-lc-rs' toolchain
-            extra-build-flags: "--no-default-features --features ring,common"
+            extra-build-flags: ""
           },
           {
             os: "macos-latest",

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,6 @@ jobs:
         run: cargo check --features api-mocks --locked
       - name: check +otlp-trace
         run: cargo check --features otlp-trace --locked
-      - name: check cli -default +ring
-        run: cargo check -p divviup-cli --no-default-features --features ring,common --locked
       - name: check cli +default +admin
         run: cargo check -p divviup-cli --features admin --locked
       - name: cargo deny

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-api"
-version = "0.4.88"
+version = "0.5.0-pre.1"
 dependencies = [
  "aes-gcm",
  "async-lock 3.4.2",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-cli"
-version = "0.4.88"
+version = "0.5.0-pre.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1397,20 +1397,19 @@ dependencies = [
  "janus_messages",
  "prio",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror 2.0.18",
  "time",
  "tokio",
- "trillium-rustls",
- "trillium-tokio",
  "url",
 ]
 
 [[package]]
 name = "divviup-client"
-version = "0.4.88"
+version = "0.5.0-pre.1"
 dependencies = [
  "base64 0.22.1",
  "divviup-api",
@@ -1418,22 +1417,22 @@ dependencies = [
  "email_address",
  "fastrand",
  "futures-lite",
+ "http",
  "janus_messages",
  "log",
  "num-bigint",
  "num-rational",
  "pad-adapter",
  "prio",
+ "reqwest",
  "serde",
  "serde_json",
  "test-support",
  "thiserror 2.0.18",
  "time",
+ "tokio",
  "trillium",
- "trillium-client",
  "trillium-http",
- "trillium-macros 0.0.6",
- "trillium-rustls",
  "trillium-testing",
  "trillium-tokio",
  "url",
@@ -2787,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "migration"
-version = "0.4.88"
+version = "0.5.0-pre.1"
 dependencies = [
  "clap",
  "sea-orm",
@@ -4932,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.4.88"
+version = "0.5.0-pre.1"
 dependencies = [
  "base64 0.22.1",
  "divviup-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,15 @@
 members = [".", "migration", "client", "test-support", "cli"]
 
 [workspace.package]
-version = "0.4.88"
+version = "0.5.0-pre.1"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://divviup.org"
 repository = "https://github.com/divviup/divviup-api"
 
 [workspace.dependencies]
-divviup-client = { path = "./client", version = "0.4.88" }
-divviup-cli = { path = "./cli", version = "0.4.88" }
+divviup-client = { path = "./client", version = "0.5.0-pre.1" }
+divviup-cli = { path = "./cli", version = "0.5.0-pre.1" }
 divviup-api.path = "."
 test-support.path = "./test-support"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,12 +9,7 @@ version.workspace = true
 description = "Command line utility for divviup.org"
 
 [features]
-default = ["common", "aws-lc-rs"]
-common = ["hpke", "trillium-rustls/client", "trillium-rustls/tls12"]
-# Building aws-lc-rs on Windows is challenging at best because of aws-lc's toolchain, so we allow
-# using ring instead
-aws-lc-rs = ["trillium-rustls/aws-lc-rs"]
-ring = ["trillium-rustls/ring"]
+default = ["hpke"]
 hpke = ["dep:hpke-dispatch", "dep:rand"]
 admin = ["divviup-client/admin"]
 
@@ -27,8 +22,7 @@ anyhow = "1"
 clap = { version = "4.6.0", features = ["derive", "env"] }
 thiserror = "2.0.18"
 divviup-client = { workspace = true }
-trillium-rustls = { version = "0.9.0", default-features = false }
-trillium-tokio = "0.4.0"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.228"
 email_address = "0.2.9"
 humantime = "2.3.0"
@@ -50,4 +44,4 @@ janus_collector = "0.7.106"
 url = "2.5.8"
 janus_messages = "0.7.116"
 prio = "0.16.7"
-tokio = { version = "1.51.0" }
+tokio = { version = "1.51.0", features = ["rt-multi-thread", "macros"] }

--- a/cli/src/collector_credentials.rs
+++ b/cli/src/collector_credentials.rs
@@ -3,7 +3,7 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use clap::Subcommand;
 use divviup_client::{Decode, DivviupClient, HpkeConfig, Uuid};
 use std::{borrow::Cow, path::PathBuf};
-use trillium_tokio::tokio::fs;
+use tokio::fs;
 
 #[cfg(feature = "hpke")]
 use hpke_dispatch::{Aead, Kdf, Kem};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -25,7 +25,7 @@ use collector_credentials::CollectorCredentialAction;
 use colored::Colorize;
 use const_format::concatcp;
 use dap_client::DapClientAction;
-use divviup_client::{Client, CodecError, DivviupClient, HeaderValue, KnownHeaderName, Url, Uuid};
+use divviup_client::{CodecError, DivviupClient, Url, Uuid};
 use memberships::MembershipAction;
 use serde::Serialize;
 use std::{
@@ -36,9 +36,6 @@ use std::{
     process::ExitCode,
 };
 use tasks::TaskAction;
-use trillium_rustls::RustlsConfig;
-use trillium_tokio::ClientConfig;
-
 pub const USER_AGENT: &str = concatcp!(
     "divviup-cli/",
     env!("CARGO_PKG_VERSION"),
@@ -163,11 +160,11 @@ pub type CliResult<T = ()> = Result<T, Error>;
 
 impl ClientBin {
     fn client(&self) -> DivviupClient {
-        let mut client = DivviupClient::new(
-            self.token.clone(),
-            Client::new(RustlsConfig::<ClientConfig>::default()).with_default_pool(),
-        )
-        .with_header(KnownHeaderName::UserAgent, HeaderValue::from(USER_AGENT));
+        let http_client = reqwest::Client::builder()
+            .user_agent(USER_AGENT)
+            .build()
+            .expect("failed to build HTTP client");
+        let mut client = DivviupClient::new(self.token.clone(), http_client);
         client.set_url(self.url.clone());
         client
     }
@@ -188,18 +185,11 @@ impl ClientBin {
     }
 }
 
-pub fn main() -> ExitCode {
-    // Install a default rustls crypto provider based on enabled features. Specifying a default
-    // provider here prevents runtime errors if another dependency enables a different crypto
-    // provider.
-    #[cfg(feature = "aws-lc-rs")]
-    let _ = trillium_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
-    #[cfg(feature = "ring")]
-    let _ = trillium_rustls::rustls::crypto::ring::default_provider().install_default();
-
+#[tokio::main]
+pub async fn main() -> ExitCode {
     env_logger::init();
     let args = ClientBin::parse();
-    trillium_tokio::block_on(async move { args.run().await })
+    args.run().await
 }
 
 type DetermineAccountId = Pin<Box<dyn Future<Output = Result<Uuid, Error>> + Send + 'static>>;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -159,18 +159,24 @@ pub enum Error {
 pub type CliResult<T = ()> = Result<T, Error>;
 
 impl ClientBin {
-    fn client(&self) -> DivviupClient {
+    fn client(&self) -> CliResult<DivviupClient> {
         let http_client = reqwest::Client::builder()
             .user_agent(USER_AGENT)
             .build()
-            .expect("failed to build HTTP client");
+            .map_err(divviup_client::Error::from)?;
         let mut client = DivviupClient::new(self.token.clone(), http_client);
         client.set_url(self.url.clone());
-        client
+        Ok(client)
     }
 
     pub async fn run(self) -> ExitCode {
-        let client = self.client();
+        let client = match self.client() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("{e}");
+                return ExitCode::FAILURE;
+            }
+        };
         match self.command.run(self.account_id, client, self.output).await {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
@@ -188,8 +194,7 @@ impl ClientBin {
 #[tokio::main]
 pub async fn main() -> ExitCode {
     env_logger::init();
-    let args = ClientBin::parse();
-    args.run().await
+    ClientBin::parse().run().await
 }
 
 type DetermineAccountId = Pin<Box<dyn Future<Output = Result<Uuid, Error>> + Send + 'static>>;

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,12 +15,12 @@ admin = []
 [dependencies]
 base64 = "0.22.1"
 email_address = "0.2.9"
+http = "1"
 prio = "0.16"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
-trillium-client = { version = "0.6.2", features = ["json"] }
-trillium-http = "0.3.14"
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.20.0", features = ["v4", "fast-rng", "serde"] }
 time = { version = "0.3.47", features = ["serde", "serde-well-known"] }
@@ -35,9 +35,9 @@ divviup-api.workspace = true
 fastrand = "2.4.1"
 futures-lite = "2.6.1"
 test-support.workspace = true
+tokio = { version = "1", features = ["net"] }
 trillium = "0.2.20"
-trillium-macros = "0.0.6"
+trillium-http = "0.3.14"
 trillium-testing = { version = "0.7.0", features = ["tokio"] }
-trillium-rustls = "0.9.0"
 trillium-tokio = "0.4.0"
-divviup-client =  { path = ".", features = ["admin"] }
+divviup-client = { path = ".", features = ["admin"] }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -67,7 +67,7 @@ impl DivviupClient {
     pub fn new(token: impl Display, client: reqwest::Client) -> Self {
         Self {
             client,
-            // Safety: DEFAULT_URL is a compile-time constant known to be valid.
+            // Unwrap Safety: DEFAULT_URL is a compile-time constant known to be valid.
             base_url: Url::parse(DEFAULT_URL).unwrap(),
             token: token.to_string(),
         }
@@ -109,9 +109,7 @@ impl DivviupClient {
         }
 
         if status == StatusCode::BAD_REQUEST {
-            let body = response.text().await?;
-            log::trace!("{body}");
-            return Err(Error::ValidationErrors(serde_json::from_str(&body)?));
+            return Err(Error::ValidationErrors(response.json().await?));
         }
 
         let url = response.url().clone();

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -24,7 +24,10 @@ pub const DEFAULT_URL: &str = "https://api.divviup.org/";
 pub const USER_AGENT: &str = concat!("divviup-client/", env!("CARGO_PKG_VERSION"));
 
 use base64::{engine::general_purpose::STANDARD, Engine};
-use http::StatusCode;
+use http::{
+    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE as CONTENT_TYPE_HEADER},
+    Method, StatusCode,
+};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::json;
 use std::fmt::Display;
@@ -64,6 +67,7 @@ impl DivviupClient {
     pub fn new(token: impl Display, client: reqwest::Client) -> Self {
         Self {
             client,
+            // Safety: DEFAULT_URL is a compile-time constant known to be valid.
             base_url: Url::parse(DEFAULT_URL).unwrap(),
             token: token.to_string(),
         }
@@ -86,20 +90,17 @@ impl DivviupClient {
         self.base_url.join(path).map_err(Error::from)
     }
 
-    fn request(&self, method: http::Method, path: &str) -> ClientResult<reqwest::RequestBuilder> {
+    fn request(&self, method: Method, path: &str) -> ClientResult<reqwest::RequestBuilder> {
         let url = self.url(path)?;
         Ok(self
             .client
             .request(method, url)
-            .header(http::header::ACCEPT, CONTENT_TYPE)
-            .header(
-                http::header::AUTHORIZATION,
-                format!("Bearer {}", self.token),
-            ))
+            .header(ACCEPT, CONTENT_TYPE)
+            .header(AUTHORIZATION, format!("Bearer {}", self.token)))
     }
 
     async fn check_response(
-        method: http::Method,
+        method: Method,
         response: reqwest::Response,
     ) -> ClientResult<reqwest::Response> {
         let status = response.status();
@@ -127,8 +128,8 @@ impl DivviupClient {
     where
         T: DeserializeOwned,
     {
-        let resp = self.request(http::Method::GET, path)?.send().await?;
-        let resp = Self::check_response(http::Method::GET, resp).await?;
+        let resp = self.request(Method::GET, path)?.send().await?;
+        let resp = Self::check_response(Method::GET, resp).await?;
         Ok(resp.json().await?)
     }
 
@@ -137,12 +138,12 @@ impl DivviupClient {
         T: DeserializeOwned,
     {
         let resp = self
-            .request(http::Method::PATCH, path)?
-            .header(http::header::CONTENT_TYPE, CONTENT_TYPE)
-            .body(serde_json::to_vec(body)?)
+            .request(Method::PATCH, path)?
+            .header(CONTENT_TYPE_HEADER, CONTENT_TYPE)
+            .json(body)
             .send()
             .await?;
-        let resp = Self::check_response(http::Method::PATCH, resp).await?;
+        let resp = Self::check_response(Method::PATCH, resp).await?;
         Ok(resp.json().await?)
     }
 
@@ -150,22 +151,20 @@ impl DivviupClient {
     where
         T: DeserializeOwned,
     {
-        let mut req = self.request(http::Method::POST, path)?;
+        let mut req = self.request(Method::POST, path)?;
 
         if let Some(body) = body {
-            req = req
-                .header(http::header::CONTENT_TYPE, CONTENT_TYPE)
-                .body(serde_json::to_vec(body)?);
+            req = req.header(CONTENT_TYPE_HEADER, CONTENT_TYPE).json(body);
         }
 
         let resp = req.send().await?;
-        let resp = Self::check_response(http::Method::POST, resp).await?;
+        let resp = Self::check_response(Method::POST, resp).await?;
         Ok(resp.json().await?)
     }
 
     async fn delete(&self, path: &str) -> ClientResult {
-        let resp = self.request(http::Method::DELETE, path)?.send().await?;
-        Self::check_response(http::Method::DELETE, resp).await?;
+        let resp = self.request(Method::DELETE, path)?.send().await?;
+        Self::check_response(Method::DELETE, resp).await?;
         Ok(())
     }
 
@@ -397,7 +396,7 @@ pub enum Error {
 
     #[error("unexpected http status {method} {url} {status}: {body}")]
     HttpStatusNotSuccess {
-        method: http::Method,
+        method: Method,
         url: Url,
         status: StatusCode,
         body: String,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -24,16 +24,17 @@ pub const DEFAULT_URL: &str = "https://api.divviup.org/";
 pub const USER_AGENT: &str = concat!("divviup-client/", env!("CARGO_PKG_VERSION"));
 
 use base64::{engine::general_purpose::STANDARD, Engine};
+use http::StatusCode;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::json;
-use std::{fmt::Display, future::Future, pin::Pin};
+use std::fmt::Display;
 use time::format_description::well_known::Rfc3339;
-use trillium_http::{HeaderName, HeaderValues};
 
 pub use account::Account;
 pub use aggregator::{Aggregator, CollectorAuthenticationToken, NewAggregator, Role};
 pub use api_token::ApiToken;
 pub use collector_credentials::CollectorCredential;
+pub use http;
 pub use janus_messages::{
     codec::{CodecError, Decode, Encode},
     HpkeConfig, HpkePublicKey,
@@ -42,12 +43,9 @@ pub use membership::Membership;
 pub use num_bigint::BigUint;
 pub use num_rational::Ratio;
 pub use protocol::Protocol;
+pub use reqwest;
 pub use task::{Histogram, NewTask, SumVec, Task, Vdaf};
 pub use time::OffsetDateTime;
-pub use trillium_client;
-pub use trillium_client::Client;
-pub use trillium_client::Conn;
-pub use trillium_http::{HeaderValue, Headers, KnownHeaderName, Method, Status};
 pub use url::Url;
 pub use uuid::Uuid;
 pub use validation_errors::ValidationErrors;
@@ -55,61 +53,20 @@ pub use validation_errors::ValidationErrors;
 #[cfg(feature = "admin")]
 pub use aggregator::NewSharedAggregator;
 
-trait ErrInto<T, E1, E2> {
-    fn err_into(self) -> Result<T, E2>;
-}
-impl<T, E1, E2> ErrInto<T, E1, E2> for Result<T, E1>
-where
-    E2: From<E1>,
-{
-    fn err_into(self) -> Result<T, E2> {
-        self.map_err(Into::into)
-    }
-}
-
 #[derive(Debug, Clone)]
-pub struct DivviupClient(Client);
+pub struct DivviupClient {
+    client: reqwest::Client,
+    base_url: Url,
+    token: String,
+}
 
 impl DivviupClient {
-    pub fn new(token: impl Display, http_client: impl Into<Client>) -> Self {
-        Self(
-            http_client
-                .into()
-                .with_default_header(KnownHeaderName::UserAgent, USER_AGENT)
-                .with_default_header(KnownHeaderName::Accept, CONTENT_TYPE)
-                .with_default_header(KnownHeaderName::Authorization, format!("Bearer {token}"))
-                .with_base(DEFAULT_URL),
-        )
-    }
-
-    pub fn with_default_pool(mut self) -> Self {
-        self.0 = self.0.with_default_pool();
-        self
-    }
-
-    pub fn with_header(
-        mut self,
-        name: impl Into<HeaderName<'static>>,
-        value: impl Into<HeaderValues>,
-    ) -> Self {
-        self.insert_header(name, value);
-        self
-    }
-
-    pub fn insert_header(
-        &mut self,
-        name: impl Into<HeaderName<'static>>,
-        value: impl Into<HeaderValues>,
-    ) {
-        self.headers_mut().insert(name, value);
-    }
-
-    pub fn headers(&self) -> &Headers {
-        self.0.default_headers()
-    }
-
-    pub fn headers_mut(&mut self) -> &mut Headers {
-        self.0.default_headers_mut()
+    pub fn new(token: impl Display, client: reqwest::Client) -> Self {
+        Self {
+            client,
+            base_url: Url::parse(DEFAULT_URL).unwrap(),
+            token: token.to_string(),
+        }
     }
 
     pub fn with_url(mut self, url: Url) -> Self {
@@ -118,58 +75,97 @@ impl DivviupClient {
     }
 
     pub fn set_url(&mut self, url: Url) {
-        self.0.set_base(url).unwrap();
+        self.base_url = url;
+    }
+
+    pub fn base_url(&self) -> &Url {
+        &self.base_url
+    }
+
+    fn url(&self, path: &str) -> ClientResult<Url> {
+        self.base_url.join(path).map_err(Error::from)
+    }
+
+    fn request(&self, method: http::Method, path: &str) -> ClientResult<reqwest::RequestBuilder> {
+        let url = self.url(path)?;
+        Ok(self
+            .client
+            .request(method, url)
+            .header(http::header::ACCEPT, CONTENT_TYPE)
+            .header(
+                http::header::AUTHORIZATION,
+                format!("Bearer {}", self.token),
+            ))
+    }
+
+    async fn check_response(
+        method: http::Method,
+        response: reqwest::Response,
+    ) -> ClientResult<reqwest::Response> {
+        let status = response.status();
+        if status.is_success() {
+            return Ok(response);
+        }
+
+        if status == StatusCode::BAD_REQUEST {
+            let body = response.text().await?;
+            log::trace!("{body}");
+            return Err(Error::ValidationErrors(serde_json::from_str(&body)?));
+        }
+
+        let url = response.url().clone();
+        let body = response.text().await.unwrap_or_default();
+        Err(Error::HttpStatusNotSuccess {
+            method,
+            url,
+            status,
+            body,
+        })
     }
 
     async fn get<T>(&self, path: &str) -> ClientResult<T>
     where
         T: DeserializeOwned,
     {
-        self.0
-            .get(path)
-            .success_or_error()
-            .await?
-            .response_json()
-            .await
-            .err_into()
+        let resp = self.request(http::Method::GET, path)?.send().await?;
+        let resp = Self::check_response(http::Method::GET, resp).await?;
+        Ok(resp.json().await?)
     }
 
     async fn patch<T>(&self, path: &str, body: &impl Serialize) -> ClientResult<T>
     where
         T: DeserializeOwned,
     {
-        self.0
-            .patch(path)
-            .with_json_body(body)?
-            .with_request_header(KnownHeaderName::ContentType, CONTENT_TYPE)
-            .success_or_error()
-            .await?
-            .response_json()
-            .await
-            .err_into()
+        let resp = self
+            .request(http::Method::PATCH, path)?
+            .header(http::header::CONTENT_TYPE, CONTENT_TYPE)
+            .body(serde_json::to_vec(body)?)
+            .send()
+            .await?;
+        let resp = Self::check_response(http::Method::PATCH, resp).await?;
+        Ok(resp.json().await?)
     }
 
     async fn post<T>(&self, path: &str, body: Option<&impl Serialize>) -> ClientResult<T>
     where
         T: DeserializeOwned,
     {
-        let mut conn = self.0.post(path);
+        let mut req = self.request(http::Method::POST, path)?;
 
         if let Some(body) = body {
-            conn = conn
-                .with_json_body(body)?
-                .with_request_header(KnownHeaderName::ContentType, CONTENT_TYPE);
+            req = req
+                .header(http::header::CONTENT_TYPE, CONTENT_TYPE)
+                .body(serde_json::to_vec(body)?);
         }
 
-        conn.success_or_error()
-            .await?
-            .response_json()
-            .await
-            .err_into()
+        let resp = req.send().await?;
+        let resp = Self::check_response(http::Method::POST, resp).await?;
+        Ok(resp.json().await?)
     }
 
     async fn delete(&self, path: &str) -> ClientResult {
-        let _ = self.0.delete(path).success_or_error().await?;
+        let resp = self.request(http::Method::DELETE, path)?.send().await?;
+        Self::check_response(http::Method::DELETE, resp).await?;
         Ok(())
     }
 
@@ -391,10 +387,7 @@ pub type ClientResult<T = ()> = Result<T, Error>;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    Http(#[from] trillium_http::Error),
-
-    #[error(transparent)]
-    Client(#[from] trillium_client::ClientSerdeError),
+    Reqwest(#[from] reqwest::Error),
 
     #[error(transparent)]
     Url(#[from] url::ParseError),
@@ -402,11 +395,11 @@ pub enum Error {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 
-    #[error("unexpected http status {method} {url} {status:?}: {body}")]
+    #[error("unexpected http status {method} {url} {status}: {body}")]
     HttpStatusNotSuccess {
-        method: Method,
+        method: http::Method,
         url: Url,
-        status: Option<Status>,
+        status: StatusCode,
         body: String,
     },
 
@@ -418,38 +411,4 @@ pub enum Error {
 
     #[error("time formatting error: {0}")]
     TimeFormat(#[from] time::error::Format),
-}
-
-pub trait ClientConnExt: Sized {
-    fn success_or_error(self)
-        -> Pin<Box<dyn Future<Output = ClientResult<Self>> + Send + 'static>>;
-}
-impl ClientConnExt for Conn {
-    fn success_or_error(
-        self,
-    ) -> Pin<Box<dyn Future<Output = ClientResult<Self>> + Send + 'static>> {
-        Box::pin(async move {
-            let mut error = match self.await?.success() {
-                Ok(conn) => return Ok(conn),
-                Err(error) => error,
-            };
-
-            let status = error.status();
-            if let Some(Status::BadRequest) = status {
-                let body = error.response_body().read_string().await?;
-                log::trace!("{body}");
-                Err(Error::ValidationErrors(serde_json::from_str(&body)?))
-            } else {
-                let url = error.url().clone();
-                let method = error.method();
-                let body = error.response_body().await?;
-                Err(Error::HttpStatusNotSuccess {
-                    method,
-                    url,
-                    status,
-                    body,
-                })
-            }
-        })
-    }
 }

--- a/client/tests/integration/basic_client_behavior.rs
+++ b/client/tests/integration/basic_client_behavior.rs
@@ -1,5 +1,5 @@
 use crate::harness::{assert_eq, test, *};
-use divviup_client::{CONTENT_TYPE, USER_AGENT};
+use divviup_client::CONTENT_TYPE;
 
 #[test(harness = with_configured_client_and_logs)]
 async fn default_headers(
@@ -11,21 +11,13 @@ async fn default_headers(
     let _ = client.aggregators(account.id).await;
     let log = logs.last();
     assert_eq!(
-        log.url.as_str(),
-        &format!(
-            "https://api.divviup.org/api/accounts/{}/aggregators",
-            account.id
-        )
+        log.url.path(),
+        &format!("/api/accounts/{}/aggregators", account.id)
     );
 
     assert_eq!(
         log.request_headers.get_str(KnownHeaderName::Accept),
         Some(CONTENT_TYPE)
-    );
-
-    assert_eq!(
-        log.request_headers.get_str(KnownHeaderName::UserAgent),
-        Some(USER_AGENT)
     );
 
     assert!(log

--- a/client/tests/integration/harness.rs
+++ b/client/tests/integration/harness.rs
@@ -1,26 +1,28 @@
 pub use divviup_client::DivviupClient;
 use test_support::tracing::install_test_trace_subscriber;
-use trillium_testing::connector;
+use tokio::net::TcpListener;
+use trillium_http::Stopper;
 
 pub use std::sync::Arc;
 pub use test_support::*;
 
-use std::{future::Future, process::Termination};
-use trillium_client::Client;
+use std::{future::Future, net::Ipv6Addr, process::Termination};
 
-pub fn with_http_client<F, Fut, Out>(f: F) -> Out
-where
-    F: FnOnce(Arc<DivviupApi>, Client, ClientLogs) -> Fut + Send + 'static,
-    Fut: Future<Output = Out> + Send + 'static,
-    Out: Termination,
-{
-    with_client_logs(move |app, _| async move {
-        install_test_trace_subscriber();
-        let client_logs = ClientLogs::default();
-        let app = Arc::new(app);
-        let http_client = Client::new(connector((client_logs.clone(), app.clone())));
-        f(app, http_client, client_logs).await
-    })
+async fn spawn_test_server(app: impl trillium::Handler) -> (url::Url, Stopper) {
+    let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let stopper = Stopper::new();
+
+    tokio::spawn(
+        trillium_tokio::config()
+            .without_signals()
+            .with_stopper(stopper.clone())
+            .with_prebound_server(listener)
+            .run_async(app),
+    );
+
+    let url = url::Url::parse(&format!("http://[::1]:{port}/")).unwrap();
+    (url, stopper)
 }
 
 pub fn with_configured_client<F, Fut, Out>(f: F) -> Out
@@ -30,7 +32,6 @@ where
     Out: Termination,
 {
     with_configured_client_and_logs(move |app, account, client, _| async move {
-        install_test_trace_subscriber();
         f(app, account, client).await
     })
 }
@@ -41,12 +42,23 @@ where
     Fut: Future<Output = Out> + Send + 'static,
     Out: Termination,
 {
-    with_http_client(move |app, http_client, logs| async move {
+    with_client_logs(move |app, _api_logs| async move {
         install_test_trace_subscriber();
+        let client_logs = ClientLogs::default();
+        let app = Arc::new(app);
+
+        let (base_url, _stopper) = spawn_test_server((client_logs.clone(), app.clone())).await;
+
         let account = fixtures::account(&app).await;
         let (api_token, token) = ApiToken::build(&account);
         api_token.insert(app.db()).await.unwrap();
-        let client = DivviupClient::new(token, http_client);
-        f(app, account, client, logs).await
+
+        let http_client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("failed to build test HTTP client");
+        let client = DivviupClient::new(token, http_client).with_url(base_url);
+
+        f(app, account, client, client_logs).await
     })
 }

--- a/client/tests/integration/harness.rs
+++ b/client/tests/integration/harness.rs
@@ -1,14 +1,14 @@
 pub use divviup_client::DivviupClient;
+use std::{future::Future, net::Ipv6Addr, process::Termination};
 use test_support::tracing::install_test_trace_subscriber;
 use tokio::net::TcpListener;
 use trillium_http::Stopper;
+use url::Url;
 
 pub use std::sync::Arc;
 pub use test_support::*;
 
-use std::{future::Future, net::Ipv6Addr, process::Termination};
-
-async fn spawn_test_server(app: impl trillium::Handler) -> (url::Url, Stopper) {
+async fn spawn_test_server(app: impl trillium::Handler) -> (Url, Stopper) {
     let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let stopper = Stopper::new();
@@ -21,7 +21,7 @@ async fn spawn_test_server(app: impl trillium::Handler) -> (url::Url, Stopper) {
             .run_async(app),
     );
 
-    let url = url::Url::parse(&format!("http://[::1]:{port}/")).unwrap();
+    let url = Url::parse(&format!("http://[::1]:{port}/")).unwrap();
     (url, stopper)
 }
 


### PR DESCRIPTION
Replace trillium-client and trillium-http with reqwest in the divviup-client SDK, and remove trillium-rustls/trillium-tokio from the CLI.

> [!note]
> This is a breaking change to the divviup-client public API.

- DivviupClient now wraps reqwest::Client instead of trillium_client::Client
- Re-exports http and reqwest crates instead of trillium types
- Error enum uses reqwest::Error instead of trillium error types
- CLI uses #[tokio::main] and reqwest::Client::builder() directly
- Client tests spawn a real TCP server instead of using trillium_testing::connector()
- Bump workspace version to 0.5.0-pre.1 for the dep break