### PR TITLE
Remove uses of defer

### DIFF
--- a/app/src/accounts/index.tsx
+++ b/app/src/accounts/index.tsx
@@ -1,4 +1,4 @@
-import { RouteObject, defer, redirect } from "react-router-dom";
+import { RouteObject, redirect } from "react-router-dom";
 import ApiClient, { NewAccount, UpdateAccount } from "../ApiClient";
 import AccountSummary from "./AccountSummary";
 import AccountForm from "./AccountForm";
@@ -16,9 +16,7 @@ export default function accounts(
         path: "",
         element: <AccountList />,
         loader() {
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({ accounts: apiClient.accounts() });
+          return { accounts: apiClient.accounts() };
         },
         index: true,
       },
@@ -45,11 +43,9 @@ export default function accounts(
         id: "account",
         loader({ params }) {
           const { accountId } = params as { accountId: string };
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({
+          return {
             account: apiClient.account(accountId),
-          });
+          };
         },
         shouldRevalidate(args) {
           return (
@@ -82,16 +78,14 @@ export default function accounts(
             index: true,
             loader({ params }) {
               const { accountId } = params as { accountId: string };
-              // TODO(#1534): replace this before react-router v7 upgrade.
-              // eslint-disable-next-line @typescript-eslint/no-deprecated
-              return defer({
+              return {
                 apiTokens: apiClient.accountApiTokens(accountId),
                 tasks: apiClient.accountTasks(accountId),
                 collectorCredentials:
                   apiClient.accountCollectorCredentials(accountId),
                 aggregators: apiClient.accountAggregators(accountId),
                 account: apiClient.account(accountId),
-              });
+              };
             },
           },
           ...children,

--- a/app/src/aggregators/index.tsx
+++ b/app/src/aggregators/index.tsx
@@ -2,7 +2,7 @@ import Aggregators from "./AggregatorList";
 import AggregatorFormPage from "./AggregatorForm";
 import AggregatorDetail from "./AggregatorDetail";
 import ApiClient from "../ApiClient";
-import { RouteObject, defer, redirect } from "react-router-dom";
+import { RouteObject, redirect } from "react-router-dom";
 
 export default function aggregators(apiClient: ApiClient): RouteObject {
   return {
@@ -13,24 +13,20 @@ export default function aggregators(apiClient: ApiClient): RouteObject {
         index: true,
         element: <Aggregators />,
         loader({ params }) {
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({
+          return {
             aggregators: apiClient.accountAggregators(
               params.accountId as string,
             ),
-          });
+          };
         },
       },
       {
         path: ":aggregatorId",
         element: <AggregatorDetail />,
         loader({ params }) {
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({
+          return {
             aggregator: apiClient.aggregator(params.aggregatorId as string),
-          });
+          };
         },
 
         async action({ params, request }) {

--- a/app/src/api-tokens/index.tsx
+++ b/app/src/api-tokens/index.tsx
@@ -1,4 +1,4 @@
-import { RouteObject, defer } from "react-router-dom";
+import { RouteObject } from "react-router-dom";
 import ApiClient from "../ApiClient";
 import ApiTokens from "./ApiTokenList";
 
@@ -11,13 +11,11 @@ export default function apiTokens(apiClient: ApiClient): RouteObject {
         index: true,
         element: <ApiTokens />,
         loader({ params }) {
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({
+          return {
             apiTokens: apiClient
               .accountApiTokens(params.accountId as string)
               .then((tokens) => tokens.reverse()),
-          });
+          };
         },
 
         shouldRevalidate(_) {

--- a/app/src/collector-credentials/index.tsx
+++ b/app/src/collector-credentials/index.tsx
@@ -1,4 +1,4 @@
-import { RouteObject, defer } from "react-router-dom";
+import { RouteObject } from "react-router-dom";
 import ApiClient from "../ApiClient";
 import CollectorCredentials from "./CollectorCredentialList";
 export default function collectorCredentials(
@@ -12,13 +12,11 @@ export default function collectorCredentials(
         index: true,
         element: <CollectorCredentials />,
         loader({ params }) {
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({
+          return {
             collectorCredentials: apiClient.accountCollectorCredentials(
               params.accountId as string,
             ),
-          });
+          };
         },
 
         id: "collectorCredentials",

--- a/app/src/memberships/index.tsx
+++ b/app/src/memberships/index.tsx
@@ -1,4 +1,4 @@
-import { RouteObject, defer } from "react-router-dom";
+import { RouteObject } from "react-router-dom";
 import ApiClient from "../ApiClient";
 import Memberships from "./Memberships";
 
@@ -7,11 +7,9 @@ export default function memberships(apiClient: ApiClient): RouteObject {
     path: "memberships",
     element: <Memberships />,
     loader({ params }) {
-      // TODO(#1534): replace this before react-router v7 upgrade.
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      return defer({
+      return {
         memberships: apiClient.accountMemberships(params.accountId as string),
-      });
+      };
     },
 
     shouldRevalidate(_) {

--- a/app/src/shared-aggregators/index.tsx
+++ b/app/src/shared-aggregators/index.tsx
@@ -1,4 +1,4 @@
-import { RouteObject, defer } from "react-router-dom";
+import { RouteObject } from "react-router-dom";
 import ApiClient, { UpdateAggregator } from "../ApiClient";
 
 export default function sharedAggregators(apiClient: ApiClient): RouteObject {
@@ -12,9 +12,7 @@ export default function sharedAggregators(apiClient: ApiClient): RouteObject {
           return import("./SharedAggregatorList");
         },
         async loader() {
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({ aggregators: apiClient.sharedAggregators() });
+          return { aggregators: apiClient.sharedAggregators() };
         },
       },
       {

--- a/app/src/tasks/index.tsx
+++ b/app/src/tasks/index.tsx
@@ -2,7 +2,7 @@ import AccountDetailFull from "./TaskList";
 import TaskForm from "./TaskForm";
 import TaskDetail from "./TaskDetail";
 import ApiClient from "../ApiClient";
-import { RouteObject, defer, redirect } from "react-router-dom";
+import { RouteObject, redirect } from "react-router-dom";
 
 export default function tasks(apiClient: ApiClient): RouteObject {
   return {
@@ -13,11 +13,9 @@ export default function tasks(apiClient: ApiClient): RouteObject {
         index: true,
         element: <AccountDetailFull />,
         loader({ params }) {
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({
+          return {
             tasks: apiClient.accountTasks(params.accountId as string),
-          });
+          };
         },
       },
       {
@@ -34,14 +32,12 @@ export default function tasks(apiClient: ApiClient): RouteObject {
           const collectorCredential = task.then((t) =>
             apiClient.collectorCredential(t.collector_credential_id),
           );
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({
+          return {
             task,
             leaderAggregator,
             helperAggregator,
             collectorCredential,
-          });
+          };
         },
 
         async action({ params, request }) {
@@ -73,16 +69,14 @@ export default function tasks(apiClient: ApiClient): RouteObject {
         path: "new",
         element: <TaskForm />,
         loader({ params }) {
-          // TODO(#1534): replace this before react-router v7 upgrade.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          return defer({
+          return {
             aggregators: apiClient.accountAggregators(
               params.accountId as string,
             ),
             collectorCredentials: apiClient.accountCollectorCredentials(
               params.accountId as string,
             ),
-          });
+          };
         },
       },
     ],


### PR DESCRIPTION
This removes uses of `defer()`, which is deprecated and will be removed in react-router v7. I tested this with the development docker compose environment, and confirmed the web app still works properly. Part of #1534.