### PR TITLE
Migrate from Trillium [part 3]: Axum middleware and error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "pin-project-lite",
+ "tokio",
  "zstd",
  "zstd-safe",
 ]
@@ -1360,7 +1361,9 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tower 0.5.2",
  "tower-http",
+ "tower-sessions-core",
  "tracing",
  "tracing-chrome",
  "tracing-log",
@@ -2732,6 +2735,7 @@ checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -5302,11 +5306,15 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5323,6 +5331,26 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-sessions-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8cce604865576b7751b7a6bc3058f754569a60d689328bb74c52b1d87e355b"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "futures",
+ "http",
+ "parking_lot",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,9 @@ uuid = { version = "1.16.0", features = ["v4", "fast-rng", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 trillium-opentelemetry = { version = "0.10.0", default-features = false, features = ["metrics"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-tower-http = { version = "0.6", features = ["trace"] }
+tower = { version = "0.5", features = ["util"] }
+tower-http = { version = "0.6", features = ["trace", "cors", "compression-full", "set-header"] }
+tower-sessions-core = "0.14"
 opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio", "logs", "metrics"] }
 opentelemetry-otlp = { version = "0.27.0", optional = true }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -16,13 +16,17 @@ pub(crate) mod proxy;
 use crate::{routes, Config, Db};
 
 use axum::extract::DefaultBodyLimit;
-use cors::cors_headers;
+use axum::http::{header, HeaderValue};
+use cors::{axum_cors_layer, cors_headers};
 use error::ErrorHandler;
 use logger::logger;
 use proxy::AxumProxy;
 use session_store::SessionStore;
 use std::{borrow::Cow, net::Ipv6Addr, net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
+use tower::ServiceBuilder;
+use tower_http::compression::CompressionLayer;
+use tower_http::set_header::SetResponseHeaderLayer;
 use tower_http::trace::TraceLayer;
 use trillium::{state, Handler, Info};
 use trillium_caching_headers::{
@@ -87,6 +91,21 @@ impl DivviupApi {
             db: db.clone(),
             config: config.clone(),
         };
+        // Middleware stack in logical order (outermost first), matching the
+        // Trillium api() handler chain.
+        //
+        // TODO(Part 7): ReplaceMimeTypesLayer goes on the /api/* sub-router.
+        // TODO(Part 6): SessionManagerLayer goes here once auth routes migrate.
+        let middleware = ServiceBuilder::new()
+            .layer(TraceLayer::new_for_http())
+            .layer(DefaultBodyLimit::max(1024 * 1024))
+            .layer(CompressionLayer::new())
+            .layer(SetResponseHeaderLayer::if_not_present(
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("private, must-revalidate"),
+            ))
+            .layer(axum_cors_layer(&config));
+
         let axum_router = axum::Router::new()
             // Temporary test endpoint to verify the proxy bridge works.
             // TODO: Remove once a real endpoint has been migrated.
@@ -94,10 +113,7 @@ impl DivviupApi {
                 "/internal/test/axum_ready",
                 axum::routing::get(|| async { "axum OK" }),
             )
-            .layer(DefaultBodyLimit::max(1024 * 1024))
-            // Basic request tracing only for now; full telemetry (metrics,
-            // OpenTelemetry, structured logging) will be added in Part 4.
-            .layer(TraceLayer::new_for_http())
+            .layer(middleware)
             .with_state(axum_state);
         let axum_listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0))
             .await

--- a/src/handler/cors.rs
+++ b/src/handler/cors.rs
@@ -1,5 +1,6 @@
 use crate::Config;
 use axum::http::{header, HeaderValue, Method as HttpMethod};
+use time::Duration;
 use tower_http::cors::CorsLayer;
 use trillium::{
     Conn, Handler,
@@ -63,7 +64,13 @@ pub fn axum_cors_layer(config: &Config) -> CorsLayer {
     origin.pop(); // strip trailing slash, matching Trillium behavior
 
     CorsLayer::new()
-        .allow_origin(origin.parse::<HeaderValue>().expect("valid origin"))
+        // unwrap safety: config.app_url is a valid URL, so stripping the
+        // trailing slash still leaves a valid HTTP header value.
+        .allow_origin(
+            origin
+                .parse::<HeaderValue>()
+                .expect("config.app_url must be a valid header value"),
+        )
         .allow_methods([
             HttpMethod::POST,
             HttpMethod::DELETE,
@@ -78,5 +85,5 @@ pub fn axum_cors_layer(config: &Config) -> CorsLayer {
             header::ETAG,
         ])
         .allow_credentials(true)
-        .max_age(std::time::Duration::from_secs(86400))
+        .max_age(Duration::DAY.unsigned_abs())
 }

--- a/src/handler/cors.rs
+++ b/src/handler/cors.rs
@@ -60,8 +60,11 @@ pub fn cors_headers(config: &Config) -> impl Handler {
 /// Build a [`tower_http::cors::CorsLayer`] matching the Trillium [`CorsHeaders`]
 /// behavior above.
 pub fn axum_cors_layer(config: &Config) -> CorsLayer {
-    let mut origin = config.app_url.to_string();
-    origin.pop(); // strip trailing slash, matching Trillium behavior
+    let origin = config
+        .app_url
+        .as_str()
+        .strip_suffix('/')
+        .unwrap_or(config.app_url.as_str());
 
     CorsLayer::new()
         // unwrap safety: config.app_url is a valid URL, so stripping the

--- a/src/handler/cors.rs
+++ b/src/handler/cors.rs
@@ -1,4 +1,6 @@
 use crate::Config;
+use axum::http::{header, HeaderValue, Method as HttpMethod};
+use tower_http::cors::CorsLayer;
 use trillium::{
     Conn, Handler,
     KnownHeaderName::{
@@ -52,4 +54,29 @@ impl CorsHeaders {
 
 pub fn cors_headers(config: &Config) -> impl Handler {
     CorsHeaders::new(config)
+}
+
+/// Build a [`tower_http::cors::CorsLayer`] matching the Trillium [`CorsHeaders`]
+/// behavior above.
+pub fn axum_cors_layer(config: &Config) -> CorsLayer {
+    let mut origin = config.app_url.to_string();
+    origin.pop(); // strip trailing slash, matching Trillium behavior
+
+    CorsLayer::new()
+        .allow_origin(origin.parse::<HeaderValue>().expect("valid origin"))
+        .allow_methods([
+            HttpMethod::POST,
+            HttpMethod::DELETE,
+            HttpMethod::OPTIONS,
+            HttpMethod::GET,
+            HttpMethod::PATCH,
+        ])
+        .allow_headers([
+            header::CONTENT_TYPE,
+            header::IF_NONE_MATCH,
+            header::IF_MODIFIED_SINCE,
+            header::ETAG,
+        ])
+        .allow_credentials(true)
+        .max_age(std::time::Duration::from_secs(86400))
 }

--- a/src/handler/custom_mime_types.rs
+++ b/src/handler/custom_mime_types.rs
@@ -11,7 +11,7 @@ use trillium::{
     Status::{NotAcceptable, UnsupportedMediaType},
 };
 
-pub const CONTENT_TYPE: &str = "application/vnd.divviup+json;version=0.1";
+pub const DIVVIUP_API_MEDIA_TYPE: &str = "application/vnd.divviup+json;version=0.1";
 #[cfg_attr(not(test), expect(dead_code))] // Used in ReplaceMimeTypesService; wired in Part 7.
 const APPLICATION_JSON: header::HeaderValue = header::HeaderValue::from_static("application/json");
 
@@ -21,13 +21,13 @@ pub struct ReplaceMimeTypes;
 impl Handler for ReplaceMimeTypes {
     async fn run(&self, mut conn: Conn) -> Conn {
         let request_headers = conn.inner_mut().request_headers_mut();
-        if let Some(CONTENT_TYPE) | None = request_headers.get_str(ContentType) {
+        if let Some(DIVVIUP_API_MEDIA_TYPE) | None = request_headers.get_str(ContentType) {
             request_headers.insert(ContentType, "application/json");
         } else {
             return conn.with_status(UnsupportedMediaType).halt();
         }
 
-        if Some(CONTENT_TYPE) == request_headers.get_str(Accept) {
+        if Some(DIVVIUP_API_MEDIA_TYPE) == request_headers.get_str(Accept) {
             request_headers.insert(Accept, "application/json");
         } else {
             return conn.with_status(NotAcceptable).halt();
@@ -37,7 +37,7 @@ impl Handler for ReplaceMimeTypes {
     }
 
     async fn before_send(&self, conn: Conn) -> Conn {
-        conn.with_response_header(ContentType, CONTENT_TYPE)
+        conn.with_response_header(ContentType, DIVVIUP_API_MEDIA_TYPE)
     }
 }
 
@@ -82,9 +82,8 @@ where
     }
 
     fn call(&mut self, mut req: Request<Body>) -> Self::Future {
-        // --- Request-side: Content-Type ---
         match req.headers().get(header::CONTENT_TYPE).map(|v| v.to_str()) {
-            Some(Ok(CONTENT_TYPE)) | None => {
+            Some(Ok(DIVVIUP_API_MEDIA_TYPE)) | None => {
                 req.headers_mut()
                     .insert(header::CONTENT_TYPE, APPLICATION_JSON);
             }
@@ -93,9 +92,8 @@ where
             }
         }
 
-        // --- Request-side: Accept ---
         match req.headers().get(header::ACCEPT).map(|v| v.to_str()) {
-            Some(Ok(CONTENT_TYPE)) => {
+            Some(Ok(DIVVIUP_API_MEDIA_TYPE)) => {
                 req.headers_mut().insert(header::ACCEPT, APPLICATION_JSON);
             }
             _ => {
@@ -103,13 +101,13 @@ where
             }
         }
 
-        // --- Call the inner service, then set response Content-Type ---
+        // Call the inner service, then set the response Content-Type
         let inner_future = self.inner.call(req);
         Box::pin(async move {
             let mut resp = inner_future.await?;
             resp.headers_mut().insert(
                 header::CONTENT_TYPE,
-                header::HeaderValue::from_static(CONTENT_TYPE),
+                header::HeaderValue::from_static(DIVVIUP_API_MEDIA_TYPE),
             );
             Ok(resp)
         })
@@ -136,8 +134,8 @@ mod tests {
         let resp = test_router()
             .oneshot(
                 Request::get("/test")
-                    .header(header::CONTENT_TYPE, CONTENT_TYPE)
-                    .header(header::ACCEPT, CONTENT_TYPE)
+                    .header(header::CONTENT_TYPE, DIVVIUP_API_MEDIA_TYPE)
+                    .header(header::ACCEPT, DIVVIUP_API_MEDIA_TYPE)
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -146,7 +144,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(
             resp.headers().get(header::CONTENT_TYPE).unwrap(),
-            CONTENT_TYPE
+            DIVVIUP_API_MEDIA_TYPE
         );
     }
 
@@ -155,7 +153,7 @@ mod tests {
         let resp = test_router()
             .oneshot(
                 Request::get("/test")
-                    .header(header::ACCEPT, CONTENT_TYPE)
+                    .header(header::ACCEPT, DIVVIUP_API_MEDIA_TYPE)
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -170,7 +168,7 @@ mod tests {
             .oneshot(
                 Request::get("/test")
                     .header(header::CONTENT_TYPE, "text/plain")
-                    .header(header::ACCEPT, CONTENT_TYPE)
+                    .header(header::ACCEPT, DIVVIUP_API_MEDIA_TYPE)
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -184,7 +182,7 @@ mod tests {
         let resp = test_router()
             .oneshot(
                 Request::get("/test")
-                    .header(header::CONTENT_TYPE, CONTENT_TYPE)
+                    .header(header::CONTENT_TYPE, DIVVIUP_API_MEDIA_TYPE)
                     .header(header::ACCEPT, "text/html")
                     .body(Body::empty())
                     .unwrap(),
@@ -199,7 +197,7 @@ mod tests {
         let resp = test_router()
             .oneshot(
                 Request::get("/test")
-                    .header(header::CONTENT_TYPE, CONTENT_TYPE)
+                    .header(header::CONTENT_TYPE, DIVVIUP_API_MEDIA_TYPE)
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/src/handler/custom_mime_types.rs
+++ b/src/handler/custom_mime_types.rs
@@ -83,13 +83,8 @@ where
 
     fn call(&mut self, mut req: Request<Body>) -> Self::Future {
         // --- Request-side: Content-Type ---
-        let ct = req
-            .headers()
-            .get(header::CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_owned);
-        match ct.as_deref() {
-            Some(CONTENT_TYPE) | None => {
+        match req.headers().get(header::CONTENT_TYPE).map(|v| v.to_str()) {
+            Some(Ok(CONTENT_TYPE)) | None => {
                 req.headers_mut()
                     .insert(header::CONTENT_TYPE, APPLICATION_JSON);
             }
@@ -99,21 +94,19 @@ where
         }
 
         // --- Request-side: Accept ---
-        let accept = req
-            .headers()
-            .get(header::ACCEPT)
-            .and_then(|v| v.to_str().ok());
-        if accept == Some(CONTENT_TYPE) {
-            req.headers_mut().insert(header::ACCEPT, APPLICATION_JSON);
-        } else {
-            return Box::pin(async { Ok(StatusCode::NOT_ACCEPTABLE.into_response()) });
+        match req.headers().get(header::ACCEPT).map(|v| v.to_str()) {
+            Some(Ok(CONTENT_TYPE)) => {
+                req.headers_mut().insert(header::ACCEPT, APPLICATION_JSON);
+            }
+            _ => {
+                return Box::pin(async { Ok(StatusCode::NOT_ACCEPTABLE.into_response()) });
+            }
         }
 
         // --- Call the inner service, then set response Content-Type ---
-        let clone = self.inner.clone();
-        let mut inner = std::mem::replace(&mut self.inner, clone);
+        let inner_future = self.inner.call(req);
         Box::pin(async move {
-            let mut resp = inner.call(req).await?;
+            let mut resp = inner_future.await?;
             resp.headers_mut().insert(
                 header::CONTENT_TYPE,
                 header::HeaderValue::from_static(CONTENT_TYPE),

--- a/src/handler/custom_mime_types.rs
+++ b/src/handler/custom_mime_types.rs
@@ -1,12 +1,19 @@
-pub const CONTENT_TYPE: &str = "application/vnd.divviup+json;version=0.1";
-
-pub struct ReplaceMimeTypes;
-
+use axum::body::Body;
+use axum::http::{header, Request, Response, StatusCode};
+use axum::response::IntoResponse;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
 use trillium::{
     Conn, Handler,
     KnownHeaderName::{Accept, ContentType},
     Status::{NotAcceptable, UnsupportedMediaType},
 };
+
+pub const CONTENT_TYPE: &str = "application/vnd.divviup+json;version=0.1";
+
+pub struct ReplaceMimeTypes;
 
 #[trillium::async_trait]
 impl Handler for ReplaceMimeTypes {
@@ -29,5 +36,185 @@ impl Handler for ReplaceMimeTypes {
 
     async fn before_send(&self, conn: Conn) -> Conn {
         conn.with_response_header(ContentType, CONTENT_TYPE)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Axum / Tower equivalent of ReplaceMimeTypes
+// ---------------------------------------------------------------------------
+
+/// Tower [`Layer`] that applies [`ReplaceMimeTypesService`] to an inner service.
+///
+/// This replicates the Trillium [`ReplaceMimeTypes`] handler for Axum routes:
+/// requests with the custom content type (or no content type) have their headers
+/// normalized to `application/json`; responses get the custom content type set.
+#[cfg_attr(not(test), expect(dead_code))] // Wired onto the API sub-router in Part 7.
+#[derive(Clone, Debug)]
+pub struct ReplaceMimeTypesLayer;
+
+impl<S> Layer<S> for ReplaceMimeTypesLayer {
+    type Service = ReplaceMimeTypesService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        ReplaceMimeTypesService { inner }
+    }
+}
+
+/// Tower [`Service`] produced by [`ReplaceMimeTypesLayer`].
+#[cfg_attr(not(test), expect(dead_code))] // Constructed by ReplaceMimeTypesLayer; wired in Part 7.
+#[derive(Clone, Debug)]
+pub struct ReplaceMimeTypesService<S> {
+    inner: S,
+}
+
+impl<S> Service<Request<Body>> for ReplaceMimeTypesService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send,
+{
+    type Response = Response<Body>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        // --- Request-side: Content-Type ---
+        let ct = req
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        match ct.as_deref() {
+            Some(CONTENT_TYPE) | None => {
+                req.headers_mut().insert(
+                    header::CONTENT_TYPE,
+                    header::HeaderValue::from_static("application/json"),
+                );
+            }
+            _ => {
+                return Box::pin(async { Ok(StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response()) });
+            }
+        }
+
+        // --- Request-side: Accept ---
+        let accept = req
+            .headers()
+            .get(header::ACCEPT)
+            .and_then(|v| v.to_str().ok());
+        if accept == Some(CONTENT_TYPE) {
+            req.headers_mut().insert(
+                header::ACCEPT,
+                header::HeaderValue::from_static("application/json"),
+            );
+        } else {
+            return Box::pin(async { Ok(StatusCode::NOT_ACCEPTABLE.into_response()) });
+        }
+
+        // --- Call the inner service, then set response Content-Type ---
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        Box::pin(async move {
+            let mut resp = inner.call(req).await?;
+            resp.headers_mut().insert(
+                header::CONTENT_TYPE,
+                header::HeaderValue::from_static(CONTENT_TYPE),
+            );
+            Ok(resp)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    fn test_router() -> Router {
+        Router::new()
+            .route("/test", get(|| async { "ok" }))
+            .layer(ReplaceMimeTypesLayer)
+    }
+
+    #[tokio::test]
+    async fn accepts_custom_content_type() {
+        let resp = test_router()
+            .oneshot(
+                Request::get("/test")
+                    .header(header::CONTENT_TYPE, CONTENT_TYPE)
+                    .header(header::ACCEPT, CONTENT_TYPE)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            CONTENT_TYPE
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_missing_content_type() {
+        let resp = test_router()
+            .oneshot(
+                Request::get("/test")
+                    .header(header::ACCEPT, CONTENT_TYPE)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_content_type() {
+        let resp = test_router()
+            .oneshot(
+                Request::get("/test")
+                    .header(header::CONTENT_TYPE, "text/plain")
+                    .header(header::ACCEPT, CONTENT_TYPE)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_accept() {
+        let resp = test_router()
+            .oneshot(
+                Request::get("/test")
+                    .header(header::CONTENT_TYPE, CONTENT_TYPE)
+                    .header(header::ACCEPT, "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_accept() {
+        let resp = test_router()
+            .oneshot(
+                Request::get("/test")
+                    .header(header::CONTENT_TYPE, CONTENT_TYPE)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
     }
 }

--- a/src/handler/custom_mime_types.rs
+++ b/src/handler/custom_mime_types.rs
@@ -12,6 +12,8 @@ use trillium::{
 };
 
 pub const CONTENT_TYPE: &str = "application/vnd.divviup+json;version=0.1";
+#[cfg_attr(not(test), expect(dead_code))] // Used in ReplaceMimeTypesService; wired in Part 7.
+const APPLICATION_JSON: header::HeaderValue = header::HeaderValue::from_static("application/json");
 
 pub struct ReplaceMimeTypes;
 
@@ -88,10 +90,8 @@ where
             .map(str::to_owned);
         match ct.as_deref() {
             Some(CONTENT_TYPE) | None => {
-                req.headers_mut().insert(
-                    header::CONTENT_TYPE,
-                    header::HeaderValue::from_static("application/json"),
-                );
+                req.headers_mut()
+                    .insert(header::CONTENT_TYPE, APPLICATION_JSON);
             }
             _ => {
                 return Box::pin(async { Ok(StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response()) });
@@ -104,10 +104,7 @@ where
             .get(header::ACCEPT)
             .and_then(|v| v.to_str().ok());
         if accept == Some(CONTENT_TYPE) {
-            req.headers_mut().insert(
-                header::ACCEPT,
-                header::HeaderValue::from_static("application/json"),
-            );
+            req.headers_mut().insert(header::ACCEPT, APPLICATION_JSON);
         } else {
             return Box::pin(async { Ok(StatusCode::NOT_ACCEPTABLE.into_response()) });
         }

--- a/src/handler/error.rs
+++ b/src/handler/error.rs
@@ -1,4 +1,7 @@
 use crate::clients::ClientError;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json as AxumJson;
 use sea_orm::DbErr;
 use serde_json::json;
 use std::{backtrace::Backtrace, sync::Arc};
@@ -130,5 +133,89 @@ impl Handler for Error {
     async fn run(&self, conn: Conn) -> Conn {
         conn.with_state(self.clone())
             .with_state(Backtrace::capture())
+    }
+}
+
+/// Axum-side error-to-response conversion, mirroring the Trillium
+/// [`ErrorHandler::before_send`] logic above.
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        match self {
+            Error::AccessDenied => StatusCode::FORBIDDEN.into_response(),
+
+            Error::NotFound => StatusCode::NOT_FOUND.into_response(),
+
+            Error::Json(ApiError::UnsupportedMimeType { .. }) => {
+                StatusCode::NOT_ACCEPTABLE.into_response()
+            }
+
+            Error::Json(ApiError::ParseError { path, message }) => (
+                StatusCode::BAD_REQUEST,
+                AxumJson(json!({"path": path, "message": message})),
+            )
+                .into_response(),
+
+            Error::Validation(e) => (StatusCode::BAD_REQUEST, AxumJson(e)).into_response(),
+
+            e => {
+                log::error!("{e}");
+                if cfg!(debug_assertions) {
+                    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::response::IntoResponse;
+
+    #[test]
+    fn access_denied_is_403() {
+        let resp = Error::AccessDenied.into_response();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn not_found_is_404() {
+        let resp = Error::NotFound.into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn unsupported_mime_type_is_406() {
+        let err = Error::Json(ApiError::UnsupportedMimeType {
+            mime_type: "text/plain".into(),
+        });
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
+    }
+
+    #[test]
+    fn parse_error_is_400() {
+        let err = Error::Json(ApiError::ParseError {
+            path: ".field".into(),
+            message: "expected string".into(),
+        });
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn validation_error_is_400() {
+        let err = Error::Validation(ValidationErrors::new());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn other_error_is_500() {
+        let err = Error::String("something broke");
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/handler/session_store.rs
+++ b/src/handler/session_store.rs
@@ -9,7 +9,12 @@ use sea_orm::{
     ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
 };
 use serde_json::json;
+use std::collections::HashMap;
 use time::OffsetDateTime;
+use tower_sessions_core::{
+    session::{Id as TowerSessionId, Record},
+    session_store as tower_store,
+};
 
 #[derive(Debug, Clone)]
 pub struct SessionStore {
@@ -99,6 +104,88 @@ impl async_session::SessionStore for SessionStore {
 
     async fn clear_store(&self) -> async_session::Result {
         session::Entity::delete_many().exec(&self.db).await?;
+        Ok(())
+    }
+}
+
+/// Axum-side session store implementing [`tower_sessions_core::SessionStore`].
+///
+/// Uses the same `session` database table as the Trillium-side [`SessionStore`],
+/// but with a different session ID format (`tower-sessions` uses base64-encoded
+/// `i128` rather than `async_session`'s UUID strings). During the proxy
+/// transition period, Trillium handles all session-dependent routes; this store
+/// will be wired into the Axum session middleware when auth routes migrate in
+/// Part 6.
+#[derive(Debug, Clone)]
+pub struct TowerSessionStore {
+    db: Db,
+}
+
+impl TowerSessionStore {
+    #[expect(dead_code)] // Wired in Part 6 when session-dependent routes migrate.
+    pub fn new(db: Db) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl tower_store::SessionStore for TowerSessionStore {
+    async fn save(&self, record: &Record) -> tower_store::Result<()> {
+        let model = session::Model {
+            id: record.id.to_string(),
+            expiry: Some(record.expiry_date),
+            data: serde_json::to_value(&record.data)
+                .map_err(|e| tower_store::Error::Encode(e.to_string()))?,
+        };
+
+        session::Entity::insert(model.into_active_model())
+            .on_conflict(
+                OnConflict::column(session::Column::Id)
+                    .update_columns([session::Column::Data, session::Column::Expiry])
+                    .clone(),
+            )
+            .exec(&self.db)
+            .await
+            .map_err(|e| tower_store::Error::Backend(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn load(&self, session_id: &TowerSessionId) -> tower_store::Result<Option<Record>> {
+        let model = session::Entity::find_by_id(session_id.to_string())
+            .filter(any![
+                session::Column::Expiry.is_null(),
+                session::Column::Expiry.gt(OffsetDateTime::now_utc())
+            ])
+            .one(&self.db)
+            .await
+            .map_err(|e| tower_store::Error::Backend(e.to_string()))?;
+
+        model
+            .map(|m| {
+                let data: HashMap<String, serde_json::Value> = serde_json::from_value(m.data)
+                    .map_err(|e| tower_store::Error::Decode(e.to_string()))?;
+                let id: TowerSessionId = m.id.parse().map_err(|e: base64::DecodeSliceError| {
+                    tower_store::Error::Decode(e.to_string())
+                })?;
+                Ok(Record {
+                    id,
+                    data,
+                    expiry_date: m.expiry.unwrap_or_else(|| {
+                        // The DB allows null expiry, but tower-sessions requires a
+                        // value. Use a far-future sentinel.
+                        OffsetDateTime::now_utc() + time::Duration::weeks(52)
+                    }),
+                })
+            })
+            .transpose()
+    }
+
+    async fn delete(&self, session_id: &TowerSessionId) -> tower_store::Result<()> {
+        session::Entity::delete_by_id(session_id.to_string())
+            .exec(&self.db)
+            .await
+            .map_err(|e| tower_store::Error::Backend(e.to_string()))?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod user;
 pub use config::{Config, ConfigError, FeatureFlags};
 pub use crypter::Crypter;
 pub use db::Db;
-pub use handler::{custom_mime_types::CONTENT_TYPE, AxumAppState, DivviupApi, Error};
+pub use handler::{custom_mime_types::DIVVIUP_API_MEDIA_TYPE, AxumAppState, DivviupApi, Error};
 pub use opentelemetry;
 pub use permissions::{Permissions, PermissionsActor};
 pub use queue::Queue;


### PR DESCRIPTION
Build the Axum-side middleware stack so that migrated routes (part >=5) will behave identically to their Trillium counterparts. No routes are migrated in this change -- all existing tests pass unchanged.

- Add `IntoResponse` impl for the `Error` enum, mirroring the Trillium `ErrorHandler::before_send` status-code mapping (403, 404, 406, 400, 500).
- Add `TowerSessionStore` implementing `tower_sessions_core::SessionStore` against the same `session` database table (which will be wired in part 6 when auth routes migrate).
- Add `axum_cors_layer()` returning a `tower_http::cors::CorsLayer` matching the existing Trillium CORS behavior.
- Add `ReplaceMimeTypesLayer` / `ReplaceMimeTypesService` Tower middleware replicating the custom MIME type negotiation (wired onto the API sub-router in part 7).
- Wire compression, cache-control, and CORS layers onto the Axum router via `ServiceBuilder`.
- Add unit tests for error response mapping and MIME type middleware.