### PR TITLE
Remedy cargo deny check

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ ignore = [
     "RUSTSEC-2025-0141", # Used by async-session and trillium
     "RUSTSEC-2024-0437", # Used by trillium and old prometheus
     "RUSTSEC-2025-0134", # Used by trillium and old requwest (which has to be old b/c trillium)
+    "RUSTSEC-2026-0097", # Used by trillium and old prometheus
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,13 @@ all-features = true
 
 [advisories]
 version = 2
+ignore = [
+    # All these must be retired when we finish migrating to Axum
+    "RUSTSEC-2025-0056", # Used by console-subscriber and trillium
+    "RUSTSEC-2025-0141", # Used by async-session and trillium
+    "RUSTSEC-2024-0437", # Used by trillium and old prometheus
+    "RUSTSEC-2025-0134", # Used by trillium and old requwest (which has to be old b/c trillium)
+]
 
 [bans]
 multiple-versions = "allow"
@@ -17,7 +24,7 @@ allow-org = { github = ["divviup"] }
 
 [licenses]
 version = 2
-allow = ["MPL-2.0", "MIT", "Apache-2.0", "BSL-1.0", "BSD-2-Clause", "BSD-3-Clause", "Unicode-DFS-2016", "Unicode-3.0", "ISC", "OpenSSL", "Unlicense", "CC0-1.0"]
+allow = ["MPL-2.0", "MIT", "Apache-2.0", "BSL-1.0", "BSD-2-Clause", "BSD-3-Clause", "Zlib", "Unicode-DFS-2016", "Unicode-3.0", "ISC", "CDLA-Permissive-2.0", "Unlicense", "CC0-1.0"]
 
 [[licenses.clarify]]
 name = "ring"

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 publish = false
 default-run = "migration"
+license.workspace = true
 
 [lib]
 name = "migration"

--- a/test-support/Cargo.toml
+++ b/test-support/Cargo.toml
@@ -3,6 +3,7 @@ name = "test-support"
 version.workspace = true
 edition = "2021"
 publish = false
+license.workspace = true
 
 [dependencies]
 fastrand = "2.4.1"


### PR DESCRIPTION
- Adds Zlib and CDLA-Permissive-2.0 to the allowed licenses; we already use them in Janus
- Ignores all the Trillium RUSTSEC issues... and when I search for the last bits of trillium to remove, I'll remove these
- Applies the project license to `test-support` to make `deny` happy