### PR TITLE
Bump version to 0.5.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-api"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "aes-gcm 0.11.0",
  "async-lock",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-cli"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-client"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "migration"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "clap",
  "sea-orm",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-run = "divviup_api_bin"
 members = [".", "cli", "client", "migration", "test-support"]
 
 [workspace.package]
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://divviup.org"
@@ -31,8 +31,8 @@ console-subscriber = "0.5.0"
 const_format = "0.2.36"
 cookie = "0.18"
 divviup-api.path = "."
-divviup-cli = { path = "./cli", version = "0.5.0-alpha.1" }
-divviup-client = { path = "./client", version = "0.5.0-alpha.1" }
+divviup-cli = { path = "./cli", version = "0.5.0-alpha.2" }
+divviup-client = { path = "./client", version = "0.5.0-alpha.2" }
 educe = "0.7.4"
 email_address = "0.2.9"
 env_logger = "0.11.10"


### PR DESCRIPTION
This prepares us to cut another alpha release for further testing, after having fixed the OTLP exporter.