### PR TITLE
Migrate from Trillium [part 4]: Axum extractors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5339,6 +5339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce8cce604865576b7751b7a6bc3058f754569a60d689328bb74c52b1d87e355b"
 dependencies = [
  "async-trait",
+ "axum-core 0.5.5",
  "base64 0.22.1",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ trillium-opentelemetry = { version = "0.10.0", default-features = false, feature
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "compression-full", "set-header"] }
-tower-sessions-core = "0.14"
+tower-sessions-core = { version = "0.14", features = ["axum-core"] }
 opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio", "logs", "metrics"] }
 opentelemetry-otlp = { version = "0.27.0", optional = true }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -4,6 +4,7 @@ pub(crate) mod assets;
 pub(crate) mod cors;
 pub(crate) mod custom_mime_types;
 pub(crate) mod error;
+pub(crate) mod extract;
 pub(crate) mod logger;
 pub(crate) mod misc;
 pub(crate) mod oauth2;
@@ -13,9 +14,9 @@ pub(crate) mod session_store;
 
 pub(crate) mod proxy;
 
-use crate::{routes, Config, Db};
+use crate::{clients::Auth0Client, routes, Config, Crypter, Db, FeatureFlags};
 
-use axum::extract::DefaultBodyLimit;
+use axum::extract::{DefaultBodyLimit, FromRef};
 use axum::http::{header, HeaderValue};
 use cors::{axum_cors_layer, cors_headers};
 use error::ErrorHandler;
@@ -58,8 +59,41 @@ fn instrument_handler(handler: impl Handler) -> impl Handler {
 /// Shared state for the Axum side of the application during migration.
 #[derive(Clone, Debug)]
 pub struct AxumAppState {
-    pub db: Db,
-    pub config: Arc<Config>,
+    pub(crate) db: Db,
+    pub(crate) config: Arc<Config>,
+    pub(crate) auth0_client: Auth0Client,
+    pub(crate) crypter: Crypter,
+    pub(crate) feature_flags: FeatureFlags,
+}
+
+impl FromRef<AxumAppState> for Db {
+    fn from_ref(state: &AxumAppState) -> Self {
+        state.db.clone()
+    }
+}
+
+impl FromRef<AxumAppState> for Arc<Config> {
+    fn from_ref(state: &AxumAppState) -> Self {
+        state.config.clone()
+    }
+}
+
+impl FromRef<AxumAppState> for Auth0Client {
+    fn from_ref(state: &AxumAppState) -> Self {
+        state.auth0_client.clone()
+    }
+}
+
+impl FromRef<AxumAppState> for Crypter {
+    fn from_ref(state: &AxumAppState) -> Self {
+        state.crypter.clone()
+    }
+}
+
+impl FromRef<AxumAppState> for FeatureFlags {
+    fn from_ref(state: &AxumAppState) -> Self {
+        state.feature_flags
+    }
 }
 
 #[derive(Handler, Debug)]
@@ -90,6 +124,9 @@ impl DivviupApi {
         let axum_state = AxumAppState {
             db: db.clone(),
             config: config.clone(),
+            auth0_client: Auth0Client::new(&config),
+            crypter: config.crypter.clone(),
+            feature_flags: config.feature_flags(),
         };
         // Middleware stack in logical order (outermost first), matching the
         // Trillium api() handler chain.

--- a/src/handler/account_bearer_token.rs
+++ b/src/handler/account_bearer_token.rs
@@ -2,6 +2,8 @@ use crate::{
     entity::{Account, ApiToken, ApiTokens},
     Db,
 };
+use axum::extract::FromRef;
+use axum::http::{header, request::Parts};
 use sea_orm::ActiveModelTrait;
 use trillium::{Conn, KnownHeaderName};
 use trillium_api::FromConn;
@@ -29,5 +31,40 @@ impl FromConn for AccountBearerToken {
         let account_bearer_token = Self { account, api_token };
         conn.insert_state(account_bearer_token.clone());
         Some(account_bearer_token)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Axum extractor — mirrors the Trillium FromConn above
+// ---------------------------------------------------------------------------
+
+impl AccountBearerToken {
+    /// Try to extract a bearer token from the request, returning `None` on
+    /// any failure (missing header, invalid token, DB miss). This is
+    /// intentionally fallible — [`PermissionsActor`](crate::PermissionsActor)
+    /// tries this first and falls back to session-based user auth.
+    pub(crate) async fn from_parts<S>(parts: &mut Parts, state: &S) -> Option<Self>
+    where
+        Db: FromRef<S>,
+        S: Send + Sync,
+    {
+        // Cache: return early if already extracted for this request.
+        if let Some(token) = parts.extensions.get::<Self>() {
+            return Some(token.clone());
+        }
+
+        let bearer = parts
+            .headers
+            .get(header::AUTHORIZATION)?
+            .to_str()
+            .ok()?
+            .strip_prefix("Bearer ")?;
+
+        let db = Db::from_ref(state);
+        let (api_token, account) = ApiTokens::load_and_check(bearer, &db).await?;
+        let api_token = api_token.mark_last_used().update(&db).await.ok()?;
+        let result = Self { account, api_token };
+        parts.extensions.insert(result.clone());
+        Some(result)
     }
 }

--- a/src/handler/account_bearer_token.rs
+++ b/src/handler/account_bearer_token.rs
@@ -34,10 +34,6 @@ impl FromConn for AccountBearerToken {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Axum extractor — mirrors the Trillium FromConn above
-// ---------------------------------------------------------------------------
-
 impl AccountBearerToken {
     /// Try to extract a bearer token from the request, returning `None` on
     /// any failure (missing header, invalid token, DB miss). This is

--- a/src/handler/extract.rs
+++ b/src/handler/extract.rs
@@ -1,0 +1,67 @@
+/// Shared helper for Axum entity extractors.
+///
+/// Each "entity extractor" (Account, Task, Aggregator, ApiToken,
+/// CollectorCredential) follows the same pattern:
+///
+///  1. Extract path parameter by name → parse as UUID
+///  2. Extract [`PermissionsActor`] (bearer token **or** session user)
+///  3. Look the entity up by primary key
+///  4. Check permissions via [`Permissions`] trait
+///
+/// [`extract_entity`] captures this pattern as a single generic async
+/// function, and the per-type [`FromRequestParts`] impls become one-liners.
+use std::collections::HashMap;
+
+use axum::extract::{FromRef, FromRequestParts, Path};
+use axum::http::request::Parts;
+use sea_orm::EntityTrait;
+use uuid::Uuid;
+
+use crate::{handler::Error, Db, Permissions, PermissionsActor};
+
+/// Look up an entity by a named path parameter, check permissions, and
+/// return it — or an appropriate [`Error`].
+///
+/// `E` is the Sea-ORM **Entity** type (e.g. `Accounts`). Its `Model` must
+/// implement [`Permissions`] and [`Clone`].
+///
+/// **Note**: This always requires a valid [`PermissionsActor`], so it cannot
+/// be used for truly public (unauthenticated) entity endpoints. If such a
+/// route is needed in the future, extract the entity and check permissions
+/// separately.
+///
+/// # Errors
+///
+/// * [`Error::NotFound`] — path param missing / unparseable, or no DB row
+/// * [`Error::AccessDenied`] — actor lacks permission for the HTTP method
+/// * Propagates DB errors and [`PermissionsActor`] extraction failures
+pub async fn extract_entity<E, S>(
+    parts: &mut Parts,
+    state: &S,
+    param_name: &str,
+) -> Result<E::Model, Error>
+where
+    E: EntityTrait,
+    <E::PrimaryKey as sea_orm::PrimaryKeyTrait>::ValueType: From<Uuid>,
+    E::Model: Permissions + Clone,
+    Db: FromRef<S>,
+    S: Send + Sync,
+{
+    let Path(params) = Path::<HashMap<String, String>>::from_request_parts(parts, state)
+        .await
+        .map_err(|_| Error::NotFound)?;
+
+    let id = params
+        .get(param_name)
+        .and_then(|s| s.parse::<Uuid>().ok())
+        .ok_or(Error::NotFound)?;
+
+    let actor = PermissionsActor::from_request_parts(parts, state).await?;
+    let db = Db::from_ref(state);
+
+    let entity = E::find_by_id(id).one(&db).await?.ok_or(Error::NotFound)?;
+
+    actor
+        .if_allowed_http(&parts.method, entity)
+        .ok_or(Error::AccessDenied)
+}

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,4 +1,10 @@
-use crate::{entity::Membership, handler::account_bearer_token::AccountBearerToken, Db, User};
+use crate::{
+    entity::Membership,
+    handler::{account_bearer_token::AccountBearerToken, Error},
+    Db, User,
+};
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::{self, request::Parts};
 use trillium::Conn;
 use trillium_api::FromConn;
 
@@ -16,16 +22,34 @@ impl PermissionsActor {
         }
     }
 
-    pub fn is_allowed<T: Permissions>(&self, method: trillium::Method, t: &T) -> bool {
-        if method.is_safe() {
+    fn check_permission<T: Permissions>(&self, is_safe: bool, t: &T) -> bool {
+        if is_safe {
             t.allow_read(self)
         } else {
             t.allow_write(self)
         }
     }
 
+    pub fn is_allowed<T: Permissions>(&self, method: trillium::Method, t: &T) -> bool {
+        self.check_permission(method.is_safe(), t)
+    }
+
     pub fn if_allowed<T: Permissions>(&self, method: trillium::Method, t: T) -> Option<T> {
         if self.is_allowed(method, &t) {
+            Some(t)
+        } else {
+            None
+        }
+    }
+
+    /// Axum-side equivalent of [`is_allowed`](Self::is_allowed).
+    pub fn is_allowed_http<T: Permissions>(&self, method: &http::Method, t: &T) -> bool {
+        self.check_permission(method.is_safe(), t)
+    }
+
+    /// Axum-side equivalent of [`if_allowed`](Self::if_allowed).
+    pub fn if_allowed_http<T: Permissions>(&self, method: &http::Method, t: T) -> Option<T> {
+        if self.is_allowed_http(method, &t) {
             Some(t)
         } else {
             None
@@ -73,6 +97,45 @@ impl FromConn for PermissionsActor {
         }
 
         actor
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Axum extractor — mirrors the Trillium FromConn above
+// ---------------------------------------------------------------------------
+
+impl<S> FromRequestParts<S> for PermissionsActor
+where
+    Db: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Error> {
+        // Cache: return early if already extracted for this request.
+        if let Some(actor) = parts.extensions.get::<Self>() {
+            return Ok(actor.clone());
+        }
+
+        let abt = AccountBearerToken::from_parts(parts, state).await;
+        let user_result = User::from_parts(parts, state).await;
+
+        // Match the Trillium behavior: if both a bearer token and a session
+        // user are present, reject the request. A request should authenticate
+        // via exactly one mechanism.
+        let actor = match (abt, user_result) {
+            (Some(abt), Err(_)) => Self::ApiToken(abt),
+            (None, Ok(user)) => {
+                let db = Db::from_ref(state);
+                let memberships = user.memberships().all(&db).await.map_err(Error::from)?;
+                Self::User(user, memberships)
+            }
+            // Both present, or neither present.
+            _ => return Err(Error::AccessDenied),
+        };
+
+        parts.extensions.insert(actor.clone());
+        Ok(actor)
     }
 }
 

--- a/src/routes/accounts.rs
+++ b/src/routes/accounts.rs
@@ -1,8 +1,10 @@
 use crate::{
     entity::{Account, Accounts, CreateMembership, NewAccount, UpdateAccount},
-    handler::Error,
+    handler::{extract::extract_entity, Error},
     Db, Permissions, PermissionsActor,
 };
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
 use sea_orm::{ActiveModelTrait, EntityTrait, TransactionTrait};
 use trillium::{async_trait, Conn, Handler, Status};
 use trillium_api::{FromConn, Json};
@@ -30,6 +32,17 @@ impl FromConn for Account {
                 None
             }
         }
+    }
+}
+
+impl<S> FromRequestParts<S> for Account
+where
+    Db: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Error> {
+        extract_entity::<Accounts, S>(parts, state, "account_id").await
     }
 }
 

--- a/src/routes/aggregators.rs
+++ b/src/routes/aggregators.rs
@@ -1,8 +1,11 @@
 use crate::{
     config::FeatureFlags,
     entity::{Account, Aggregator, AggregatorColumn, Aggregators, NewAggregator, UpdateAggregator},
+    handler::extract::extract_entity,
     Db, Error, Permissions, PermissionsActor,
 };
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
 use sea_orm::{
     sea_query::{all, any},
     ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter,
@@ -28,6 +31,17 @@ impl FromConn for Aggregator {
                 None
             }
         }
+    }
+}
+
+impl<S> FromRequestParts<S> for Aggregator
+where
+    Db: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Error> {
+        extract_entity::<Aggregators, S>(parts, state, "aggregator_id").await
     }
 }
 

--- a/src/routes/api_tokens.rs
+++ b/src/routes/api_tokens.rs
@@ -1,7 +1,10 @@
 use crate::{
     entity::{Account, ApiToken, ApiTokenColumn, ApiTokens, UpdateApiToken},
+    handler::extract::extract_entity,
     Db, Error, Permissions, PermissionsActor,
 };
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, QueryFilter, QueryOrder};
 use trillium::{Conn, Handler, Status};
 use trillium_api::{FromConn, Json};
@@ -33,6 +36,17 @@ impl FromConn for ApiToken {
                 None
             }
         }
+    }
+}
+
+impl<S> FromRequestParts<S> for ApiToken
+where
+    Db: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Error> {
+        extract_entity::<ApiTokens, S>(parts, state, "api_token_id").await
     }
 }
 

--- a/src/routes/collector_credentials.rs
+++ b/src/routes/collector_credentials.rs
@@ -3,8 +3,11 @@ use crate::{
         Account, CollectorCredential, CollectorCredentialColumn, CollectorCredentials,
         NewCollectorCredential, UpdateCollectorCredential,
     },
+    handler::extract::extract_entity,
     Db, Error, Permissions, PermissionsActor,
 };
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, QueryFilter};
 use trillium::{Conn, Handler, Status};
 use trillium_api::{FromConn, Json};
@@ -39,6 +42,17 @@ impl FromConn for CollectorCredential {
                 None
             }
         }
+    }
+}
+
+impl<S> FromRequestParts<S> for CollectorCredential
+where
+    Db: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Error> {
+        extract_entity::<CollectorCredentials, S>(parts, state, "collector_credential_id").await
     }
 }
 

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -2,8 +2,11 @@ use crate::{
     clients::aggregator_client::{api_types::TaskAggregationJobMetrics, TaskUploadMetrics},
     config::FeatureFlags,
     entity::{Account, NewTask, Task, TaskColumn, Tasks, UpdateTask},
+    handler::extract::extract_entity,
     Crypter, Db, Error, Permissions, PermissionsActor,
 };
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
 use querystrong::QueryStrong;
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, IntoActiveModel, ModelTrait,
@@ -50,6 +53,17 @@ impl FromConn for Task {
                 None
             }
         }
+    }
+}
+
+impl<S> FromRequestParts<S> for Task
+where
+    Db: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Error> {
+        extract_entity::<Tasks, S>(parts, state, "task_id").await
     }
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,12 +1,16 @@
 use crate::{
     entity::{AccountColumn, Accounts, MembershipColumn, Memberships},
+    handler::Error,
     Db,
 };
+use axum::extract::FromRef;
+use axum::http::request::Parts;
 use sea_orm::{
     sea_query::all, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QuerySelect, Select,
 };
 use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
+use tower_sessions_core::Session;
 use trillium::{async_trait, Conn};
 use trillium_api::FromConn;
 use trillium_sessions::SessionConnExt;
@@ -79,5 +83,46 @@ impl FromConn for User {
         user.populate_admin(db).await;
         conn.insert_state(user.clone());
         Some(user)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Axum extractor — mirrors the Trillium FromConn above
+// ---------------------------------------------------------------------------
+//
+// Dead until Part 6 wires SessionManagerLayer onto the Axum router.
+// The tower-sessions Session is placed in request extensions by that layer;
+// without it, extraction will fail at runtime (which is fine — nothing calls
+// this until Part 6).
+
+impl User {
+    pub(crate) async fn from_parts<S>(parts: &mut Parts, state: &S) -> Result<Self, Error>
+    where
+        Db: FromRef<S>,
+        S: Send + Sync,
+    {
+        // Cache: return early if already extracted for this request.
+        if let Some(user) = parts.extensions.get::<Self>() {
+            return Ok(user.clone());
+        }
+
+        let session = parts
+            .extensions
+            .get::<Session>()
+            .ok_or(Error::AccessDenied)?;
+
+        let mut user: Self = session
+            .get(USER_SESSION_KEY)
+            .await
+            .map_err(|e| {
+                log::error!("session store error: {e}");
+                Error::String("session store error")
+            })?
+            .ok_or(Error::AccessDenied)?;
+
+        let db = Db::from_ref(state);
+        user.populate_admin(&db).await;
+        parts.extensions.insert(user.clone());
+        Ok(user)
     }
 }


### PR DESCRIPTION
Add `FromRequestParts` impls alongside every existing `FromConn` impl so that Axum handlers (migrated in Parts 5-7) can extract the same types. Both impls coexist on the same types; no routes migrate in this PR.

Added extractors:
- Db, Auth0Client, Crypter, FeatureFlags: via `FromRef<AxumAppState>`
- AccountBearerToken: from `Authorization: Bearer` header + DB lookup, cached in request extensions
- User: from tower-sessions Session (n.b. this is dead until Part 6 wires up `SessionManagerLayer`)
- PermissionsActor: tries bearer token, falls back to session user + memberships query, cached in request extensions
- Account, Task, Aggregator, ApiToken, CollectorCredential: via a shared `extract_entity` helper that generically handles path param parsing, DB lookup, and permission checking

Other changes:
- Expand AxumAppState with auth0_client, crypter, feature_flags fields
- Add `is_allowed_http`/`if_allowed_http` methods on PermissionsActor for `http::Method` (this is refactored to share logic with the Trillium variants via `check_permission`)
- Enable `axum-core` feature on tower-sessions-core for Session's  `FromRequestParts` impl