### PR TITLE
Remove vite-plugin-eslint

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -58,8 +58,7 @@
         "source-map-explorer": "^2.5.3",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.0",
-        "vite": "^8.2.2",
-        "vite-plugin-eslint": "^1.8.1"
+        "vite": "^8.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1189,19 +1188,6 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
     },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
@@ -4342,12 +4328,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -8622,48 +8602,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-eslint": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
-      "integrity": "sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^4.2.1",
-        "@types/eslint": "^8.4.5",
-        "rollup": "^2.77.2"
-      },
-      "peerDependencies": {
-        "eslint": ">=7",
-        "vite": ">=2"
-      }
-    },
-    "node_modules/vite-plugin-eslint/node_modules/@types/eslint": {
-      "version": "8.56.11",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
-      "integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/vite-plugin-eslint/node_modules/rollup": {
-      "version": "2.80.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
-      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/vite/node_modules/picomatch": {

--- a/app/package.json
+++ b/app/package.json
@@ -80,8 +80,7 @@
     "source-map-explorer": "^2.5.3",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0",
-    "vite": "^8.2.2",
-    "vite-plugin-eslint": "^1.8.1"
+    "vite": "^8.2.2"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from "vite";
-import eslint from "vite-plugin-eslint";
 import react from "@vitejs/plugin-react-swc";
 import postcssNesting from "postcss-nesting";
 
@@ -8,7 +7,7 @@ export default defineConfig(() => ({
     sourcemap: true,
     outDir: process.env.BUILD_PATH || "build",
   },
-  plugins: [react(), eslint()],
+  plugins: [react()],
   server: {
     port: 8081,
     strictPort: true,


### PR DESCRIPTION
This removes vite-plugin-eslint, which appears to be unmaintained, and has issues with its types exports. There's at least one more active fork, but I think we'd be fine just dropping this plugin. I have found that my IDE integrations are good enough for linting code interactively, so I don't think it's necessary to also do so in our development server.