### PR TITLE
Migrate from Trillium [part 10]: OTel 0.32 upgrade, OTLP metrics, HTTP metrics middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,38 +328,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
-dependencies = [
- "async-trait",
- "axum-core 0.4.3",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 1.0.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core 0.5.5",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -369,7 +342,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -378,32 +351,12 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 0.1.2",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -419,7 +372,7 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -778,9 +731,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
 dependencies = [
  "futures-core",
- "prost 0.14.1",
+ "prost",
  "prost-types",
- "tonic 0.14.2",
+ "tonic",
  "tonic-prost",
  "tracing-core",
 ]
@@ -798,14 +751,14 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost 0.14.1",
+ "prost",
  "prost-types",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -1114,7 +1067,7 @@ dependencies = [
  "aes-gcm",
  "async-lock",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "base64 0.22.1",
  "console-subscriber",
  "cookie",
@@ -1129,15 +1082,13 @@ dependencies = [
  "oauth2",
  "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-prometheus",
  "opentelemetry_sdk",
  "prio",
- "prometheus",
  "querystrong",
  "rand 0.8.5",
  "rcgen",
  "regex",
- "reqwest",
+ "reqwest 0.12.15",
  "rustc_version",
  "rustls",
  "rustls-webpki",
@@ -1153,7 +1104,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-sessions",
  "tracing",
@@ -1186,7 +1137,7 @@ dependencies = [
  "janus_messages",
  "prio",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1200,7 +1151,7 @@ dependencies = [
 name = "divviup-client"
 version = "0.5.0-pre.1"
 dependencies = [
- "axum 0.8.9",
+ "axum",
  "base64 0.22.1",
  "divviup-api",
  "divviup-client",
@@ -1214,7 +1165,7 @@ dependencies = [
  "num-rational",
  "pad-adapter",
  "prio",
- "reqwest",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "test-support",
@@ -1676,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1686,7 +1637,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.2.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1872,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1909,13 +1860,14 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1961,18 +1913,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2148,16 +2104,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
@@ -2209,15 +2155,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2240,12 +2177,12 @@ dependencies = [
  "backoff",
  "educe",
  "http",
- "itertools 0.14.0",
+ "itertools",
  "janus_core",
  "janus_messages",
  "prio",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.15",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2266,7 +2203,7 @@ dependencies = [
  "janus_messages",
  "prio",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.15",
  "retry-after",
  "serde",
  "serde_json",
@@ -2299,7 +2236,7 @@ dependencies = [
  "prio",
  "rand 0.8.5",
  "regex",
- "reqwest",
+ "reqwest 0.12.15",
  "serde",
  "serde_yaml",
  "thiserror 2.0.18",
@@ -2473,12 +2410,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -2718,7 +2649,7 @@ dependencies = [
  "getrandom 0.2.16",
  "http",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2756,82 +2687,74 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.13.3",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "async-trait",
- "futures-core",
  "http",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.13.1",
- "thiserror 1.0.69",
- "tokio",
- "tonic 0.12.3",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry-prometheus"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b834e966ea5e2d03dfe5f2253f03d22cce21403ee940265070eeee96cee0bcc"
-dependencies = [
- "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
- "prometheus",
- "protobuf",
- "tracing",
+ "prost",
+ "reqwest 0.13.3",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.1",
- "tonic 0.12.3",
+ "prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
- "serde_json",
- "thiserror 1.0.69",
+ "portable-atomic",
+ "rand 0.9.0",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -3200,51 +3123,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
-dependencies = [
- "bytes",
- "prost-derive 0.13.1",
-]
-
-[[package]]
 name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
- "prost-derive 0.14.1",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
-dependencies = [
- "anyhow",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3254,7 +3139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3266,14 +3151,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
- "prost 0.14.1",
+ "prost",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"
@@ -3523,10 +3402,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower 0.5.3",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3534,6 +3413,37 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3983,7 +3893,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.1",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -4178,7 +4088,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.2.1",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -4448,12 +4358,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4494,7 +4398,7 @@ name = "test-support"
 version = "0.5.0-pre.1"
 dependencies = [
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "divviup-api",
@@ -4503,7 +4407,7 @@ dependencies = [
  "pretty_assertions",
  "querystrong",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.15",
  "sea-orm",
  "serde",
  "serde_json",
@@ -4512,7 +4416,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -4705,39 +4609,9 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.2.1",
+ "indexmap",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.7.5",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.1",
- "socket2 0.5.5",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4747,7 +4621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -4760,10 +4634,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "socket2 0.6.3",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4776,28 +4650,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
- "prost 0.14.1",
- "tonic 0.14.2",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -4808,10 +4662,10 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.2.1",
+ "indexmap",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -4825,7 +4679,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151b5a3e3c45df17466454bb74e9ecedecc955269bdedbf4d150dfa393b55a36"
 dependencies = [
- "axum-core 0.5.5",
+ "axum-core",
  "cookie",
  "futures-util",
  "http",
@@ -4857,9 +4711,11 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4899,7 +4755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568531ec3dfcf3ffe493de1958ae5662a0284ac5d767476ecdb6a34ff8c6b06c"
 dependencies = [
  "async-trait",
- "axum-core 0.5.5",
+ "axum-core",
  "base64 0.22.1",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-run = "divviup_api_bin"
 [features]
 default = []
 integration-testing = []
-otlp-trace = ["opentelemetry/trace", "opentelemetry_sdk/trace"]
+otlp-trace = ["opentelemetry/trace", "opentelemetry_sdk/trace", "opentelemetry-otlp/trace"]
 
 [dependencies]
 aes-gcm = "0.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-run = "divviup_api_bin"
 [features]
 default = []
 integration-testing = []
-otlp-trace = ["opentelemetry/trace", "opentelemetry-otlp", "opentelemetry_sdk/trace"]
+otlp-trace = ["opentelemetry/trace", "opentelemetry_sdk/trace"]
 
 [dependencies]
 aes-gcm = "0.10.3"
@@ -46,10 +46,8 @@ git-version = "0.3.9"
 httpdate = "1.0.3"
 janus_messages = "0.7.96"
 log = "0.4.27"
-opentelemetry = { version = "0.27.1", features = ["metrics", "logs"] }
-opentelemetry-prometheus = { version = "0.27.0", features = ["prometheus-encoding"] }
+opentelemetry = { version = "0.32.0", features = ["metrics", "logs"] }
 prio = "0.16.7"
-prometheus = "0.13.4"
 querystrong = "0.4.0"
 rand = "0.8.5"
 # This crate does not actually need to depend on rustls-webpki directly, but we need to make sure the feature "std" is enabled. See Janus issue #3744.
@@ -82,8 +80,8 @@ rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] 
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "compression-full", "set-header", "fs"] }
 tower-sessions = { version = "0.15", features = ["axum-core", "signed"] }
-opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio", "logs", "metrics"] }
-opentelemetry-otlp = { version = "0.27.0", optional = true }
+opentelemetry_sdk = { version = "0.32.0", features = ["rt-tokio", "logs", "metrics"] }
+opentelemetry-otlp = { version = "0.32.0", features = ["metrics", "http-proto", "reqwest-client"] }
 
 [dependencies.oauth2]
 version = "5.0.0"

--- a/deny.toml
+++ b/deny.toml
@@ -6,9 +6,7 @@ all-features = true
 version = 2
 ignore = [
     "RUSTSEC-2025-0056", # Used by console-subscriber
-    "RUSTSEC-2024-0437", # protobuf 2.28.0 via opentelemetry-prometheus → prometheus
     "RUSTSEC-2025-0134", # rustls-pemfile 2.2.0 via reqwest
-    "RUSTSEC-2026-0097", # rand 0.8.5 via prometheus
 ]
 
 [bans]

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,7 +1,6 @@
 use divviup_api::{
     handler::build_app, telemetry, trace, trace::install_trace_subscriber, Config, Queue,
 };
-use prometheus::Registry;
 use rustls::crypto::aws_lc_rs;
 use std::sync::Arc;
 use tokio::{
@@ -15,14 +14,7 @@ use tokio_util::sync::CancellationToken;
 
 #[derive(Clone, Debug)]
 struct MonitoringState {
-    registry: Registry,
     trace_reload_handle: Arc<trace::TraceReloadHandle>,
-}
-
-impl axum::extract::FromRef<MonitoringState> for Registry {
-    fn from_ref(state: &MonitoringState) -> Self {
-        state.registry.clone()
-    }
 }
 
 impl axum::extract::FromRef<MonitoringState> for Arc<trace::TraceReloadHandle> {
@@ -49,14 +41,14 @@ async fn main() {
     let (_guards, trace_reload_handle) = install_trace_subscriber(&config.trace_config()).unwrap();
     let cancel = CancellationToken::new();
 
-    // Monitoring server (metrics + traceconfig)
-    let registry = telemetry::install_metrics().expect("failed to install metrics provider");
+    // Telemetry providers (OTLP push — endpoint via OTEL_EXPORTER_OTLP_ENDPOINT)
+    let telemetry = telemetry::install_telemetry().expect("failed to install telemetry providers");
+
+    // Monitoring server (traceconfig)
     let monitoring_state = MonitoringState {
-        registry,
         trace_reload_handle: Arc::new(trace_reload_handle),
     };
     let monitoring_router = axum::Router::new()
-        .route("/metrics", axum::routing::get(telemetry::metrics_handler))
         .route(
             "/traceconfig",
             axum::routing::get(trace::get_traceconfig).put(trace::put_traceconfig),
@@ -105,6 +97,11 @@ async fn main() {
     }
 
     let _ = monitoring_handle.await;
+
+    // Shut down telemetry providers last so in-flight spans and metrics from
+    // the servers and queue workers are flushed before the OTLP exporters are
+    // dropped. Traces are flushed before metrics.
+    telemetry.shutdown();
 }
 
 async fn shutdown_signal(cancel: CancellationToken) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,7 @@ pub struct Config {
     pub postmark_url: Url,
     /// The address to listen on for the main HTTP server.
     pub listen_address: SocketAddr,
-    /// The address to listen on for prometheus metrics and tracing configuration.
+    /// The address to listen on for the monitoring server (tracing configuration).
     pub monitoring_listen_address: SocketAddr,
     /// Comma-joined unpadded base64url encoded cryptographically random secrets, 32 bytes long
     /// after decoding. The first one is used for new sessions.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -116,7 +116,7 @@ pub async fn build_app(config: Config) -> BuiltApp {
 
     let middleware = ServiceBuilder::new()
         .layer(axum::middleware::from_fn_with_state(
-            HttpMetrics::new(),
+            HttpMetrics::new(), // instruments are registered once here, then cloned per request
             http_metrics::http_metrics_middleware,
         ))
         .layer(
@@ -126,15 +126,18 @@ pub async fn build_app(config: Config) -> BuiltApp {
                     .get("x-forwarded-for")
                     .and_then(|v| v.to_str().ok())
                     .and_then(|s| s.rsplit(',').next())
-                    .map(str::trim)
-                    .unwrap_or("");
-                tracing::debug_span!(
+                    .map(str::trim);
+                let span = tracing::debug_span!(
                     "request",
                     method = %request.method(),
                     uri = %request.uri(),
                     version = ?request.version(),
-                    client.address = client_ip,
-                )
+                    client.address = tracing::field::Empty,
+                );
+                if let Some(ip) = client_ip {
+                    span.record("client.address", ip);
+                }
+                span
             }),
         )
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_SIZE))

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -5,6 +5,7 @@ pub(crate) mod cors;
 pub(crate) mod custom_mime_types;
 pub(crate) mod error;
 pub(crate) mod extract;
+pub(crate) mod http_metrics;
 pub(crate) mod oauth2;
 pub(crate) mod session_store;
 
@@ -14,11 +15,13 @@ use crate::{
     Config, Crypter, Db, FeatureFlags,
 };
 use axum::{
+    body::Body,
     extract::{DefaultBodyLimit, FromRef},
-    http::{header, HeaderValue},
+    http::{header, HeaderValue, Request},
     routing,
 };
 use cors::axum_cors_layer;
+use http_metrics::HttpMetrics;
 use oauth2::OauthClient;
 use session_store::axum_session_layer;
 use std::sync::Arc;
@@ -111,16 +114,29 @@ pub async fn build_app(config: Config) -> BuiltApp {
         client: config.client.clone(),
     };
 
-    // TODO(Part 10): add OpenTelemetry HTTP metrics middleware. The deleted
-    // trillium-opentelemetry handler provided http.server.* histograms and
-    // optional OTLP per-request spans; TraceLayer only emits tracing events.
-    //
-    // TODO(Part 10): restore X-Forwarded-For / Forwarded header propagation.
-    // The deleted trillium-forwarding::Forwarding::trust_always() updated the
-    // peer IP from proxy headers so trace spans logged the client IP. Without
-    // it, TraceLayer records the proxy/load-balancer IP instead.
     let middleware = ServiceBuilder::new()
-        .layer(TraceLayer::new_for_http())
+        .layer(axum::middleware::from_fn_with_state(
+            HttpMetrics::new(),
+            http_metrics::http_metrics_middleware,
+        ))
+        .layer(
+            TraceLayer::new_for_http().make_span_with(|request: &Request<Body>| {
+                let client_ip = request
+                    .headers()
+                    .get("x-forwarded-for")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.rsplit(',').next())
+                    .map(str::trim)
+                    .unwrap_or("");
+                tracing::debug_span!(
+                    "request",
+                    method = %request.method(),
+                    uri = %request.uri(),
+                    version = ?request.version(),
+                    client.address = client_ip,
+                )
+            }),
+        )
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_SIZE))
         .layer(CompressionLayer::new())
         .layer(SetResponseHeaderLayer::if_not_present(

--- a/src/handler/http_metrics.rs
+++ b/src/handler/http_metrics.rs
@@ -60,8 +60,7 @@ impl HttpMetrics {
                 .with_unit("s")
                 .with_description("Duration of HTTP server requests")
                 .with_boundaries(vec![
-                    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0,
-                    7.5, 10.0,
+                    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
                 ])
                 .build(),
             active_requests: meter
@@ -98,10 +97,7 @@ pub async fn http_metrics_middleware(
     let duration = start.elapsed().as_secs_f64();
 
     let status_code = response.status();
-    let status = KeyValue::new(
-        "http.response.status_code",
-        i64::from(status_code.as_u16()),
-    );
+    let status = KeyValue::new("http.response.status_code", i64::from(status_code.as_u16()));
     let mut duration_attrs = vec![method_attr, scheme_attr, status];
     if status_code.is_server_error() || status_code.is_client_error() {
         duration_attrs.push(KeyValue::new(

--- a/src/handler/http_metrics.rs
+++ b/src/handler/http_metrics.rs
@@ -59,6 +59,10 @@ impl HttpMetrics {
                 .f64_histogram("http.server.request.duration")
                 .with_unit("s")
                 .with_description("Duration of HTTP server requests")
+                .with_boundaries(vec![
+                    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0,
+                    7.5, 10.0,
+                ])
                 .build(),
             active_requests: meter
                 .i64_up_down_counter("http.server.active_requests")
@@ -93,11 +97,18 @@ pub async fn http_metrics_middleware(
     let response = next.run(request).await;
     let duration = start.elapsed().as_secs_f64();
 
+    let status_code = response.status();
     let status = KeyValue::new(
         "http.response.status_code",
-        i64::from(response.status().as_u16()),
+        i64::from(status_code.as_u16()),
     );
     let mut duration_attrs = vec![method_attr, scheme_attr, status];
+    if status_code.is_server_error() || status_code.is_client_error() {
+        duration_attrs.push(KeyValue::new(
+            "error.type",
+            status_code.as_u16().to_string(),
+        ));
+    }
     if let Some(route) = route {
         duration_attrs.push(KeyValue::new("http.route", route));
     }

--- a/src/handler/http_metrics.rs
+++ b/src/handler/http_metrics.rs
@@ -82,10 +82,7 @@ pub async fn http_metrics_middleware(
     let method_attr = KeyValue::new("http.request.method", method.to_owned());
     let scheme_attr = KeyValue::new("url.scheme", scheme.to_owned());
 
-    let mut active_attrs = vec![method_attr.clone(), scheme_attr.clone()];
-    if let Some(ref route) = route {
-        active_attrs.push(KeyValue::new("http.route", route.clone()));
-    }
+    let active_attrs = [method_attr.clone(), scheme_attr.clone()];
     metrics.active_requests.add(1, &active_attrs);
     let _guard = ActiveGuard {
         counter: &metrics.active_requests,

--- a/src/handler/http_metrics.rs
+++ b/src/handler/http_metrics.rs
@@ -1,0 +1,110 @@
+use axum::{
+    extract::{MatchedPath, Request, State},
+    middleware::Next,
+    response::IntoResponse,
+};
+use opentelemetry::{
+    global,
+    metrics::{Histogram, UpDownCounter},
+    KeyValue,
+};
+use std::time::Instant;
+
+fn normalize_method(method: &str) -> &str {
+    match method {
+        "CONNECT" | "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT" | "TRACE" => {
+            method
+        }
+        _ => "_OTHER",
+    }
+}
+
+fn request_scheme(request: &Request) -> &str {
+    request
+        .headers()
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| request.uri().scheme_str())
+        .unwrap_or("http")
+}
+
+struct ActiveGuard<'a> {
+    counter: &'a UpDownCounter<i64>,
+    attrs: &'a [KeyValue],
+}
+
+impl Drop for ActiveGuard<'_> {
+    fn drop(&mut self) {
+        self.counter.add(-1, self.attrs);
+    }
+}
+
+#[derive(Clone)]
+pub struct HttpMetrics {
+    request_duration: Histogram<f64>,
+    active_requests: UpDownCounter<i64>,
+}
+
+impl Default for HttpMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpMetrics {
+    pub fn new() -> Self {
+        let meter = global::meter("divviup-api");
+        Self {
+            request_duration: meter
+                .f64_histogram("http.server.request.duration")
+                .with_unit("s")
+                .with_description("Duration of HTTP server requests")
+                .build(),
+            active_requests: meter
+                .i64_up_down_counter("http.server.active_requests")
+                .with_unit("{request}")
+                .with_description("Number of active HTTP server requests")
+                .build(),
+        }
+    }
+}
+
+pub async fn http_metrics_middleware(
+    State(metrics): State<HttpMetrics>,
+    matched_path: Option<MatchedPath>,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    let method = normalize_method(request.method().as_str());
+    let scheme = request_scheme(&request);
+    let route = matched_path.map(|p| p.as_str().to_owned());
+
+    let method_attr = KeyValue::new("http.request.method", method.to_owned());
+    let scheme_attr = KeyValue::new("url.scheme", scheme.to_owned());
+
+    let mut active_attrs = vec![method_attr.clone(), scheme_attr.clone()];
+    if let Some(ref route) = route {
+        active_attrs.push(KeyValue::new("http.route", route.clone()));
+    }
+    metrics.active_requests.add(1, &active_attrs);
+    let _guard = ActiveGuard {
+        counter: &metrics.active_requests,
+        attrs: &active_attrs,
+    };
+
+    let start = Instant::now();
+    let response = next.run(request).await;
+    let duration = start.elapsed().as_secs_f64();
+
+    let status = KeyValue::new(
+        "http.response.status_code",
+        i64::from(response.status().as_u16()),
+    );
+    let mut duration_attrs = vec![method_attr, scheme_attr, status];
+    if let Some(route) = route {
+        duration_attrs.push(KeyValue::new("http.route", route));
+    }
+    metrics.request_duration.record(duration, &duration_attrs);
+
+    response
+}

--- a/src/handler/http_metrics.rs
+++ b/src/handler/http_metrics.rs
@@ -96,15 +96,12 @@ pub async fn http_metrics_middleware(
     let response = next.run(request).await;
     let duration = start.elapsed().as_secs_f64();
 
-    let status_code = response.status();
-    let status = KeyValue::new("http.response.status_code", i64::from(status_code.as_u16()));
+    let status = KeyValue::new(
+        "http.response.status_code",
+        i64::from(response.status().as_u16()),
+    );
     let mut duration_attrs = vec![method_attr, scheme_attr, status];
-    if status_code.is_server_error() || status_code.is_client_error() {
-        duration_attrs.push(KeyValue::new(
-            "error.type",
-            status_code.as_u16().to_string(),
-        ));
-    }
+
     if let Some(route) = route {
         duration_attrs.push(KeyValue::new("http.route", route));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ pub use db::Db;
 pub use handler::{
     build_app, custom_mime_types::DIVVIUP_API_MEDIA_TYPE, AxumAppState, BuiltApp, Error,
 };
-pub use opentelemetry;
 pub use permissions::{AdminPermissionsActor, Permissions, PermissionsActor};
 pub use queue::Queue;
 use serde::{Deserialize, Deserializer};

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,27 +1,37 @@
-use axum::{
-    extract::State,
-    http::{header, StatusCode},
-    response::IntoResponse,
-};
 use git_version::git_version;
 use opentelemetry::{global, KeyValue};
-use opentelemetry_sdk::{
-    metrics::{MetricError, SdkMeterProvider},
-    Resource,
-};
-use prometheus::{Encoder, Registry, TextEncoder};
+use opentelemetry_otlp::MetricExporter;
+use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
 
-/// Install the Prometheus metrics provider and return the [`Registry`] so it
-/// can be shared with the metrics HTTP handler.
-pub fn install_metrics() -> Result<Registry, MetricError> {
-    let registry = Registry::new();
-    let exporter = opentelemetry_prometheus::exporter()
-        .with_registry(registry.clone())
-        .build()
-        .unwrap();
+#[cfg(feature = "otlp-trace")]
+use opentelemetry_sdk::trace::SdkTracerProvider;
 
-    // Note that the implementation of `Default` pulls in attributes set via environment variables.
-    let default_resource = Resource::default();
+#[derive(Debug)]
+pub struct TelemetryProviders {
+    meter_provider: SdkMeterProvider,
+    #[cfg(feature = "otlp-trace")]
+    tracer_provider: SdkTracerProvider,
+}
+
+impl TelemetryProviders {
+    pub fn shutdown(self) {
+        #[cfg(feature = "otlp-trace")]
+        if let Err(e) = self.tracer_provider.shutdown() {
+            tracing::error!("tracer provider shutdown error: {e}");
+        }
+        if let Err(e) = self.meter_provider.shutdown() {
+            tracing::error!("meter provider shutdown error: {e}");
+        }
+    }
+}
+
+/// Install OTLP telemetry providers. Metrics (and optionally traces) are
+/// pushed to the collector endpoint configured via
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` (default `http://localhost:4318`).
+///
+/// Returns [`TelemetryProviders`] so callers can shut down gracefully.
+pub fn install_telemetry() -> Result<TelemetryProviders, Box<dyn std::error::Error>> {
+    let exporter = MetricExporter::builder().with_http().build()?;
 
     let mut git_revision: &str = git_version!(fallback = "unknown");
     if git_revision == "unknown" {
@@ -29,49 +39,43 @@ pub fn install_metrics() -> Result<Registry, MetricError> {
             git_revision = value;
         }
     }
-    let version_info_resource = Resource::new([
-        KeyValue::new("service.name", "divviup-api"),
-        KeyValue::new(
-            "service.version",
-            format!("{}-{}", env!("CARGO_PKG_VERSION"), git_revision),
-        ),
-        KeyValue::new("process.runtime.name", "Rust"),
-        KeyValue::new("process.runtime.version", env!("RUSTC_SEMVER")),
-    ]);
 
-    let resource = default_resource.merge(&version_info_resource);
+    let resource = Resource::builder()
+        .with_attributes([
+            KeyValue::new("service.name", "divviup-api"),
+            KeyValue::new(
+                "service.version",
+                format!("{}-{}", env!("CARGO_PKG_VERSION"), git_revision),
+            ),
+            KeyValue::new("process.runtime.name", "Rust"),
+            KeyValue::new("process.runtime.version", env!("RUSTC_SEMVER")),
+        ])
+        .build();
 
-    global::set_meter_provider(
-        SdkMeterProvider::builder()
-            .with_reader(exporter)
-            .with_resource(resource.clone())
-            .build(),
-    );
+    let meter_provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter)
+        .with_resource(resource.clone())
+        .build();
+
+    global::set_meter_provider(meter_provider.clone());
 
     #[cfg(feature = "otlp-trace")]
-    global::set_tracer_provider({
+    let tracer_provider = {
         use opentelemetry_otlp::SpanExporter;
-        use opentelemetry_sdk::{runtime::Tokio, trace::TracerProvider};
 
-        TracerProvider::builder()
+        let provider = SdkTracerProvider::builder()
             .with_resource(resource)
-            .with_batch_exporter(SpanExporter::builder().with_tonic().build().unwrap(), Tokio)
-            .build()
-    });
+            .with_batch_exporter(
+                SpanExporter::builder().with_http().build()?,
+            )
+            .build();
+        global::set_tracer_provider(provider.clone());
+        provider
+    };
 
-    Ok(registry)
-}
-
-/// Axum handler that serves Prometheus metrics in text format.
-pub async fn metrics_handler(
-    State(registry): State<Registry>,
-) -> Result<impl IntoResponse, (axum::http::StatusCode, String)> {
-    let encoder = TextEncoder::new();
-    let content_type = encoder.format_type().to_owned();
-    let metrics = registry.gather();
-    let mut buf = String::new();
-    encoder
-        .encode_utf8(&metrics, &mut buf)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    Ok(([(header::CONTENT_TYPE, content_type)], buf))
+    Ok(TelemetryProviders {
+        meter_provider,
+        #[cfg(feature = "otlp-trace")]
+        tracer_provider,
+    })
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -65,9 +65,7 @@ pub fn install_telemetry() -> Result<TelemetryProviders, Box<dyn std::error::Err
 
         let provider = SdkTracerProvider::builder()
             .with_resource(resource)
-            .with_batch_exporter(
-                SpanExporter::builder().with_http().build()?,
-            )
+            .with_batch_exporter(SpanExporter::builder().with_http().build()?)
             .build();
         global::set_tracer_provider(provider.clone());
         provider

--- a/test-support/src/lib.rs
+++ b/test-support/src/lib.rs
@@ -446,8 +446,7 @@ impl TestResponse {
     }
 }
 
-// These are reimplementations of the Trillium assertion macros atop Axum. In Part 10
-// we can decide whether to keep these or refactor the tests, but they're used heavily.
+// Assertion macros for Axum test responses, modeled after Trillium's test assertions.
 
 #[macro_export]
 macro_rules! assert_ok {


### PR DESCRIPTION
Upgrade the OpenTelemetry ecosystem from 0.27 to 0.32 and switch from Prometheus scrape-based metrics export to OTLP push. Prometheus 3.x in prod supports native OTLP ingestion, so the prometheus and opentelemetry-prometheus crates are removed entirely.

Changes:

- Upgrade opentelemetry, opentelemetry_sdk, and opentelemetry-otlp to 0.32. Use the new Resource::builder() and SdkMeterProvider APIs.

- Replace the Prometheus exporter with an OTLP HTTP MetricExporter using periodic push (endpoint via OTEL_EXPORTER_OTLP_ENDPOINT).

- Remove the /metrics endpoint from the monitoring server; it now only serves /traceconfig.

- Add a custom HTTP metrics middleware (src/handler/http_metrics.rs) that records http.server.request.duration and http.server.active_requests following OTel HTTP semantic conventions, including url.scheme, http.request.method (normalized to known methods or _OTHER), http.route (omitted for unmatched paths), and http.response.status_code.

- Propagate client IP into trace spans by parsing the rightmost X-Forwarded-For value in a custom TraceLayer make_span_with. This is a difference from `trillium-forwarding::Forwarding::trust_always()` that extracted the leftmost XFF entry. Given that we have only a single proxy, they arrive at the same behavior, but rightmost is generally safer since it's the directly-attached load-balancer.

- Return a TelemetryProviders struct from install_telemetry() so both the meter provider and the OTLP tracer provider (when otlp-trace is enabled) are shut down gracefully on exit.

- Remove stale RUSTSEC advisory ignores from deny.toml.