### PR TITLE
Enable warnings on use of deprecated APIs

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -69,6 +69,7 @@ export default defineConfig(
         },
       ],
       "no-console": "warn",
+      "@typescript-eslint/no-deprecated": "warn",
     },
   },
 );

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -1,13 +1,14 @@
 // @ts-check
 
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 import prettierConfig from "eslint-config-prettier";
 import eslintPluginReact from "eslint-plugin-react";
 import eslintPluginReactHooks from "eslint-plugin-react-hooks";
 import globals from "globals";
 
-export default tseslint.config(
+export default defineConfig(
   {
     // Global ignores
     ignores: ["build"],

--- a/app/src/accounts/AccountSummary.tsx
+++ b/app/src/accounts/AccountSummary.tsx
@@ -5,7 +5,7 @@ import ListGroup from "react-bootstrap/ListGroup";
 import { useFetcher, useParams, useRouteLoaderData } from "react-router-dom";
 import {
   ChangeEvent,
-  FormEvent,
+  SubmitEvent,
   Suspense,
   useCallback,
   useEffect,
@@ -49,7 +49,7 @@ function AccountName() {
   );
   const fetcher = useFetcher();
   const submit = useCallback(
-    (e: FormEvent<HTMLFormElement>) => {
+    (e: SubmitEvent<HTMLFormElement>) => {
       e.preventDefault();
       if (name === originalName) {
         setIsEditingName(false);

--- a/app/src/accounts/index.tsx
+++ b/app/src/accounts/index.tsx
@@ -16,6 +16,8 @@ export default function accounts(
         path: "",
         element: <AccountList />,
         loader() {
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({ accounts: apiClient.accounts() });
         },
         index: true,
@@ -43,6 +45,8 @@ export default function accounts(
         id: "account",
         loader({ params }) {
           const { accountId } = params as { accountId: string };
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({
             account: apiClient.account(accountId),
           });
@@ -78,6 +82,8 @@ export default function accounts(
             index: true,
             loader({ params }) {
               const { accountId } = params as { accountId: string };
+              // TODO(#1534): replace this before react-router v7 upgrade.
+              // eslint-disable-next-line @typescript-eslint/no-deprecated
               return defer({
                 apiTokens: apiClient.accountApiTokens(accountId),
                 tasks: apiClient.accountTasks(accountId),

--- a/app/src/aggregators/index.tsx
+++ b/app/src/aggregators/index.tsx
@@ -13,6 +13,8 @@ export default function aggregators(apiClient: ApiClient): RouteObject {
         index: true,
         element: <Aggregators />,
         loader({ params }) {
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({
             aggregators: apiClient.accountAggregators(
               params.accountId as string,
@@ -24,6 +26,8 @@ export default function aggregators(apiClient: ApiClient): RouteObject {
         path: ":aggregatorId",
         element: <AggregatorDetail />,
         loader({ params }) {
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({
             aggregator: apiClient.aggregator(params.aggregatorId as string),
           });

--- a/app/src/api-tokens/index.tsx
+++ b/app/src/api-tokens/index.tsx
@@ -11,6 +11,8 @@ export default function apiTokens(apiClient: ApiClient): RouteObject {
         index: true,
         element: <ApiTokens />,
         loader({ params }) {
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({
             apiTokens: apiClient
               .accountApiTokens(params.accountId as string)

--- a/app/src/collector-credentials/index.tsx
+++ b/app/src/collector-credentials/index.tsx
@@ -12,6 +12,8 @@ export default function collectorCredentials(
         index: true,
         element: <CollectorCredentials />,
         loader({ params }) {
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({
             collectorCredentials: apiClient.accountCollectorCredentials(
               params.accountId as string,

--- a/app/src/memberships/index.tsx
+++ b/app/src/memberships/index.tsx
@@ -7,6 +7,8 @@ export default function memberships(apiClient: ApiClient): RouteObject {
     path: "memberships",
     element: <Memberships />,
     loader({ params }) {
+      // TODO(#1534): replace this before react-router v7 upgrade.
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       return defer({
         memberships: apiClient.accountMemberships(params.accountId as string),
       });

--- a/app/src/shared-aggregators/index.tsx
+++ b/app/src/shared-aggregators/index.tsx
@@ -12,6 +12,8 @@ export default function sharedAggregators(apiClient: ApiClient): RouteObject {
           return import("./SharedAggregatorList");
         },
         async loader() {
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({ aggregators: apiClient.sharedAggregators() });
         },
       },

--- a/app/src/tasks/TaskDetail/DisableTaskButton.tsx
+++ b/app/src/tasks/TaskDetail/DisableTaskButton.tsx
@@ -5,7 +5,7 @@ import {
   useNavigation,
   useParams,
 } from "react-router-dom";
-import React, { FormEvent, useCallback, useEffect, useState } from "react";
+import React, { SubmitEvent, useCallback, useEffect, useState } from "react";
 import { Play, SignStop } from "react-bootstrap-icons";
 import { Button, Modal } from "react-bootstrap";
 import { WithTask } from ".";
@@ -29,7 +29,7 @@ export default function DisableTaskButton() {
   };
 
   const submit = useCallback(
-    (e: FormEvent<HTMLFormElement>) => {
+    (e: SubmitEvent<HTMLFormElement>) => {
       e.preventDefault();
       fetcher.submit(
         { expiration: isExpired ? null : new Date().toISOString() },

--- a/app/src/tasks/index.tsx
+++ b/app/src/tasks/index.tsx
@@ -13,6 +13,8 @@ export default function tasks(apiClient: ApiClient): RouteObject {
         index: true,
         element: <AccountDetailFull />,
         loader({ params }) {
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({
             tasks: apiClient.accountTasks(params.accountId as string),
           });
@@ -32,6 +34,8 @@ export default function tasks(apiClient: ApiClient): RouteObject {
           const collectorCredential = task.then((t) =>
             apiClient.collectorCredential(t.collector_credential_id),
           );
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({
             task,
             leaderAggregator,
@@ -69,6 +73,8 @@ export default function tasks(apiClient: ApiClient): RouteObject {
         path: "new",
         element: <TaskForm />,
         loader({ params }) {
+          // TODO(#1534): replace this before react-router v7 upgrade.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return defer({
             aggregators: apiClient.accountAggregators(
               params.accountId as string,


### PR DESCRIPTION
This enables warnings for `@typescript-eslint/no-deprecated`, to find uses of deprecated APIs. I fixed two simple uses of deprecated APIs, and ignored the uses of react-router's `defer()` for now, to be handled separately as part of our migration to react-router v7.

See also #1416 and #1534.