### PR TITLE
Fix OTLP exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ httpdate.workspace = true
 janus_messages.workspace = true
 log.workspace = true
 opentelemetry = { workspace = true, features = ["metrics", "logs"] }
-opentelemetry-otlp = { workspace = true, features = ["metrics", "http-proto", "reqwest-client"] }
+opentelemetry-otlp = { workspace = true, features = ["metrics", "http-proto", "reqwest-blocking-client"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "logs", "metrics"] }
 prio.workspace = true
 querystrong.workspace = true


### PR DESCRIPTION
It appears that the feature `opentelemetry-otlp/reqwest-client` is not usable, because the SDK's periodic reader runs an async task using `futures_executor::block_on()`, while the async reqwest client needs to be run on a Tokio runtime.

See open-telemetry/opentelemetry-rust#3125.