### PR TITLE
Add smoke tests of two components

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -11,7 +11,7 @@ import globals from "globals";
 export default defineConfig(
   {
     // Global ignores
-    ignores: ["build"],
+    ignores: ["build", "coverage"],
   },
   {
     extends: [

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -45,6 +45,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "@types/swagger-ui-react": "^5.18.0",
         "@vitejs/plugin-react-swc": "^4.3.3",
+        "@vitest/coverage-v8": "^4.1.11",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
@@ -236,9 +237,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -246,9 +247,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -280,13 +281,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -351,17 +352,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/selector-resolve-nested": {
@@ -2896,6 +2907,37 @@
         "vite": "^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
@@ -3250,6 +3292,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.5",
@@ -5187,6 +5248,13 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -5748,6 +5816,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.4.tgz",
@@ -6284,6 +6391,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {

--- a/app/package.json
+++ b/app/package.json
@@ -67,6 +67,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "@types/swagger-ui-react": "^5.18.0",
     "@vitejs/plugin-react-swc": "^4.3.3",
+    "@vitest/coverage-v8": "^4.1.11",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import { testApiMock } from "./mocks.js";
 
-test("smoke test of accounts list via router", async () => {
+testApiMock("smoke test of accounts list via router", async () => {
   // We make our first request for /api_url while importing ApiClientContext, so
   // we need to delay importing this module until after test mocks have been set
   // up.

--- a/app/src/accounts/AccountSummary.test.tsx
+++ b/app/src/accounts/AccountSummary.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import AccountSummary from "./AccountSummary.js";
+import {
+  Account,
+  Aggregator,
+  ApiToken,
+  CollectorCredential,
+  Task,
+} from "../ApiClient.js";
+
+test("AccountSummary renders", async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/accounts/:account_id",
+        id: "account",
+        element: <AccountSummary />,
+        async loader({ params }) {
+          const { accountId } = params as { accountId: string };
+          return {
+            apiTokens: (async (): Promise<ApiToken[]> => {
+              return [
+                {
+                  id: "00000000-0000-0000-0000-000000000001",
+                  account_id: accountId,
+                  token_hash: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                  created_at: "1985-04-12T23:20:50.52Z",
+                  name: "Test API token",
+                },
+              ];
+            })(),
+            tasks: (async (): Promise<Task[]> => {
+              return [];
+            })(),
+            collectorCredentials: (async (): Promise<CollectorCredential[]> => {
+              return [];
+            })(),
+            aggregators: (async (): Promise<Aggregator[]> => {
+              return [];
+            })(),
+            account: (async (): Promise<Account> => {
+              return {
+                name: "Test account",
+                id: accountId,
+                created_at: "1985-04-12T23:20:50.52Z",
+                updated_at: "1985-04-12T23:20:50.52Z",
+                intends_to_use_shared_aggregators: false,
+                admin: false,
+              };
+            })(),
+          };
+        },
+      },
+    ],
+    {
+      initialEntries: ["/accounts/00000000-0000-0000-0000-000000000000"],
+    },
+  );
+
+  render(<RouterProvider router={router} />);
+
+  await screen.findByText("Test account");
+});

--- a/app/src/mocks.ts
+++ b/app/src/mocks.ts
@@ -1,0 +1,28 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+
+const handlers = [
+  http.get("http://localhost:3000/api_url", () => {
+    return HttpResponse.text("http://api.invalid/");
+  }),
+  http.get("http://api.invalid/api/users/me", () => {
+    return HttpResponse.json({
+      admin: false,
+    });
+  }),
+  http.get("http://api.invalid/api/accounts", () => {
+    return HttpResponse.json([
+      {
+        name: "Test account",
+        id: "00000000-0000-0000-0000-000000000000",
+      },
+    ]);
+  }),
+];
+
+const server = setupServer(...handlers);
+
+export const testApiMock = test.extend("server", server);
+testApiMock.beforeAll(() => server.listen());
+testApiMock.afterEach(() => server.resetHandlers());
+testApiMock.afterAll(() => server.close());

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -3,31 +3,3 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/vitest";
-
-import { http, HttpResponse } from "msw";
-import { setupServer } from "msw/node";
-
-const handlers = [
-  http.get("http://localhost:3000/api_url", () => {
-    return HttpResponse.text("http://api.invalid/");
-  }),
-  http.get("http://api.invalid/api/users/me", () => {
-    return HttpResponse.json({
-      admin: false,
-    });
-  }),
-  http.get("http://api.invalid/api/accounts", () => {
-    return HttpResponse.json([
-      {
-        name: "Test account",
-        id: "00000000-0000-0000-0000-000000000000",
-      },
-    ]);
-  }),
-];
-
-const server = setupServer(...handlers);
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());

--- a/app/src/tasks/TaskDetail.test.tsx
+++ b/app/src/tasks/TaskDetail.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import TaskDetail from "./TaskDetail/index.js";
+import {
+  Account,
+  Aggregator,
+  CollectorCredential,
+  Task,
+} from "../ApiClient.js";
+
+test("TaskDetail renders", async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/accounts/:account_id",
+        id: "account",
+        async loader({ params }) {
+          const { accountId } = params as { accountId: string };
+          return {
+            account: (async (): Promise<Account> => {
+              return {
+                name: "Test account",
+                id: accountId,
+                created_at: "1985-04-12T23:20:50.52Z",
+                updated_at: "1985-04-12T23:20:50.52Z",
+                intends_to_use_shared_aggregators: false,
+                admin: false,
+              };
+            })(),
+          };
+        },
+        children: [
+          {
+            path: "tasks/:taskId",
+            element: <TaskDetail />,
+            async loader({ params }) {
+              const { accountId, taskId } = params as {
+                accountId: string;
+                taskId: string;
+              };
+              return {
+                task: (async (): Promise<Task> => {
+                  return {
+                    id: taskId,
+                    name: "Counter task",
+                    leader_aggregator_id:
+                      "00000000-0000-0000-0000-00000000000a",
+                    helper_aggregator_id:
+                      "00000000-0000-0000-0000-00000000000b",
+                    vdaf: { type: "count" },
+                    min_batch_size: 100,
+                    time_precision_seconds: 3600,
+                    account_id: accountId,
+                    created_at: "1985-04-12T23:20:50.52Z",
+                    updated_at: "1985-04-12T23:20:50.52Z",
+                    expiration: null,
+                    max_batch_size: null,
+                    batch_time_window_size_seconds: null,
+                    collector_credential_id:
+                      "00000000-0000-0000-0000-00000000000c",
+                    report_counter_interval_collected: 0,
+                    report_counter_decode_failure: 0,
+                    report_counter_decrypt_failure: 0,
+                    report_counter_expired: 0,
+                    report_counter_outdated_key: 0,
+                    report_counter_success: 0,
+                    report_counter_too_early: 0,
+                    report_counter_task_expired: 0,
+                    aggregation_job_counter_success: 0,
+                    aggregation_job_counter_helper_batch_collected: 0,
+                    aggregation_job_counter_helper_report_replayed: 0,
+                    aggregation_job_counter_helper_report_dropped: 0,
+                    aggregation_job_counter_helper_hpke_unknown_config_id: 0,
+                    aggregation_job_counter_helper_hpke_decrypt_failure: 0,
+                    aggregation_job_counter_helper_vdaf_prep_error: 0,
+                    aggregation_job_counter_helper_task_expired: 0,
+                    aggregation_job_counter_helper_invalid_message: 0,
+                    aggregation_job_counter_helper_report_too_early: 0,
+                  };
+                })(),
+                leaderAggregator: (async (): Promise<Aggregator> => {
+                  return {
+                    id: "00000000-0000-0000-0000-00000000000a",
+                    account_id: accountId,
+                    created_at: "1985-04-12T23:20:50.52Z",
+                    updated_at: "1985-04-12T23:20:50.52Z",
+                    deleted_at: null,
+                    api_url: "http://leader.invalid/aggregator-api/",
+                    dap_url: "http://leader.invalid/",
+                    role: "Leader",
+                    name: "Leader aggregator",
+                    is_first_party: true,
+                    vdafs: [
+                      "Prio3Count",
+                      "Prio3Sum",
+                      "Prio3Histogram",
+                      "Prio3SumVec",
+                    ],
+                    query_types: ["TimeInterval", "FixedSize"],
+                    features: [
+                      "TokenHash",
+                      "UploadMetrics",
+                      "TimeBucketedFixedSize",
+                      "PureDpDiscreteLaplace",
+                      "AggregationJobMetrics",
+                    ],
+                    protocol: "DAP-09",
+                  };
+                })(),
+                helperAggregator: (async (): Promise<Aggregator> => {
+                  return {
+                    id: "00000000-0000-0000-0000-00000000000b",
+                    account_id: accountId,
+                    created_at: "1985-04-12T23:20:50.52Z",
+                    updated_at: "1985-04-12T23:20:50.52Z",
+                    deleted_at: null,
+                    api_url: "http://helper.invalid/aggregator-api/",
+                    dap_url: "http://helper.invalid/",
+                    role: "Helper",
+                    name: "Helper aggregator",
+                    is_first_party: false,
+                    vdafs: [
+                      "Prio3Count",
+                      "Prio3Sum",
+                      "Prio3Histogram",
+                      "Prio3SumVec",
+                    ],
+                    query_types: ["TimeInterval", "FixedSize"],
+                    features: [
+                      "TokenHash",
+                      "UploadMetrics",
+                      "TimeBucketedFixedSize",
+                      "PureDpDiscreteLaplace",
+                      "AggregationJobMetrics",
+                    ],
+                    protocol: "DAP-09",
+                  };
+                })(),
+                collectorCredential:
+                  (async (): Promise<CollectorCredential> => {
+                    return {
+                      id: "00000000-0000-0000-0000-00000000000c",
+                      hpke_config: {
+                        id: 0,
+                        kem_id: "X25519HkdfSha256",
+                        kdf_id: "HkdfSha256",
+                        aead_id: "Aes128Gcm",
+                        public_key:
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                      },
+                      created_at: "1985-04-12T23:20:50.52Z",
+                      updated_at: "1985-04-12T23:20:50.52Z",
+                      deleted_at: null,
+                      name: "Test collector credential",
+                      token_hash: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    };
+                  })(),
+              };
+            },
+          },
+        ],
+      },
+    ],
+    {
+      initialEntries: [
+        "/accounts/00000000-0000-0000-0000-000000000000/tasks/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      ],
+    },
+  );
+
+  render(<RouterProvider router={router} />);
+
+  await screen.findByText("Minimum Batch Size: 100");
+});


### PR DESCRIPTION
This adds smoke tests of two of our bigger components, using a fake router. I first moved network mocking from a setup file to a regular module, and declared an "extended" test function that sets up and tears down the mocks. This lets us avoid this extra machinery when we're not using it. I then added smoke tests for an account page (including part of the first run wizard) and a task page (including syntax-highlighted sample code). I also added a test coverage library, to get `vitest --coverage` to work, and help guide my choice of components.