### PR TITLE
Set easy react-router future feature flags

### DIFF
--- a/app/src/aggregators/AggregatorForm.tsx
+++ b/app/src/aggregators/AggregatorForm.tsx
@@ -74,7 +74,7 @@ export function AggregatorForm({
     >
       {(props) => (
         <Form
-          method="post"
+          method="POST"
           onSubmit={props.handleSubmit}
           noValidate
           autoComplete="off"

--- a/app/src/aggregators/DeleteAggregatorButton.tsx
+++ b/app/src/aggregators/DeleteAggregatorButton.tsx
@@ -41,7 +41,7 @@ export default function DeleteAggregatorButton() {
           <Button variant="secondary" onClick={close}>
             Close
           </Button>
-          <fetcher.Form method="delete">
+          <fetcher.Form method="DELETE">
             <Button
               variant="danger"
               type="submit"

--- a/app/src/api-tokens/ApiTokenList.tsx
+++ b/app/src/api-tokens/ApiTokenList.tsx
@@ -51,7 +51,7 @@ export default function ApiTokens() {
       </Row>
       <Row className="mb-3">
         <Col>
-          <Form method="post">
+          <Form method="POST">
             <Button
               variant="primary"
               type="submit"
@@ -120,7 +120,7 @@ function TokenName({ apiToken }: { apiToken: ApiToken }) {
   }, [fetcher, setEditing]);
   if (isEditing) {
     return (
-      <fetcher.Form action={apiToken.id} method="patch">
+      <fetcher.Form action={apiToken.id} method="PATCH">
         <FormGroup>
           <InputGroup>
             <FormControl
@@ -205,7 +205,7 @@ function DeleteButton({ apiToken }: { apiToken: ApiToken }) {
           <Button variant="secondary" onClick={close}>
             Close
           </Button>
-          <fetcher.Form method="delete" action={apiToken.id}>
+          <fetcher.Form method="DELETE" action={apiToken.id}>
             <Button
               variant="danger"
               type="submit"

--- a/app/src/collector-credentials/CollectorCredentialForm.tsx
+++ b/app/src/collector-credentials/CollectorCredentialForm.tsx
@@ -86,7 +86,7 @@ export default function CollectorCredentialForm() {
     );
   } else {
     return (
-      <fetcher.Form method="post">
+      <fetcher.Form method="POST">
         <Row>
           <Col sm="5">
             <FormGroup>

--- a/app/src/collector-credentials/CollectorCredentialList.tsx
+++ b/app/src/collector-credentials/CollectorCredentialList.tsx
@@ -118,7 +118,7 @@ function Name({
   }, [fetcher, setEditing]);
   if (isEditing) {
     return (
-      <fetcher.Form action={collectorCredential.id} method="patch">
+      <fetcher.Form action={collectorCredential.id} method="PATCH">
         <FormGroup>
           <InputGroup>
             <FormControl
@@ -204,7 +204,7 @@ function DeleteButton({
           <Button variant="secondary" onClick={close}>
             Close
           </Button>
-          <fetcher.Form method="delete" action={collectorCredential.id}>
+          <fetcher.Form method="DELETE" action={collectorCredential.id}>
             <Button
               variant="danger"
               type="submit"

--- a/app/src/memberships/Memberships.tsx
+++ b/app/src/memberships/Memberships.tsx
@@ -48,7 +48,7 @@ function DeleteMembershipButton({ membership }: { membership: Membership }) {
   const open = React.useCallback(() => setShow(true), []);
 
   const deleteMembership = React.useCallback(() => {
-    submit({ membershipId: membership.id }, { method: "delete" });
+    submit({ membershipId: membership.id }, { method: "DELETE" });
   }, [membership, submit]);
 
   return (
@@ -83,7 +83,7 @@ function AddMembershipForm() {
   return (
     <Form
       action="."
-      method="post"
+      method="POST"
       onSubmit={React.useCallback(() => {
         setEmail("");
       }, [setEmail])}

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -21,21 +21,29 @@ import collectorCredentials from "./collector-credentials/index.js";
 import swaggerUi from "./swagger-ui.js";
 
 function buildRouter(apiClient: ApiClient) {
-  return createBrowserRouter([
-    swaggerUi(),
-    layout(apiClient, [
-      logout(apiClient),
-      root(apiClient),
-      admin(apiClient, [queue(apiClient), sharedAggregators(apiClient)]),
-      accounts(apiClient, [
-        aggregators(apiClient),
-        apiTokens(apiClient),
-        memberships(apiClient),
-        tasks(apiClient),
-        collectorCredentials(apiClient),
+  return createBrowserRouter(
+    [
+      swaggerUi(),
+      layout(apiClient, [
+        logout(apiClient),
+        root(apiClient),
+        admin(apiClient, [queue(apiClient), sharedAggregators(apiClient)]),
+        accounts(apiClient, [
+          aggregators(apiClient),
+          apiTokens(apiClient),
+          memberships(apiClient),
+          tasks(apiClient),
+          collectorCredentials(apiClient),
+        ]),
       ]),
-    ]),
-  ]);
+    ],
+    {
+      future: {
+        v7_relativeSplatPath: true,
+        v7_normalizeFormMethod: true,
+      },
+    },
+  );
 }
 
 export default function Router() {

--- a/app/src/shared-aggregators/SharedAggregatorList.tsx
+++ b/app/src/shared-aggregators/SharedAggregatorList.tsx
@@ -176,7 +176,7 @@ function DeleteAggregatorButton({ aggregator }: { aggregator: Aggregator }) {
           <Button variant="secondary" onClick={close}>
             Close
           </Button>
-          <fetcher.Form method="delete" action={aggregator.id}>
+          <fetcher.Form method="DELETE" action={aggregator.id}>
             <Button
               variant="danger"
               type="submit"

--- a/app/src/tasks/TaskForm/index.tsx
+++ b/app/src/tasks/TaskForm/index.tsx
@@ -107,7 +107,7 @@ export default function TaskForm() {
               return (
                 <Form
                   className="mb-5"
-                  method="post"
+                  method="POST"
                   onSubmit={formikProps.handleSubmit}
                   noValidate
                   autoComplete="off"


### PR DESCRIPTION
This sets two of the six flags from the react-router v7 migration guide. These two obviously don't affect us, as we don't use any asterisks in routes, and we never read `formMethod` attributes. I also capitalized HTTP methods where we pass them in to the fetcher, for consistency.