### PR TITLE
Improve testability of components

### DIFF
--- a/app/src/ApiClientContext.tsx
+++ b/app/src/ApiClientContext.tsx
@@ -1,3 +1,5 @@
 import React from "react";
 import { ApiClient } from "./ApiClient.js";
-export const ApiClientContext = React.createContext<ApiClient>(new ApiClient());
+export const ApiClientContext = React.createContext<ApiClient | undefined>(
+  undefined,
+);

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -4,8 +4,8 @@ test("smoke test of accounts list via router", async () => {
   // We make our first request for /api_url while importing ApiClientContext, so
   // we need to delay importing this module until after test mocks have been set
   // up.
-  const routerModule = await import("./router.js");
-  const Router = routerModule.default;
-  render(<Router />);
+  const appModule = await import("./App.js");
+  const App = appModule.default;
+  render(<App />);
   expect(await screen.findByText("Test account")).toBeTruthy();
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { ApiClientContext } from "./ApiClientContext.js";
+import { ApiClient } from "./ApiClient.js";
+import Router from "./router.js";
+import { PrimeReactProvider } from "primereact/api";
+
+export default function App() {
+  const apiClient = React.useMemo(() => new ApiClient(), []);
+  return (
+    <ApiClientContext.Provider value={apiClient}>
+      <PrimeReactProvider>
+        <Router />
+      </PrimeReactProvider>
+    </ApiClientContext.Provider>
+  );
+}

--- a/app/src/accounts/NextSteps/AggregatorTypeSelection.tsx
+++ b/app/src/accounts/NextSteps/AggregatorTypeSelection.tsx
@@ -200,12 +200,15 @@ export default function AggregatorTypeSelection() {
 }
 
 async function submit(
-  apiClient: ApiClient,
+  apiClient: ApiClient | undefined,
   accountId: string,
   newAggregator: NewAggregator,
   actions: FormikHelpers<NewAggregator>,
   setAggregator: (aggregator: Aggregator) => void,
 ) {
+  if (apiClient === undefined) {
+    throw new Error("must be within context provider for ApiClient");
+  }
   const aggregator = await apiClient.createAggregator(accountId, newAggregator);
 
   if ("error" in aggregator) {

--- a/app/src/accounts/NextSteps/InlineCollectorCredentials.tsx
+++ b/app/src/accounts/NextSteps/InlineCollectorCredentials.tsx
@@ -1,5 +1,10 @@
 import { Button, Col, Row } from "react-bootstrap";
-import { useFetcher, useParams, useRevalidator } from "react-router-dom";
+import {
+  useFetcher,
+  useLoaderData,
+  useParams,
+  useRevalidator,
+} from "react-router-dom";
 import { ApiToken } from "../../ApiClient.js";
 import React from "react";
 import { useInterval } from "use-interval";
@@ -86,7 +91,9 @@ export default function InlineCollectorCredentials() {
 
   const [token, setToken] = React.useState<string>("«TOKEN»");
   const { revalidate, state } = useRevalidator();
-  const apiUrl = usePromise(apiClient.apiUrl(), DEFAULT_API_URL);
+
+  const { apiUrl } = useLoaderData() as { apiUrl: Promise<string> };
+  const apiUrlOutput = usePromise(apiUrl, DEFAULT_API_URL);
 
   if (anyCollectorCredentials) {
     return (
@@ -99,9 +106,9 @@ export default function InlineCollectorCredentials() {
     );
   } else {
     const command =
-      apiUrl == DEFAULT_API_URL
+      apiUrlOutput == DEFAULT_API_URL
         ? `divviup -t ${token} collector-credential generate`
-        : `divviup -u ${apiUrl} -t ${token} collector-credential generate`;
+        : `divviup -u ${apiUrlOutput} -t ${token} collector-credential generate`;
     return (
       <>
         <ol className="list-unstyled">

--- a/app/src/accounts/NextSteps/InlineCollectorCredentials.tsx
+++ b/app/src/accounts/NextSteps/InlineCollectorCredentials.tsx
@@ -70,6 +70,9 @@ export default function InlineCollectorCredentials() {
   const [inFlight, setInFlight] = React.useState(false);
   useInterval(
     React.useCallback(() => {
+      if (apiClient === undefined) {
+        throw new Error("must be within context provider for ApiClient");
+      }
       if (inFlight || anyCollectorCredentials) return;
       setInFlight(true);
       apiClient

--- a/app/src/accounts/index.tsx
+++ b/app/src/accounts/index.tsx
@@ -85,6 +85,7 @@ export default function accounts(
                   apiClient.accountCollectorCredentials(accountId),
                 aggregators: apiClient.accountAggregators(accountId),
                 account: apiClient.account(accountId),
+                apiUrl: apiClient.apiUrl(),
               };
             },
           },

--- a/app/src/aggregators/AggregatorForm.tsx
+++ b/app/src/aggregators/AggregatorForm.tsx
@@ -24,12 +24,15 @@ import {
 import { ApiClientContext } from "../ApiClientContext.js";
 
 async function submit(
-  apiClient: ApiClient,
+  apiClient: ApiClient | undefined,
   accountId: string,
   newAggregator: NewAggregator,
   actions: FormikHelpers<NewAggregator>,
   navigate: NavigateFunction,
 ) {
+  if (apiClient === undefined) {
+    throw new Error("must be within context provider for ApiClient");
+  }
   const aggregator = await apiClient.createAggregator(accountId, newAggregator);
 
   if ("error" in aggregator) {

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -2,13 +2,10 @@ import React, { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 //import reportWebVitals from "./reportWebVitals";
 import "bootstrap/dist/css/bootstrap.min.css";
-import { ApiClientContext } from "./ApiClientContext.js";
-import { ApiClient } from "./ApiClient.js";
-import Router from "./router.js";
-import { PrimeReactProvider } from "primereact/api";
 import "primereact/resources/themes/lara-light-indigo/theme.css";
 import "primereact/resources/primereact.min.css";
 import { RelativeTimeElement } from "@github/relative-time-element";
+import App from "./App.js";
 
 declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -26,17 +23,6 @@ declare module "react" {
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
-
-function App() {
-  const apiClient = React.useMemo(() => new ApiClient(), []);
-  return (
-    <ApiClientContext.Provider value={apiClient}>
-      <PrimeReactProvider>
-        <Router />
-      </PrimeReactProvider>
-    </ApiClientContext.Provider>
-  );
-}
 
 root.render(
   <StrictMode>

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -48,6 +48,9 @@ function buildRouter(apiClient: ApiClient) {
 
 export default function Router() {
   const apiClient = React.useContext(ApiClientContext);
+  if (apiClient === undefined) {
+    throw new Error("must be within context provider for ApiClient");
+  }
   const router = React.useMemo(() => buildRouter(apiClient), [apiClient]);
   return <RouterProvider router={router} />;
 }

--- a/app/src/shared-aggregators/SharedAggregatorForm.tsx
+++ b/app/src/shared-aggregators/SharedAggregatorForm.tsx
@@ -6,11 +6,14 @@ import { ApiClientContext } from "../ApiClientContext.js";
 import React from "react";
 
 async function submit(
-  apiClient: ApiClient,
+  apiClient: ApiClient | undefined,
   newAggregator: NewAggregator,
   actions: FormikHelpers<NewAggregator>,
   revalidate: () => void,
 ) {
+  if (apiClient === undefined) {
+    throw new Error("must be within context provider for ApiClient");
+  }
   const aggregator = await apiClient.createSharedAggregator(newAggregator);
 
   if ("error" in aggregator) {

--- a/app/src/tasks/TaskForm/index.tsx
+++ b/app/src/tasks/TaskForm/index.tsx
@@ -23,12 +23,15 @@ import VdafDetails from "./VdafDetails.js";
 import { LongHelpText } from "./HelpText.js";
 
 async function submit(
-  apiClient: ApiClient,
+  apiClient: ApiClient | undefined,
   accountId: string,
   newTask: NewTask,
   actions: FormikHelpers<NewTask>,
   navigate: NavigateFunction,
 ) {
+  if (apiClient === undefined) {
+    throw new Error("must be within context provider for ApiClient");
+  }
   const task = await apiClient.createTask(accountId, newTask);
 
   if ("error" in task) {


### PR DESCRIPTION
This makes some changes to make components more testable in isolation, with a fake router in place of the real router. I moved one `ApiClient` call out of a render function and into a loader. This avoids creating a new promise and passing it to the `usePromise()` hook each time (though the promise would complete immediately). I changed the existing test to render the `<App>` component instead of the `<Router>` component, so that we include a couple context providers that were missing before. Then, I changed the type carried by `ApiClientContext` to allow `undefined`, and set its default value to `undefined`. This means we only initialize the `ApiClient` once at startup, and lets us avoid initializing it (and making a network request) when importing various modules that consume `ApiClientContext`. I added runtime checks that the value is not `undefined` before making requests or setting up our routes.

Closes #782.