### PR TITLE
Remove deprecated types package

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -42,7 +42,6 @@
         "@types/luxon": "^3.7.4",
         "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
-        "@types/react-bootstrap": "^1.1.0",
         "@types/react-dom": "^19.2.4",
         "@types/react-router": "^5.1.20",
         "@types/react-router-bootstrap": "^0.26.8",
@@ -1039,9 +1038,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1059,9 +1055,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1079,9 +1072,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1099,9 +1089,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1119,9 +1106,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1139,9 +1123,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2081,9 +2062,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2101,9 +2079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2121,9 +2096,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2141,9 +2113,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2161,9 +2130,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2181,9 +2147,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2562,17 +2525,6 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-bootstrap": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/react-bootstrap/-/react-bootstrap-1.1.0.tgz",
-      "integrity": "sha512-n8qsRzcODi1rGmodQQagjSddkvxBRQrU6P/Ec8pUjLuY1cYnYvIAkV4Xp/Ji78t4nhdT7kdMW/MnKEwfrUGasw==",
-      "deprecated": "This is a stub types definition. react-bootstrap provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-bootstrap": "*"
       }
     },
     "node_modules/@types/react-dom": {
@@ -6115,9 +6067,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6139,9 +6088,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6163,9 +6109,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6187,9 +6130,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/app/package.json
+++ b/app/package.json
@@ -64,7 +64,6 @@
     "@types/luxon": "^3.7.4",
     "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
-    "@types/react-bootstrap": "^1.1.0",
     "@types/react-dom": "^19.2.4",
     "@types/react-router": "^5.1.20",
     "@types/react-router-bootstrap": "^0.26.8",


### PR DESCRIPTION
This cleans up a dependency we no longer need, since the react-bootstrap package now includes types. I spotted a warning for this when running `npm install`.