### PR TITLE
Enable CARGO_BUILD_WARNINGS=deny in CI

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    env:
+      CARGO_BUILD_WARNINGS: deny
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,8 @@ env:
 jobs:
   build_rust:
     runs-on: ubuntu-latest
-
+    env:
+      CARGO_BUILD_WARNINGS: deny
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7.0.0


### PR DESCRIPTION
This uses the new [CARGO_BUILD_WARNINGS](https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/#cargo-support-for-denying-warnings) to fail CI if there are any warnings. (This is a bit nicer than using `RUSTFLAGS="-D warnings"` because it doesn't affect Cargo's key for cached build output reuse, and it doesn't fight with `RUSTFLAGS` set in `.cargo/config.toml`)