### PR TITLE
Migrate from Trillium [part 2]: Axum scaffold and proxy fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,13 +236,12 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.1.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
- "event-listener 4.0.3",
- "event-listener-strategy 0.4.0",
+ "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
 ]
@@ -302,7 +301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener 5.4.1",
- "event-listener-strategy 0.5.2",
+ "event-listener-strategy",
  "pin-project-lite",
 ]
 
@@ -362,9 +361,12 @@ dependencies = [
 
 [[package]]
 name = "async_cell"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834eee9ce518130a3b4d5af09ecc43e9d6b57ee76613f227a1ddd6b77c7a62bc"
+checksum = "447ab28afbb345f5408b120702a44e5529ebf90b1796ec76e9528df8e288e6c2"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "atoi"
@@ -445,10 +447,13 @@ checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
  "axum-core 0.5.5",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit 0.8.4",
  "memchr",
@@ -456,10 +461,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
+ "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -498,6 +508,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -907,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1064,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1315,6 +1326,7 @@ dependencies = [
  "aes-gcm",
  "async-lock 3.4.2",
  "async-session",
+ "axum 0.8.6",
  "base64 0.22.1",
  "console-subscriber",
  "educe",
@@ -1335,6 +1347,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "regex",
+ "reqwest",
  "rustc_version",
  "rustls-webpki",
  "sea-orm",
@@ -1347,6 +1360,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-chrome",
  "tracing-log",
@@ -1609,19 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.4.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
-dependencies = [
- "event-listener 4.0.3",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.1",
  "pin-project-lite",
@@ -1849,6 +1853,21 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result",
 ]
 
 [[package]]
@@ -2720,6 +2739,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru-slab"
@@ -4086,6 +4118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5253,6 +5291,22 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ otlp-trace = ["opentelemetry/trace", "opentelemetry-otlp", "opentelemetry_sdk/tr
 
 [dependencies]
 aes-gcm = "0.10.3"
+axum = "0.8"
 async-lock = "3.4.1"
 async-session = "3.0.0"
 base64 = "0.22.1"
@@ -93,6 +94,8 @@ url = "2.5.2"
 uuid = { version = "1.16.0", features = ["v4", "fast-rng", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 trillium-opentelemetry = { version = "0.10.0", default-features = false, features = ["metrics"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+tower-http = { version = "0.6", features = ["trace"] }
 opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio", "logs", "metrics"] }
 opentelemetry-otlp = { version = "0.27.0", optional = true }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -64,7 +64,6 @@ pub struct DivviupApi {
     handler: Box<dyn Handler>,
     db: Db,
     config: Arc<Config>,
-    #[handler(skip)]
     axum_addr: SocketAddr,
 }
 
@@ -148,7 +147,7 @@ impl DivviupApi {
         &self.config.crypter
     }
 
-    #[allow(dead_code)] // Scaffolded for later migration parts.
+    #[expect(dead_code)] // Scaffolded for later migration parts.
     pub(crate) fn axum_addr(&self) -> SocketAddr {
         self.axum_addr
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -11,13 +11,18 @@ pub(crate) mod opentelemetry;
 pub(crate) mod origin_router;
 pub(crate) mod session_store;
 
+pub(crate) mod proxy;
+
 use crate::{routes, Config, Db};
 
 use cors::cors_headers;
 use error::ErrorHandler;
 use logger::logger;
+use proxy::AxumProxy;
 use session_store::SessionStore;
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, net::Ipv6Addr, net::SocketAddr, sync::Arc};
+use tokio::net::TcpListener;
+use tower_http::trace::TraceLayer;
 use trillium::{state, Handler, Info};
 use trillium_caching_headers::{
     cache_control, caching_headers,
@@ -45,20 +50,29 @@ fn instrument_handler(handler: impl Handler) -> impl Handler {
     handler
 }
 
+/// Shared state for the Axum side of the application during migration.
+#[derive(Clone, Debug)]
+pub struct AxumAppState {
+    pub db: Db,
+    pub config: Arc<Config>,
+}
+
 #[derive(Handler, Debug)]
 pub struct DivviupApi {
     #[handler(except = init)]
     handler: Box<dyn Handler>,
     db: Db,
     config: Arc<Config>,
+    #[handler(skip)]
+    axum_addr: SocketAddr,
 }
 
 impl DivviupApi {
     pub async fn init(&mut self, info: &mut Info) {
         *info.server_description_mut() = format!("divviup-api {}", env!("CARGO_PKG_VERSION"));
         *info.listener_description_mut() = format!(
-            "api url: {}\n             app url: {}\n",
-            self.config.api_url, self.config.app_url,
+            "api url: {}\n             app url: {}\n             axum: {}\n",
+            self.config.api_url, self.config.app_url, self.axum_addr,
         );
         self.handler.init(info).await
     }
@@ -66,6 +80,37 @@ impl DivviupApi {
     pub async fn new(config: Config) -> Self {
         let config = Arc::new(config);
         let db = Db::connect(config.database_url.as_ref()).await;
+
+        // Spawn the Axum server on an ephemeral port. Routes will be migrated
+        // here incrementally; for now the router is empty and the proxy below
+        // is a no-op fallback.
+        let axum_state = AxumAppState {
+            db: db.clone(),
+            config: config.clone(),
+        };
+        let axum_router = axum::Router::new()
+            // Temporary test endpoint to verify the proxy bridge works.
+            // TODO: Remove once a real endpoint has been migrated.
+            .route(
+                "/internal/test/axum_ready",
+                axum::routing::get(|| async { "axum OK" }),
+            )
+            // Basic request tracing only for now; full telemetry (metrics,
+            // OpenTelemetry, structured logging) will be added in Part 4.
+            .layer(TraceLayer::new_for_http())
+            .with_state(axum_state);
+        let axum_listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+        let axum_addr = axum_listener.local_addr().unwrap();
+        // TODO: Wire graceful shutdown into axum::serve(...).with_graceful_shutdown()
+        // so that in-flight requests are drained when the Trillium server stops.
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(axum_listener, axum_router).await {
+                log::error!("axum server error: {e}");
+            }
+        });
+
+        let proxy = AxumProxy::new(axum_addr);
+
         Self {
             handler: Box::new((
                 conn_id(),
@@ -77,10 +122,12 @@ impl DivviupApi {
                 #[cfg(assets)]
                 instrument_handler(assets::static_assets(&config)),
                 instrument_handler(api(&db, &config)),
+                proxy,
                 ErrorHandler,
             )),
             db,
             config,
+            axum_addr,
         }
     }
 
@@ -94,6 +141,10 @@ impl DivviupApi {
 
     pub fn crypter(&self) -> &crate::Crypter {
         &self.config.crypter
+    }
+
+    pub fn axum_addr(&self) -> SocketAddr {
+        self.axum_addr
     }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -15,6 +15,7 @@ pub(crate) mod proxy;
 
 use crate::{routes, Config, Db};
 
+use axum::extract::DefaultBodyLimit;
 use cors::cors_headers;
 use error::ErrorHandler;
 use logger::logger;
@@ -95,12 +96,17 @@ impl DivviupApi {
                 "/internal/test/axum_ready",
                 axum::routing::get(|| async { "axum OK" }),
             )
+            .layer(DefaultBodyLimit::max(1024 * 1024))
             // Basic request tracing only for now; full telemetry (metrics,
             // OpenTelemetry, structured logging) will be added in Part 4.
             .layer(TraceLayer::new_for_http())
             .with_state(axum_state);
-        let axum_listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
-        let axum_addr = axum_listener.local_addr().unwrap();
+        let axum_listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0))
+            .await
+            .expect("failed to bind Axum listener on IPv6 loopback");
+        let axum_addr = axum_listener
+            .local_addr()
+            .expect("failed to get Axum listener address");
         // TODO: Wire graceful shutdown into axum::serve(...).with_graceful_shutdown()
         // so that in-flight requests are drained when the Trillium server stops.
         tokio::spawn(async move {
@@ -143,7 +149,8 @@ impl DivviupApi {
         &self.config.crypter
     }
 
-    pub fn axum_addr(&self) -> SocketAddr {
+    #[allow(dead_code)] // Scaffolded for later migration parts.
+    pub(crate) fn axum_addr(&self) -> SocketAddr {
         self.axum_addr
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -83,8 +83,7 @@ impl DivviupApi {
         let db = Db::connect(config.database_url.as_ref()).await;
 
         // Spawn the Axum server on an ephemeral port. Routes will be migrated
-        // here incrementally; for now the router is empty and the proxy below
-        // is a no-op fallback.
+        // here incrementally.
         let axum_state = AxumAppState {
             db: db.clone(),
             config: config.clone(),

--- a/src/handler/proxy.rs
+++ b/src/handler/proxy.rs
@@ -1,0 +1,122 @@
+//! Temporary reverse proxy handler that forwards unmatched Trillium requests to
+//! the local Axum server. This exists only during the incremental migration and
+//! will be removed once all routes have been moved to Axum.
+
+use reqwest::header::{HeaderName, CONNECTION, HOST, TRANSFER_ENCODING};
+use std::net::SocketAddr;
+use trillium::{Conn, Handler, Status};
+
+/// A Trillium [`Handler`] that proxies unhalted requests to a local Axum server.
+#[derive(Debug)]
+pub struct AxumProxy {
+    upstream: String,
+    client: reqwest::Client,
+}
+
+impl AxumProxy {
+    pub fn new(addr: SocketAddr) -> Self {
+        Self {
+            upstream: format!("http://[::1]:{}", addr.port()),
+            client: reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("failed to build proxy HTTP client"),
+        }
+    }
+}
+
+/// Headers that should not be forwarded through the proxy.
+const UNPROXYABLE_HEADERS: [HeaderName; 3] = [HOST, TRANSFER_ENCODING, CONNECTION];
+
+#[trillium::async_trait]
+impl Handler for AxumProxy {
+    async fn run(&self, mut conn: Conn) -> Conn {
+        // Only proxy requests that haven't been handled by earlier handlers.
+        if conn.status().is_some() || conn.is_halted() {
+            return conn;
+        }
+
+        let method = conn.method();
+        let path = conn.path();
+        let querystring = conn.querystring();
+
+        let url = if querystring.is_empty() {
+            format!("{}{}", self.upstream, path)
+        } else {
+            format!("{}{}?{}", self.upstream, path, querystring)
+        };
+
+        let reqwest_method = match reqwest::Method::from_bytes(method.as_ref().as_bytes()) {
+            Ok(m) => m,
+            Err(_) => return conn.with_status(Status::BadRequest).halt(),
+        };
+
+        let mut builder = self.client.request(reqwest_method, &url);
+
+        // Forward request headers, filtering out hop-by-hop headers.
+        for (name, values) in conn.request_headers() {
+            let header_name = match HeaderName::from_bytes(name.as_ref().as_bytes()) {
+                Ok(h) => h,
+                Err(_) => continue,
+            };
+            if UNPROXYABLE_HEADERS.contains(&header_name) {
+                continue;
+            }
+            for value in values.iter() {
+                if let Some(s) = value.as_str() {
+                    builder = builder.header(&header_name, s);
+                }
+            }
+        }
+
+        // Forward the request body. Note: no size limit is enforced here;
+        // the Trillium API layer (trillium-api) enforces a 1 MiB limit before
+        // requests reach this handler, so it's fine for the migration window.
+        let body = conn.request_body().await.read_bytes().await;
+        match body {
+            Ok(bytes) if !bytes.is_empty() => {
+                builder = builder.body(bytes);
+            }
+            Err(e) => {
+                log::error!("axum proxy error reading request body: {e}");
+                return conn.with_status(Status::BadRequest).halt();
+            }
+            _ => {}
+        }
+
+        let resp = match builder.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                log::error!("axum proxy error: {e}");
+                return conn.with_status(Status::BadGateway).halt();
+            }
+        };
+
+        let status = resp.status().as_u16();
+        let resp_headers = resp.headers().clone();
+        let body = match resp.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                log::error!("axum proxy error reading response: {e}");
+                return conn.with_status(Status::BadGateway).halt();
+            }
+        };
+
+        let mut conn = conn.with_status(status).halt();
+
+        for (name, value) in resp_headers.iter() {
+            if UNPROXYABLE_HEADERS.contains(name) {
+                continue;
+            }
+            if let Ok(v) = value.to_str() {
+                conn.response_headers_mut()
+                    .append(name.as_str().to_owned(), v.to_owned());
+            }
+        }
+
+        // This copies the response body; we could avoid it by streaming via
+        // resp.into_body() + Body::new_streaming, but it's not worth the extra
+        // plumbing for a temporary shim.
+        conn.with_body(body.to_vec())
+    }
+}

--- a/src/handler/proxy.rs
+++ b/src/handler/proxy.rs
@@ -2,7 +2,7 @@
 //! the local Axum server. This exists only during the incremental migration and
 //! will be removed once all routes have been moved to Axum.
 
-use reqwest::header::{HeaderName, CONNECTION, HOST, TRANSFER_ENCODING};
+use reqwest::header::{HeaderName, CONNECTION, HOST, TE, TRAILER, TRANSFER_ENCODING};
 use std::net::SocketAddr;
 use trillium::{Conn, Handler, Status};
 
@@ -25,8 +25,8 @@ impl AxumProxy {
     }
 }
 
-/// Headers that should not be forwarded through the proxy.
-const UNPROXYABLE_HEADERS: [HeaderName; 3] = [HOST, TRANSFER_ENCODING, CONNECTION];
+/// Hop-by-hop headers that should not be forwarded through the proxy (RFC 7230 §6.1).
+const UNPROXYABLE_HEADERS: [HeaderName; 5] = [HOST, TRANSFER_ENCODING, CONNECTION, TE, TRAILER];
 
 #[trillium::async_trait]
 impl Handler for AxumProxy {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod user;
 pub use config::{Config, ConfigError, FeatureFlags};
 pub use crypter::Crypter;
 pub use db::Db;
-pub use handler::{custom_mime_types::CONTENT_TYPE, DivviupApi, Error};
+pub use handler::{custom_mime_types::CONTENT_TYPE, AxumAppState, DivviupApi, Error};
 pub use opentelemetry;
 pub use permissions::{Permissions, PermissionsActor};
 pub use queue::Queue;

--- a/tests/integration/axum_proxy.rs
+++ b/tests/integration/axum_proxy.rs
@@ -1,0 +1,12 @@
+use test_support::{assert_eq, test, *};
+
+#[test(harness = set_up)]
+async fn axum_proxy_bridge(app: DivviupApi) -> TestResult {
+    let mut conn = get("/internal/test/axum_ready")
+        .with_api_host()
+        .run_async(&app)
+        .await;
+    assert_eq!(conn.status().unwrap(), Status::Ok);
+    assert_eq!(conn.take_response_body_string().unwrap(), "axum OK");
+    Ok(())
+}

--- a/tests/integration/axum_proxy.rs
+++ b/tests/integration/axum_proxy.rs
@@ -10,3 +10,12 @@ async fn axum_proxy_bridge(app: DivviupApi) -> TestResult {
     assert_eq!(conn.take_response_body_string().unwrap(), "axum OK");
     Ok(())
 }
+
+/// Verify that a route handled by Trillium (health check) is served
+/// directly and not double-forwarded through the proxy to Axum.
+#[test(harness = set_up)]
+async fn trillium_route_not_proxied(app: DivviupApi) -> TestResult {
+    let conn = get("/health").with_api_host().run_async(&app).await;
+    assert_eq!(conn.status().unwrap(), Status::Ok);
+    Ok(())
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -5,6 +5,7 @@ mod aggregators;
 mod api_tokens;
 mod assets;
 mod auth;
+mod axum_proxy;
 mod collector_credentials;
 mod crypter;
 mod health_check;


### PR DESCRIPTION
Establish dual-server infrastructure for incremental route migration. Trillium remains the primary listener; a proxy handler at the end of the handler chain forwards unmatched requests to a local Axum server.

- Add axum, reqwest, and tower-http dependencies to the main crate
- Define AxumAppState struct (Db + Arc<Config>) for the Axum side
- Spawn an Axum server on an ephemeral loopback port in DivviupApi::new() with a TraceLayer for request-level tracing
- Add AxumProxy handler that forwards unhalted Trillium requests to the local Axum server via reqwest (trillium-proxy is incompatible with trillium 0.2.x, so we use a custom handler like Janus did)
- Wire the proxy into the handler chain just before ErrorHandler
- Add /internal/test/axum_ready endpoint and integration test to verify the proxy bridge works end-to-end