### PR TITLE
Bump version to 0.5.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-api"
-version = "0.5.0-pre.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "aes-gcm 0.11.0",
  "async-lock",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-cli"
-version = "0.5.0-pre.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-client"
-version = "0.5.0-pre.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "migration"
-version = "0.5.0-pre.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "clap",
  "sea-orm",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.5.0-pre.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-run = "divviup_api_bin"
 members = [".", "cli", "client", "migration", "test-support"]
 
 [workspace.package]
-version = "0.5.0-pre.1"
+version = "0.5.0-alpha.1"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://divviup.org"
@@ -31,8 +31,8 @@ console-subscriber = "0.5.0"
 const_format = "0.2.36"
 cookie = "0.18"
 divviup-api.path = "."
-divviup-cli = { path = "./cli", version = "0.5.0-pre.1" }
-divviup-client = { path = "./client", version = "0.5.0-pre.1" }
+divviup-cli = { path = "./cli", version = "0.5.0-alpha.1" }
+divviup-client = { path = "./client", version = "0.5.0-alpha.1" }
 educe = "0.7.4"
 email_address = "0.2.9"
 env_logger = "0.11.10"


### PR DESCRIPTION
This bumps the version number to 0.5.0-alpha.1. I think cutting a pre-release and making container images will make testing it easier.

Stacked on #2368