### PR TITLE
Fix flake in demo script

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -121,7 +121,7 @@ jobs:
 
           for i in {1..150}; do
             measurement=$(( $RANDOM % 10 ))
-            ./divviup dap-client upload --task-id $TASK_ID --measurement $measurement;
+            ./divviup dap-client upload --task-id=$TASK_ID --measurement $measurement;
           done
 
           echo "finished uploading measurements"
@@ -129,7 +129,7 @@ jobs:
           sleep 120
 
           ./divviup dap-client collect \
-            --task-id $TASK_ID \
+            --task-id=$TASK_ID \
             --collector-credential-file $COLLECTOR_CREDENTIAL_PATH \
             --current-batch
 


### PR DESCRIPTION
I just saw a test flake where the DAP TaskID of `-zKmU4DBI6ZaSASzDMaZEw70Hbo0HSuD5bFbOE3VkBo` was randomly generated, and our command line tools interpreted `--task-id -zKmU4DBI6ZaSASzDMaZEw70Hbo0HSuD5bFbOE3VkBo` as an invalid set of command line arguments, reporting "error: unexpected argument '-z' found". This PR fixes the issue by providing the TaskID value after an equals sign, instead of as a separate argument. I'm going to open an equivalent PR on the tutorial that this is testing.