### PR TITLE
Enable react-router future flags

### DIFF
--- a/app/src/accounts/AccountSummary.test.tsx
+++ b/app/src/accounts/AccountSummary.test.tsx
@@ -58,7 +58,9 @@ test("AccountSummary renders", async () => {
     },
   );
 
-  render(<RouterProvider router={router} />);
+  render(
+    <RouterProvider router={router} future={{ v7_startTransition: true }} />,
+  );
 
   await screen.findByText("Test account");
 });

--- a/app/src/layout/index.tsx
+++ b/app/src/layout/index.tsx
@@ -18,6 +18,7 @@ export default function layout(
       return false;
     },
     errorElement: <ErrorPage apiClient={apiClient} />,
+    hydrateFallbackElement: <div />,
     children,
   };
 }

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -41,6 +41,7 @@ function buildRouter(apiClient: ApiClient) {
       future: {
         v7_relativeSplatPath: true,
         v7_normalizeFormMethod: true,
+        v7_partialHydration: true,
       },
     },
   );

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -41,7 +41,9 @@ function buildRouter(apiClient: ApiClient) {
       future: {
         v7_relativeSplatPath: true,
         v7_normalizeFormMethod: true,
+        v7_fetcherPersist: true,
         v7_partialHydration: true,
+        v7_skipActionErrorRevalidation: true,
       },
     },
   );
@@ -53,7 +55,9 @@ export default function Router() {
     throw new Error("must be within context provider for ApiClient");
   }
   const router = React.useMemo(() => buildRouter(apiClient), [apiClient]);
-  return <RouterProvider router={router} />;
+  return (
+    <RouterProvider router={router} future={{ v7_startTransition: true }} />
+  );
 }
 
 function root(_apiClient: ApiClient): RouteObject {

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -59,6 +59,7 @@ export default function Router() {
 function root(_apiClient: ApiClient): RouteObject {
   return {
     path: "",
+    element: null,
     async loader() {
       return redirect("/accounts");
     },

--- a/app/src/tasks/TaskDetail.test.tsx
+++ b/app/src/tasks/TaskDetail.test.tsx
@@ -168,7 +168,9 @@ test("TaskDetail renders", async () => {
     },
   );
 
-  render(<RouterProvider router={router} />);
+  render(
+    <RouterProvider router={router} future={{ v7_startTransition: true }} />,
+  );
 
   await screen.findByText("Minimum Batch Size: 100");
 });


### PR DESCRIPTION
This enables the last four future flags, per the [migration guide](https://reactrouter.com/7.18.3/upgrading/v6). Part of #1534. I made some small tweaks to address warnings I saw. I clicked through the app for a bit and didn't notice any big issues, either in the interactions or in the browser console.