### PR TITLE
Migrate from Trillium [part 5]: health check endpoint

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -145,11 +145,12 @@ impl DivviupApi {
 
         let axum_router = axum::Router::new()
             // Temporary test endpoint to verify the proxy bridge works.
-            // TODO: Remove once a real endpoint has been migrated.
+            // TODO: Remove once enough routes have migrated to make it redundant.
             .route(
                 "/internal/test/axum_ready",
                 axum::routing::get(|| async { "axum OK" }),
             )
+            .route("/health", axum::routing::get(routes::health_check))
             .layer(middleware)
             .with_state(axum_state);
         let axum_listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0))
@@ -171,7 +172,6 @@ impl DivviupApi {
         Self {
             handler: Box::new((
                 conn_id(),
-                routes::health_check(&db),
                 Forwarding::trust_always(),
                 opentelemetry(),
                 caching_headers(),

--- a/src/routes/health_check.rs
+++ b/src/routes/health_check.rs
@@ -1,22 +1,10 @@
 use crate::Db;
+use axum::{extract::State, http::StatusCode};
 use sea_orm::ConnectionTrait;
-use trillium::{async_trait, Conn, Handler, Status};
 
-struct HealthCheck(Db);
-
-#[async_trait]
-impl Handler for HealthCheck {
-    async fn run(&self, conn: Conn) -> Conn {
-        if conn.path() != "/health" {
-            return conn;
-        }
-        if self.0.execute_unprepared("select 1").await.is_err() {
-            return conn.halt().with_status(500);
-        }
-        conn.halt().with_status(Status::Ok)
+pub async fn health_check(State(db): State<Db>) -> StatusCode {
+    if db.execute_unprepared("select 1").await.is_err() {
+        return StatusCode::INTERNAL_SERVER_ERROR;
     }
-}
-
-pub fn health_check(db: &Db) -> impl Handler {
-    HealthCheck(db.clone())
+    StatusCode::OK
 }

--- a/tests/integration/axum_proxy.rs
+++ b/tests/integration/axum_proxy.rs
@@ -11,10 +11,10 @@ async fn axum_proxy_bridge(app: DivviupApi) -> TestResult {
     Ok(())
 }
 
-/// Verify that a route handled by Trillium (health check) is served
-/// directly and not double-forwarded through the proxy to Axum.
+/// Verify that `/health` — the first real route migrated to Axum — is
+/// reached via the Trillium → proxy → Axum path.
 #[test(harness = set_up)]
-async fn trillium_route_not_proxied(app: DivviupApi) -> TestResult {
+async fn axum_proxies_health(app: DivviupApi) -> TestResult {
     let conn = get("/health").with_api_host().run_async(&app).await;
     assert_eq!(conn.status().unwrap(), Status::Ok);
     Ok(())


### PR DESCRIPTION
First real route migrated to Axum- `/health` is removed from the Trillium handler chain and served by an Axum handler that extracts `State<Db>`, and runs the DB check.

Requests enter through the Trillium listener, fall through to the proxy, and reach the Axum handler -- proving the proxy path end-to-end.