### PR TITLE
Read asset location at runtime, copy assets to final container image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-api"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 dependencies = [
  "aes-gcm 0.11.0",
  "async-lock",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-cli"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "divviup-client"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "migration"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 dependencies = [
  "clap",
  "sea-orm",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-run = "divviup_api_bin"
 members = [".", "cli", "client", "migration", "test-support"]
 
 [workspace.package]
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://divviup.org"

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,7 @@ COPY src /src/src
 COPY test-support /src/test-support
 COPY client /src/client
 COPY cli /src/cli
-COPY --from=assets /src/app/build /src/app/build
-RUN ASSET_DIR=/src/app/build cargo build --workspace --bins --profile ${RUST_PROFILE} --features ${RUST_FEATURES}
+RUN cargo build --workspace --bins --profile ${RUST_PROFILE} --features ${RUST_FEATURES}
 # Hack: --profile=dev outputs to target/debug, so to interpolate $RUST_PROFILE in the next stage,
 # we need to create this symlink.
 RUN ln -s debug target/dev
@@ -54,4 +53,6 @@ COPY --from=builder /src/target/${RUST_PROFILE}/migration /migration
 COPY --from=builder /src/target/${RUST_PROFILE}/migrate_to /migrate_to
 COPY --from=builder /src/target/${RUST_PROFILE}/divviup_api_bin /divviup_api_bin
 COPY --from=builder /src/target/${RUST_PROFILE}/divviup /divviup
+COPY --from=assets /src/app/build /var/www
+ENV ASSET_DIR=/var/www
 ENTRYPOINT ["/divviup_api_bin"]

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,6 @@
 use rustc_version::version;
 
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(assets)");
-    if let Ok(asset_dir) = std::env::var("ASSET_DIR") {
-        println!("cargo:rustc-cfg=assets");
-        println!("cargo:rerun-if-changed={asset_dir}");
-    }
-    println!("cargo:rerun-if-env-changed=ASSET_DIR");
     let rustc_semver = version().expect("could not parse rustc version");
     println!("cargo:rustc-env=RUSTC_SEMVER={rustc_semver}");
     println!("cargo:rerun-if-env-changed=RUSTC");

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,4 @@
 pub(crate) mod account_bearer_token;
-#[cfg(assets)]
 pub(crate) mod assets;
 pub(crate) mod cors;
 pub(crate) mod custom_mime_types;
@@ -152,7 +151,6 @@ pub async fn build_app(config: Config) -> BuiltApp {
     #[cfg(feature = "integration-testing")]
     let middleware = middleware.layer(axum::middleware::from_fn(inject_integration_testing_user));
 
-    #[cfg(assets)]
     let middleware = middleware.layer(axum::middleware::from_fn_with_state(
         assets::AssetConfig::new(&config.api_url, &config.app_url),
         assets::serve_assets,

--- a/src/handler/assets.rs
+++ b/src/handler/assets.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use std::{
     convert::Infallible,
+    env,
     future::Future,
     path::{Path, PathBuf},
     pin::Pin,
@@ -14,6 +15,7 @@ use std::{
 };
 use tower::Service;
 use tower_http::services::{ServeDir, ServeFile};
+use tracing::info;
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -24,9 +26,12 @@ pub struct AssetConfig {
 }
 
 impl AssetConfig {
-    pub fn new(api_url: &Url, app_url: &Url) -> Self {
-        // TODO(#2263): move ASSET_DIR from compile-time to runtime env var
-        let asset_dir = PathBuf::from(env!("ASSET_DIR"));
+    pub fn new(api_url: &Url, app_url: &Url) -> Option<Self> {
+        let Some(asset_dir_os) = env::var_os("ASSET_DIR") else {
+            info!("environment variable ASSET_DIR is not set, only the API will be served");
+            return None;
+        };
+        let asset_dir = PathBuf::from(asset_dir_os);
         let fallback = IndexFallback::new(asset_dir.join("index.html"));
         let serve_dir = ServeDir::new(asset_dir).fallback(fallback);
         let host = app_url.host_str().expect("app_url must have a host");
@@ -34,11 +39,11 @@ impl AssetConfig {
             Some(port) => format!("{host}:{port}"),
             None => host.to_owned(),
         };
-        Self {
+        Some(Self {
             api_url: api_url.clone(),
             app_host,
             serve_dir,
-        }
+        })
     }
 }
 
@@ -90,10 +95,14 @@ fn request_host(headers: &HeaderMap) -> Option<&str> {
 /// (or `X-Forwarded-Host`) matches the configured app origin. Requests
 /// to other hosts pass through to the API routes.
 pub async fn serve_assets(
-    State(config): State<AssetConfig>,
+    State(config): State<Option<AssetConfig>>,
     request: Request,
     next: Next,
 ) -> Response {
+    let Some(config) = config else {
+        return next.run(request).await;
+    };
+
     let host_matches =
         request_host(request.headers()).is_some_and(|h| h.eq_ignore_ascii_case(&config.app_host));
 

--- a/tests/integration/assets.rs
+++ b/tests/integration/assets.rs
@@ -1,10 +1,15 @@
-#![cfg(assets)]
+use std::env;
+
 use test_support::{assert_eq, test, *};
 
 const INDEX_FILE_SNIPPET: &str = "<!DOCTYPE html>";
 
 #[test(harness = set_up)]
 async fn root_serves_index(app: DivviupApi) -> TestResult {
+    if env::var_os("ASSET_DIR").is_none() {
+        return Ok(());
+    }
+
     assert_body_contains!(
         get("/").with_app_host().run_async(&app).await,
         INDEX_FILE_SNIPPET
@@ -14,6 +19,10 @@ async fn root_serves_index(app: DivviupApi) -> TestResult {
 
 #[test(harness = set_up)]
 async fn not_found_path_serves_index(app: DivviupApi) -> TestResult {
+    if env::var_os("ASSET_DIR").is_none() {
+        return Ok(());
+    }
+
     assert_body_contains!(
         get("/this-is/some-arbitrary-path?and-it&does-not-matter")
             .with_app_host()
@@ -26,6 +35,10 @@ async fn not_found_path_serves_index(app: DivviupApi) -> TestResult {
 
 #[test(harness = set_up)]
 async fn api_path_serves_index(app: DivviupApi) -> TestResult {
+    if env::var_os("ASSET_DIR").is_none() {
+        return Ok(());
+    }
+
     assert_body_contains!(
         get("/api/users/me").with_app_host().run_async(&app).await,
         INDEX_FILE_SNIPPET
@@ -35,6 +48,10 @@ async fn api_path_serves_index(app: DivviupApi) -> TestResult {
 
 #[test(harness = set_up)]
 async fn api_url(app: DivviupApi) -> TestResult {
+    if env::var_os("ASSET_DIR").is_none() {
+        return Ok(());
+    }
+
     assert_ok!(
         get("/api_url").with_app_host().run_async(&app).await,
         "https://api.example/",
@@ -46,6 +63,10 @@ async fn api_url(app: DivviupApi) -> TestResult {
 
 #[test(harness = set_up)]
 async fn missing_asset_is_not_cached(app: DivviupApi) -> TestResult {
+    if env::var_os("ASSET_DIR").is_none() {
+        return Ok(());
+    }
+
     let resp = get("/assets/does-not-exist.js")
         .with_app_host()
         .run_async(&app)
@@ -57,6 +78,10 @@ async fn missing_asset_is_not_cached(app: DivviupApi) -> TestResult {
 
 #[test(harness = set_up)]
 async fn static_files(app: DivviupApi) -> TestResult {
+    if env::var_os("ASSET_DIR").is_none() {
+        return Ok(());
+    }
+
     let html_conn = get("/").with_app_host().run_async(&app).await;
 
     assert_ok!(&html_conn);


### PR DESCRIPTION
This closes #2263 and closes #2429. We now read the ASSET_DIR environment variable at runtime instead of during compilation. The build script logic around ASSET_DIR can now be removed, and the `ServeDir` service code is now always compiled. To handle the case where ASSET_DIR is not provided, the middleware's state is changed from `AssetConfig` to `Option<AssetConfig>`, and it always immediately calls the next handler if assets were not provided. The Dockerfile is updated to both provide ASSET_DIR at runtime instead of during compilation, and to copy the assets into the final image instead of the builder image. I updated asset-related tests so that they exit early if no assets are provided, in place of relying on conditional compilation.