### PR TITLE
Use flat config for eslint-plugin-react-hooks

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -3,7 +3,6 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import prettierConfig from "eslint-config-prettier";
-import { fixupPluginRules } from "@eslint/compat";
 import eslintPluginReact from "eslint-plugin-react";
 import eslintPluginReactHooks from "eslint-plugin-react-hooks";
 import globals from "globals";
@@ -18,6 +17,7 @@ export default tseslint.config(
       eslint.configs.recommended,
       ...tseslint.configs.recommended,
       prettierConfig,
+      eslintPluginReactHooks.configs.flat.recommended,
     ],
     settings: {
       react: {
@@ -41,12 +41,10 @@ export default tseslint.config(
     },
     plugins: {
       react: eslintPluginReact,
-      "react-hooks": fixupPluginRules(eslintPluginReactHooks),
     },
     rules: {
       // Recommended rules from plugins that don't yet support flat config:
       ...eslintPluginReact.configs.recommended.rules,
-      ...eslintPluginReactHooks.configs.recommended.rules,
 
       // Rules from eslint-plugin-react's jsx-runtime config:
       "react/react-in-jsx-scope": 0,

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -29,7 +29,6 @@
         "web-vitals": "^6.1.1"
       },
       "devDependencies": {
-        "@eslint/compat": "^2.0.2",
         "@eslint/js": "^9.29.0",
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
@@ -441,27 +440,6 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/compat": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.2.tgz",
-      "integrity": "sha512-pR1DoD0h3HfF675QZx0xsyrsU8q70Z/plx7880NOhS02NuWLgBCOMDL787nUeQ7EWLkxv3bPQJaarjcPQb2Dwg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.1.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": "^8.40 || 9 || 10"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@eslint/config-array": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
@@ -525,19 +503,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/app/package.json
+++ b/app/package.json
@@ -51,7 +51,6 @@
     ]
   },
   "devDependencies": {
-    "@eslint/compat": "^2.0.2",
     "@eslint/js": "^9.29.0",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
`eslint-plugin-react-hooks` has been updated for a while now to support eslint v9's flat config API. This PR cleans up our compatibility shim, and just uses the recommended configuration directly.