### PR TITLE
Allow postinstall scripts from existing packages

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -94,6 +94,7 @@
     "tree-sitter@0.21.1": true,
     "@tree-sitter-grammars/tree-sitter-yaml@0.7.1": true,
     "core-js-pure": false,
-    "@scarf/scarf@1.4.0": true
+    "@scarf/scarf@1.4.0": true,
+    "@swc/core@1.15.46": true
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -92,6 +92,7 @@
     "tree-sitter-json@0.24.8": true,
     "tree-sitter@0.22.4": true,
     "tree-sitter@0.21.1": true,
-    "@tree-sitter-grammars/tree-sitter-yaml@0.7.1": true
+    "@tree-sitter-grammars/tree-sitter-yaml@0.7.1": true,
+    "core-js-pure": false
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -93,6 +93,7 @@
     "tree-sitter@0.22.4": true,
     "tree-sitter@0.21.1": true,
     "@tree-sitter-grammars/tree-sitter-yaml@0.7.1": true,
-    "core-js-pure": false
+    "core-js-pure": false,
+    "@scarf/scarf@1.4.0": true
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -87,5 +87,11 @@
     "transformIgnorePatterns": [
       "node_modules/(?!@axios)/"
     ]
+  },
+  "allowScripts": {
+    "tree-sitter-json@0.24.8": true,
+    "tree-sitter@0.22.4": true,
+    "tree-sitter@0.21.1": true,
+    "@tree-sitter-grammars/tree-sitter-yaml@0.7.1": true
   }
 }


### PR DESCRIPTION
It looks like a future version of NPM is going to require explicit approval of postinstall scripts before running them. See https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/. This PR allows all existing postinstall scripts in our dependency tree (at least when compiling on my system). See the commit messages for brief descriptions of their purposes.