### PR TITLE
Fix Swagger UI inside development compose environment

### DIFF
--- a/compose.dev.override.yaml
+++ b/compose.dev.override.yaml
@@ -49,11 +49,11 @@ services:
       # `develop` cannot be used with an `image` directive, so we need to use a minimal dockerfile
       # containing the image we need.
       dockerfile: Dockerfile.vite
-    working_dir: /srv/app
+    working_dir: /srv/divviup-api/app
     volumes:
      - type: bind
-       source: ./app
-       target: /srv/app
+       source: .
+       target: /srv/divviup-api
     entrypoint:
       - /bin/sh
       - -c


### PR DESCRIPTION
When using `compose.dev.yaml`, the Vite container currently has the `app` subdirectory mounted into it. This works for most things, except for `app/public/swagger.yml`, which is a symbolic link pointing outside of the `app` directory. This breaks Swagger UI when using this particular development setup. This change instead mounts the whole repository into the container, and adjusts the working directory to match. With this, the Swagger UI loads properly.