### PR TITLE
Switch divviup-cli to tracing-subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,6 @@ dependencies = [
  "const_format",
  "divviup-client",
  "email_address",
- "env_logger",
  "hpke-dispatch",
  "humantime",
  "janus_client",
@@ -1501,6 +1500,9 @@ dependencies = [
  "thiserror 2.0.20",
  "time",
  "tokio",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -1633,29 +1635,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "env_filter"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -2679,30 +2658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,15 +3389,6 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ divviup-cli = { path = "./cli", version = "0.5.0" }
 divviup-client = { path = "./client", version = "0.5.0" }
 educe = "0.7.4"
 email_address = "0.2.9"
-env_logger = "0.11.10"
 fastrand = "2.3.0"
 futures-lite = "2.6.1"
 git-version = "0.3.9"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,6 @@ colored.workspace = true
 const_format.workspace = true
 divviup-client = { workspace = true }
 email_address.workspace = true
-env_logger.workspace = true
 hpke-dispatch = { workspace = true, features = ["serde"], optional = true }
 humantime.workspace = true
 janus_client.workspace = true
@@ -45,4 +44,7 @@ time = { workspace = true, features = [
     "local-offset",
 ] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing.workspace = true
+tracing-log.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "std", "fmt"] }
 url.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -36,6 +36,7 @@ use std::{
     process::ExitCode,
 };
 use tasks::TaskAction;
+use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
 pub const USER_AGENT: &str = concatcp!(
     "divviup-cli/",
     env!("CARGO_PKG_VERSION"),
@@ -193,7 +194,14 @@ impl ClientBin {
 
 #[tokio::main]
 pub async fn main() -> ExitCode {
-    env_logger::init();
+    let tracing_filter = EnvFilter::from_default_env();
+    let layer = tracing_subscriber::fmt::layer().pretty();
+    let subscriber = Registry::default().with(layer.with_filter(tracing_filter));
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("global default tracing subscriber was already set");
+
+    tracing_log::LogTracer::init().expect("global logger was already set");
+
     ClientBin::parse().run().await
 }
 


### PR DESCRIPTION
This switches `divviup-cli` from using the `log` logging facade to using `tracing` instead. Previously, we could only really get log output from reqwest.