### PR TITLE
Add RUSTSEC-2026-0173 to deny ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ version = 2
 ignore = [
     "RUSTSEC-2025-0056", # Used by console-subscriber
     "RUSTSEC-2025-0134", # rustls-pemfile 2.2.0 via reqwest
+    "RUSTSEC-2026-0173", # from validator_derive and sea-bae
 ]
 
 [bans]


### PR DESCRIPTION
There's no migration I can see for us -- at present, anyway. We get this through both sea-bae and validator_derive.